### PR TITLE
Add filetree reader for testing

### DIFF
--- a/examples/basic.go
+++ b/examples/basic.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/stereoscope/pkg/file"
-	"os"
 )
 
 func main() {
@@ -45,5 +46,4 @@ func main() {
 		panic(err)
 	}
 	fmt.Println(content)
-
 }

--- a/pkg/tree/breadth_first_walker.go
+++ b/pkg/tree/breadth_first_walker.go
@@ -7,14 +7,14 @@ import (
 )
 
 type BreadthFirstWalker struct {
-	visitor    Visitor
+	visitor    NodeVisitor
 	tree       Reader
 	queue      node.Queue
 	visited    node.Set
 	conditions WalkConditions
 }
 
-func NewBreadthFirstWalker(reader Reader, visitor Visitor) *BreadthFirstWalker {
+func NewBreadthFirstWalker(reader Reader, visitor NodeVisitor) *BreadthFirstWalker {
 	return &BreadthFirstWalker{
 		visitor: visitor,
 		tree:    reader,
@@ -22,7 +22,7 @@ func NewBreadthFirstWalker(reader Reader, visitor Visitor) *BreadthFirstWalker {
 	}
 }
 
-func NewBreadthFirstWalkerWithConditions(reader Reader, visitor Visitor, conditions WalkConditions) *BreadthFirstWalker {
+func NewBreadthFirstWalkerWithConditions(reader Reader, visitor NodeVisitor, conditions WalkConditions) *BreadthFirstWalker {
 	return &BreadthFirstWalker{
 		visitor:    visitor,
 		tree:       reader,

--- a/pkg/tree/breadth_first_walker_test.go
+++ b/pkg/tree/breadth_first_walker_test.go
@@ -1,9 +1,10 @@
 package tree
 
 import (
+	"testing"
+
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/tree/node"
-	"testing"
 )
 
 func bfsTestTree() *FileTree {
@@ -94,7 +95,7 @@ func TestBFS_Walk_ShouldTerminate(t *testing.T) {
 
 	h := WalkConditions{
 		ShouldTerminate: func(path node.Node) bool {
-			if tr.FileByPathID(path.ID()).Path == terminatePath {
+			if tr.fileByPathID(path.ID()).Path == terminatePath {
 				return true
 			}
 			return false
@@ -130,7 +131,7 @@ func TestBFS_Walk_ShouldVisit(t *testing.T) {
 	h := WalkConditions{
 		ShouldTerminate: nil,
 		ShouldVisit: func(path node.Node) bool {
-			if tr.FileByPathID(path.ID()).Path == skipPath {
+			if tr.fileByPathID(path.ID()).Path == skipPath {
 				return false
 			}
 			return true
@@ -165,7 +166,7 @@ func TestBFS_Walk_ShouldContinueBranch(t *testing.T) {
 		ShouldTerminate: nil,
 		ShouldVisit:     nil,
 		ShouldContinueBranch: func(path node.Node) bool {
-			if tr.FileByPathID(path.ID()).Path == prunePath {
+			if tr.fileByPathID(path.ID()).Path == prunePath {
 				return false
 			}
 			return true

--- a/pkg/tree/depth_first_walker.go
+++ b/pkg/tree/depth_first_walker.go
@@ -8,14 +8,14 @@ import (
 
 // DepthFirstWalker implements stateful depth-first tree traversal.
 type DepthFirstWalker struct {
-	visitor    Visitor
+	visitor    NodeVisitor
 	tree       Reader
 	stack      node.Stack
 	visited    node.Set
 	conditions WalkConditions
 }
 
-func NewDepthFirstWalker(reader Reader, visitor Visitor) *DepthFirstWalker {
+func NewDepthFirstWalker(reader Reader, visitor NodeVisitor) *DepthFirstWalker {
 	return &DepthFirstWalker{
 		visitor: visitor,
 		tree:    reader,
@@ -23,7 +23,7 @@ func NewDepthFirstWalker(reader Reader, visitor Visitor) *DepthFirstWalker {
 	}
 }
 
-func NewDepthFirstWalkerWithConditions(reader Reader, visitor Visitor, conditions WalkConditions) *DepthFirstWalker {
+func NewDepthFirstWalkerWithConditions(reader Reader, visitor NodeVisitor, conditions WalkConditions) *DepthFirstWalker {
 	return &DepthFirstWalker{
 		visitor:    visitor,
 		tree:       reader,

--- a/pkg/tree/depth_first_walker_test.go
+++ b/pkg/tree/depth_first_walker_test.go
@@ -93,7 +93,7 @@ func TestDFS_Walk_ShouldTerminate(t *testing.T) {
 
 	h := WalkConditions{
 		ShouldTerminate: func(path node.Node) bool {
-			if tr.FileByPathID(path.ID()).Path == terminatePath {
+			if tr.fileByPathID(path.ID()).Path == terminatePath {
 				return true
 			}
 			return false
@@ -128,7 +128,7 @@ func TestDFS_Walk_ShouldVisit(t *testing.T) {
 	h := WalkConditions{
 		ShouldTerminate: nil,
 		ShouldVisit: func(path node.Node) bool {
-			if tr.FileByPathID(path.ID()).Path == skipPath {
+			if tr.fileByPathID(path.ID()).Path == skipPath {
 				return false
 			}
 			return true
@@ -160,7 +160,7 @@ func TestDFS_Walk_ShouldPruneBranch(t *testing.T) {
 		ShouldTerminate: nil,
 		ShouldVisit:     nil,
 		ShouldContinueBranch: func(path node.Node) bool {
-			if tr.FileByPathID(path.ID()).Path == prunePath {
+			if tr.fileByPathID(path.ID()).Path == prunePath {
 				return false
 			}
 			return true

--- a/pkg/tree/filetree.go
+++ b/pkg/tree/filetree.go
@@ -42,19 +42,19 @@ func (t *FileTree) HasPath(path file.Path) bool {
 	return ok
 }
 
-func (t *FileTree) FileByPathID(id node.ID) file.Reference {
+func (t *FileTree) fileByPathID(id node.ID) file.Reference {
 	return t.pathToFileRef[id]
 }
 
 func (t *FileTree) VisitorFn(fn func(file.Reference)) func(node.Node) {
 	return func(node node.Node) {
-		fn(t.FileByPathID(node.ID()))
+		fn(t.fileByPathID(node.ID()))
 	}
 }
 
 func (t *FileTree) ConditionFn(fn func(file.Reference) bool) func(node.Node) bool {
 	return func(node node.Node) bool {
-		return fn(t.FileByPathID(node.ID()))
+		return fn(t.fileByPathID(node.ID()))
 	}
 }
 
@@ -66,20 +66,6 @@ func (t *FileTree) AllFiles() []file.Reference {
 		idx++
 	}
 	return files
-}
-
-func (t *FileTree) Files(paths []file.Path) ([]file.Reference, error) {
-	files := make([]file.Reference, len(paths))
-	idx := 0
-	for _, path := range paths {
-		f := t.File(path)
-		if f == nil {
-			return nil, fmt.Errorf("could not find path: %+v", path)
-		}
-		files[idx] = *f
-		idx++
-	}
-	return files, nil
 }
 
 func (t *FileTree) File(path file.Path) *file.Reference {

--- a/pkg/tree/filetree_reader.go
+++ b/pkg/tree/filetree_reader.go
@@ -1,0 +1,12 @@
+package tree
+
+import (
+	"github.com/anchore/stereoscope/pkg/file"
+)
+
+type FileTreeReader interface {
+	AllFiles() []file.Reference
+	HasPath(path file.Path) bool
+	File(path file.Path) *file.Reference
+	Walk(fn func(f file.Reference))
+}

--- a/pkg/tree/union_filetree_test.go
+++ b/pkg/tree/union_filetree_test.go
@@ -1,8 +1,9 @@
 package tree
 
 import (
-	"github.com/anchore/stereoscope/pkg/file"
 	"testing"
+
+	"github.com/anchore/stereoscope/pkg/file"
 )
 
 func TestUnionFileTree_Squash(t *testing.T) {

--- a/pkg/tree/visitor.go
+++ b/pkg/tree/visitor.go
@@ -1,5 +1,10 @@
 package tree
 
-import "github.com/anchore/stereoscope/pkg/tree/node"
+import (
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/tree/node"
+)
 
-type Visitor func(n node.Node)
+type NodeVisitor func(node.Node)
+
+type FileVisitor func(file.Reference)


### PR DESCRIPTION
This adds an interface which downstream packages can use as a mock point (if desired).

Additionally:
- reduces number of read functions (such as fileByPathID) by not exporting them
- rename Visitor -> NodeVisitor for clarity (there can also be FileVisitors)
- apparently linting? it seems that goland vs vscode settings clash... blerg

Closes #18 