### PR TITLE
Use fewer resources in the pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,17 +9,24 @@ jobs:
       - image: circleci/golang:<< parameters.version >>
         environment:
           GO111MODULE: "on"
+    # 1CPU / 2GB RAM
+    resource_class: small
     steps:
+
       - checkout
+
       - restore_cache:
           keys:
             - go-<< parameters.version >>-{{ checksum "go.sum" }}-{{ checksum "Makefile" }}
+
       - run: make bootstrap
+
       - save_cache:
           key: go-<< parameters.version >>-{{ checksum "go.sum" }}-{{ checksum "Makefile" }}
           paths:
             - "/go/pkg/mod"
             - ".tmp"
+
       - run:
           name: run static analysis
           command: make lint
@@ -32,10 +39,10 @@ jobs:
       - image: circleci/golang:<< parameters.version >>
         environment:
           GO111MODULE: "on"
-          # work around for recent circle CI breaking change (should remove asap)
-          # Error: "Error response from daemon: client version 1.39 is too new. Maximum supported API version is 1.38"
-          DOCKER_API_VERSION: "1.38"
+    # 1CPU / 2GB RAM
+    resource_class: small
     steps:
+
       - checkout
 
       - restore_cache:
@@ -89,7 +96,7 @@ jobs:
             - "integration/test-fixtures/tar-cache"
 
 workflows:
-  commit:
+  "Static Analysis & All Tests":
     jobs:
       - run-static-analysis:
           name: "Static Analysis"


### PR DESCRIPTION
uses the `small` docker resource class, removes the docker version lock in CI, and updates the workflow title