### PR TITLE
Refine API for image & content fetching

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,6 +12,14 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+const (
+	NoActionOption Option = iota
+	ReadImageOption
+	SquashImageOption
+)
+
+type Option uint
+
 var trackerInstance *tracker
 
 func init() {
@@ -48,9 +56,20 @@ func (t *tracker) cleanup() error {
 }
 
 // GetImage parses the user provided image string and provides a image object
-func GetImage(userStr string) (*image.Image, error) {
+func GetImage(userStr string, options ...Option) (*image.Image, error) {
 	var provider image.Provider
 	source, imgStr := image.ParseImageSpec(userStr)
+
+	var processingOption = NoActionOption
+	if len(options) == 0 {
+		processingOption = SquashImageOption
+	} else {
+		for _, o := range options {
+			if o > processingOption {
+				processingOption = o
+			}
+		}
+	}
 
 	switch source {
 	case image.TarballSource:
@@ -67,7 +86,26 @@ func GetImage(userStr string) (*image.Image, error) {
 		return nil, fmt.Errorf("unable determine image source")
 	}
 
-	return provider.Provide()
+	img, err := provider.Provide()
+	if err != nil {
+		return nil, err
+	}
+
+	if processingOption >= ReadImageOption {
+		err = img.Read()
+		if err != nil {
+			return nil, fmt.Errorf("could not read image: %+v", err)
+		}
+	}
+
+	if processingOption >= SquashImageOption {
+		err = img.Squash()
+		if err != nil {
+			return nil, fmt.Errorf("could not squash image: %+v", err)
+		}
+	}
+
+	return img, nil
 }
 
 func Cleanup() {

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -11,17 +11,14 @@ func main() {
 	/////////////////////////////////////////////////////////////////
 	// pass a path to an image tar as an argument:
 	//    tarball://./path/to.tar
+	//
+	// This will:
+	//  - catalog the file metadata (img.Read)
+	//  - squash the layers into a single filetree (img.Squash)
+	//
+	// note: if you'd prefer to read and squash the image manually, pass stereoscope.NoActionOption
+	// or pass the Option you'd prefer (e.g. only read, no squash = stereoscope.ReadImageOption)
 	image, err := stereoscope.GetImage(os.Args[1])
-	if err != nil {
-		panic(err)
-	}
-
-	// delete any cached tar files
-	defer stereoscope.Cleanup()
-
-	/////////////////////////////////////////////////////////////////
-	// Catalog the file metadata and build the file trees
-	err = image.Read()
 	if err != nil {
 		panic(err)
 	}
@@ -36,13 +33,6 @@ func main() {
 	}
 
 	////////////////////////////////////////////////////////////////
-	// Squash the file trees
-	err = image.Squash()
-	if err != nil {
-		panic(err)
-	}
-
-	////////////////////////////////////////////////////////////////
 	// Show the squashed tree
 	image.SquashedTree.Walk(func(f file.Reference) {
 		fmt.Println("   ", f.Path)
@@ -50,7 +40,7 @@ func main() {
 
 	////////////////////////////////////////////////////////////////
 	// Fetch file contents from the (squashed) image
-	content, err := image.FileContents("/etc/centos-release")
+	content, err := image.FileContentsFromSquash("/etc/centos-release")
 	if err != nil {
 		panic(err)
 	}

--- a/integration/fixture_image_simple_asserts.go
+++ b/integration/fixture_image_simple_asserts.go
@@ -43,7 +43,7 @@ func assertImageSimpleFixtureTrees(t *testing.T, i *image.Image) {
 }
 
 func assertImageSimpleFixtureContents(t *testing.T, i *image.Image) {
-	actualContents, err := i.MultipleFileContents(
+	actualContents, err := i.MultipleFileContentsFromSquash(
 		"/somefile-1.txt",
 		"/somefile-2.txt",
 		"/really/nested/file-3.txt",

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -100,16 +100,6 @@ func getSquashedImage(t *testing.T, source, name string) *image.Image {
 		t.Fatal("could not get tar image:", err)
 	}
 
-	err = i.Read()
-	if err != nil {
-		t.Fatal("could not read tar image:", err)
-	}
-
-	err = i.Squash()
-	if err != nil {
-		t.Fatal("could not squash image:", err)
-	}
-
 	return i
 }
 

--- a/pkg/image/content.go
+++ b/pkg/image/content.go
@@ -7,7 +7,7 @@ import (
 	"github.com/anchore/stereoscope/pkg/tree"
 )
 
-func fetchFileContents(filetree *tree.FileTree, fileCatalog *FileCatalog, path file.Path) (string, error) {
+func fetchFileContentsByPath(filetree *tree.FileTree, fileCatalog *FileCatalog, path file.Path) (string, error) {
 	fileReference := filetree.File(path)
 	if fileReference == nil {
 		return "", fmt.Errorf("could not find file path in Tree: %s", path)
@@ -20,7 +20,7 @@ func fetchFileContents(filetree *tree.FileTree, fileCatalog *FileCatalog, path f
 	return content, nil
 }
 
-func fetchMultipleFileContents(filetree *tree.FileTree, fileCatalog *FileCatalog, paths ...file.Path) (map[file.Reference]string, error) {
+func fetchMultipleFileContentsByPath(filetree *tree.FileTree, fileCatalog *FileCatalog, paths ...file.Path) (map[file.Reference]string, error) {
 	fileReferences := make([]file.Reference, len(paths))
 	for idx, path := range paths {
 		fileReference := filetree.File(path)

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -60,10 +60,26 @@ func (i *Image) Squash() error {
 	return nil
 }
 
-func (i *Image) FileContents(path file.Path) (string, error) {
-	return fetchFileContents(i.SquashedTree, &i.FileCatalog, path)
+func (i *Image) FileContentsFromSquash(path file.Path) (string, error) {
+	return fetchFileContentsByPath(i.SquashedTree, &i.FileCatalog, path)
 }
 
-func (i *Image) MultipleFileContents(paths ...file.Path) (map[file.Reference]string, error) {
-	return fetchMultipleFileContents(i.SquashedTree, &i.FileCatalog, paths...)
+func (i *Image) MultipleFileContentsFromSquash(paths ...file.Path) (map[file.Reference]string, error) {
+	return fetchMultipleFileContentsByPath(i.SquashedTree, &i.FileCatalog, paths...)
+}
+
+func (i *Image) FileContentsByRef(ref file.Reference) (string, error) {
+	content, err := i.FileCatalog.FileContents(ref)
+	if err != nil {
+		return "", err
+	}
+	return content, nil
+}
+
+func (i *Image) MultipleFileContentsByRef(refs ...file.Reference) (map[file.Reference]string, error) {
+	content, err := i.FileCatalog.MultipleFileContents(refs...)
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
 }

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -44,9 +44,9 @@ func (l *Layer) Read(catalog *FileCatalog) error {
 }
 
 func (l *Layer) FileContents(path file.Path) (string, error) {
-	return fetchFileContents(l.Tree, l.fileCatalog, path)
+	return fetchFileContentsByPath(l.Tree, l.fileCatalog, path)
 }
 
 func (l *Layer) MultipleFileContents(paths ...file.Path) (map[file.Reference]string, error) {
-	return fetchMultipleFileContents(l.Tree, l.fileCatalog, paths...)
+	return fetchMultipleFileContentsByPath(l.Tree, l.fileCatalog, paths...)
 }


### PR DESCRIPTION
- Add fetch content by file reference (to support image BOM)
- Add `getImage` options, such that Read() and Squash() can optionally be applied to the fetched image. The default is to Read() and Squash() when no options are given. This allows the user to get an image that is already cataloged and squashed in fewer steps while adding flexibility. (closes #3 )