### PR TITLE
Add event bus and initial events

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,6 @@
 linters-settings:
+  funlen:
+    lines: 65
 linters:
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true

--- a/client.go
+++ b/client.go
@@ -5,12 +5,14 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/anchore/stereoscope/internal/bus"
 	"github.com/anchore/stereoscope/internal/log"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/stereoscope/pkg/image/docker"
 	"github.com/anchore/stereoscope/pkg/logger"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/hashicorp/go-multierror"
+	"github.com/wagoodman/go-partybus"
 )
 
 const (
@@ -105,6 +107,10 @@ func GetImage(userStr string, options ...Option) (*image.Image, error) {
 
 func SetLogger(logger logger.Logger) {
 	log.Log = logger
+}
+
+func SetBus(b *partybus.Bus) {
+	bus.SetPublisher(b)
 }
 
 func Cleanup() {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.0 // indirect
+	github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d
+	github.com/wagoodman/go-progress v0.0.0-20200621122631-1a2120f0695a
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9 // indirect
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 	google.golang.org/genproto v0.0.0-20200604104852-0b0486081ffb // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,7 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/anchore/go-testutils v0.0.0-20200520222037-edc2bf1864fe h1:YMXe4RA3qy4Ri5fmGQii/Gn+Pxv3oBfiS/LqzeOVuwo=
 github.com/anchore/go-testutils v0.0.0-20200520222037-edc2bf1864fe/go.mod h1:D3rc2L/q4Hcp9eeX6AIJH4Q+kPjOtJCFhG9za90j+nU=
 github.com/anchore/stereoscope v0.0.0-20200520221116-025e07f1c93e/go.mod h1:bkyLl5VITnrmgErv4S1vDfVz/TGAZ5il6161IQo7w2g=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ=
 github.com/apex/log v1.3.0/go.mod h1:jd8Vpsr46WAe3EZSQ/IUMs2qQD/GOycT5rPWCO1yGcs=
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
@@ -359,6 +360,7 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.2/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gookit/color v1.2.4/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
+github.com/gookit/color v1.2.5/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/goreleaser/goreleaser v0.136.0/go.mod h1:wiKrPUeSNh6Wu8nUHxZydSOVQ/OZvOaO7DTtFqie904=
@@ -607,6 +609,7 @@ github.com/securego/gosec v0.0.0-20200103095621-79fbf3af8d83/go.mod h1:vvbZ2Ae7A
 github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989/go.mod h1:i9l/TNj+yDFh9SZXUTvspXTjbFXgZGP/UvhU1S65A4A=
 github.com/securego/gosec/v2 v2.3.0/go.mod h1:UzeVyUXbxukhLeHKV3VVqo7HdoQR9MrRfFmZYotn8ME=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
@@ -700,6 +703,14 @@ github.com/valyala/quicktemplate v1.2.0/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOV
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vdemeester/k8s-pkg-credentialprovider v1.17.4/go.mod h1:inCTmtUdr5KJbreVojo06krnTgaeAz/Z7lynpPk/Q2c=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
+github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d h1:KOxOL6qpmqwoPloNwi+CEgc1ayjHNOFNrvoOmeDOjDg=
+github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d/go.mod h1:JPirS5jde/CF5qIjcK4WX+eQmKXdPc6vcZkJ/P0hfPw=
+github.com/wagoodman/go-progress v0.0.0-20200526224006-dd1404d54b0b h1:UDJoympq2F2QqhIu0wF6PtI+Apq1sW3TobBoZOrUTa8=
+github.com/wagoodman/go-progress v0.0.0-20200526224006-dd1404d54b0b/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
+github.com/wagoodman/go-progress v0.0.0-20200621015745-33e4eae271f6 h1:UlFz5LlVG0sWVLP+TlXg74cuYU4e8pi0AI1DtGN94hg=
+github.com/wagoodman/go-progress v0.0.0-20200621015745-33e4eae271f6/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
+github.com/wagoodman/go-progress v0.0.0-20200621122631-1a2120f0695a h1:lV3ioFpbqvfZ1bXSQfloLWzom1OPU/5UjyU0wmBlkNc=
+github.com/wagoodman/go-progress v0.0.0-20200621122631-1a2120f0695a/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
 github.com/xanzy/go-gitlab v0.31.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/go-gitlab v0.32.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -1,0 +1,19 @@
+package bus
+
+import "github.com/wagoodman/go-partybus"
+
+var publisher partybus.Publisher
+var active bool
+
+func SetPublisher(p partybus.Publisher) {
+	publisher = p
+	if p != nil {
+		active = true
+	}
+}
+
+func Publish(event partybus.Event) {
+	if active {
+		publisher.Publish(event)
+	}
+}

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -1,0 +1,11 @@
+package event
+
+import (
+	"github.com/wagoodman/go-partybus"
+)
+
+const (
+	FetchImage partybus.EventType = "fetch-image-event"
+	ReadImage  partybus.EventType = "read-image-event"
+	ReadLayer  partybus.EventType = "read-layer-event"
+)

--- a/pkg/event/parsers/parsers.go
+++ b/pkg/event/parsers/parsers.go
@@ -1,0 +1,89 @@
+package parsers
+
+import (
+	"fmt"
+
+	"github.com/anchore/stereoscope/pkg/event"
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/wagoodman/go-partybus"
+	"github.com/wagoodman/go-progress"
+)
+
+type ErrBadPayload struct {
+	Type  partybus.EventType
+	Field string
+	Value interface{}
+}
+
+func (e *ErrBadPayload) Error() string {
+	return fmt.Sprintf("event='%s' has bad event payload field='%v': '%+v'", string(e.Type), e.Field, e.Value)
+}
+
+func newPayloadErr(t partybus.EventType, field string, value interface{}) error {
+	return &ErrBadPayload{
+		Type:  t,
+		Field: field,
+		Value: value,
+	}
+}
+
+func checkEventType(actual, expected partybus.EventType) error {
+	if actual != expected {
+		return newPayloadErr(expected, "Type", actual)
+	}
+	return nil
+}
+
+func ParseFetchImage(e partybus.Event) (string, progress.StagedProgressable, error) {
+	if err := checkEventType(e.Type, event.FetchImage); err != nil {
+		return "", nil, err
+	}
+
+	imgName, ok := e.Source.(string)
+	if !ok {
+		return "", nil, newPayloadErr(e.Type, "Source", e.Source)
+	}
+
+	prog, ok := e.Value.(progress.StagedProgressable)
+	if !ok {
+		return "", nil, newPayloadErr(e.Type, "Value", e.Value)
+	}
+
+	return imgName, prog, nil
+}
+
+func ParseReadImage(e partybus.Event) (*image.Metadata, progress.Progressable, error) {
+	if err := checkEventType(e.Type, event.ReadImage); err != nil {
+		return nil, nil, err
+	}
+
+	imgMetadata, ok := e.Source.(image.Metadata)
+	if !ok {
+		return nil, nil, newPayloadErr(e.Type, "Source", e.Source)
+	}
+
+	prog, ok := e.Value.(progress.Progressable)
+	if !ok {
+		return nil, nil, newPayloadErr(e.Type, "Value", e.Value)
+	}
+
+	return &imgMetadata, prog, nil
+}
+
+func ParseReadLayer(e partybus.Event) (*image.LayerMetadata, progress.Monitorable, error) {
+	if err := checkEventType(e.Type, event.ReadLayer); err != nil {
+		return nil, nil, err
+	}
+
+	layerMetadata, ok := e.Source.(image.LayerMetadata)
+	if !ok {
+		return nil, nil, newPayloadErr(e.Type, "Source", e.Source)
+	}
+
+	prog, ok := e.Value.(progress.Monitorable)
+	if !ok {
+		return nil, nil, newPayloadErr(e.Type, "Value", e.Value)
+	}
+
+	return &layerMetadata, prog, nil
+}


### PR DESCRIPTION
This adds the idea of an event bus for targeted, read-only, rich object introspection. Its usage is meant to mimic that of a logger (one way info, a single global instance, and the application is responsible for providing the instance [not the lib]).

Adds the first 3 events:
- fetch image: emitted whenever there is a image provider that wishes to share progress of getting an image tar (e.g. a docker image save + writing the file).
- read image: emitted to show progress of parsing an image tar and creating the squash trees.
- read layer: emitted to show the progress of parsing a layer tar and creating the diff trees.

Each event object must (rather, really really should) provide a convenience parser function for lib consumers to leverage.

This will be used in future PRs in other repos as the foundation for CLI progress behaviors.

