### PR TITLE
Add pull to docker daemon image provider

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 linters-settings:
   funlen:
-    lines: 65
+    lines: 75
 linters:
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/anchore/go-testutils v0.0.0-20200520222037-edc2bf1864fe h1:YMXe4RA3qy4Ri5fmGQii/Gn+Pxv3oBfiS/LqzeOVuwo=
-github.com/anchore/go-testutils v0.0.0-20200520222037-edc2bf1864fe/go.mod h1:D3rc2L/q4Hcp9eeX6AIJH4Q+kPjOtJCFhG9za90j+nU=
 github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db h1:LWKezJnFTFxNkZ4MzajVf+YWvJS0+7hwFr59u6SS7cw=
 github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db/go.mod h1:D3rc2L/q4Hcp9eeX6AIJH4Q+kPjOtJCFhG9za90j+nU=
 github.com/anchore/stereoscope v0.0.0-20200520221116-025e07f1c93e/go.mod h1:bkyLl5VITnrmgErv4S1vDfVz/TGAZ5il6161IQo7w2g=
@@ -203,6 +201,7 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -611,6 +610,7 @@ github.com/securego/gosec v0.0.0-20200103095621-79fbf3af8d83/go.mod h1:vvbZ2Ae7A
 github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989/go.mod h1:i9l/TNj+yDFh9SZXUTvspXTjbFXgZGP/UvhU1S65A4A=
 github.com/securego/gosec/v2 v2.3.0/go.mod h1:UzeVyUXbxukhLeHKV3VVqo7HdoQR9MrRfFmZYotn8ME=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
@@ -707,10 +707,6 @@ github.com/vdemeester/k8s-pkg-credentialprovider v1.17.4/go.mod h1:inCTmtUdr5KJb
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d h1:KOxOL6qpmqwoPloNwi+CEgc1ayjHNOFNrvoOmeDOjDg=
 github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d/go.mod h1:JPirS5jde/CF5qIjcK4WX+eQmKXdPc6vcZkJ/P0hfPw=
-github.com/wagoodman/go-progress v0.0.0-20200526224006-dd1404d54b0b h1:UDJoympq2F2QqhIu0wF6PtI+Apq1sW3TobBoZOrUTa8=
-github.com/wagoodman/go-progress v0.0.0-20200526224006-dd1404d54b0b/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
-github.com/wagoodman/go-progress v0.0.0-20200621015745-33e4eae271f6 h1:UlFz5LlVG0sWVLP+TlXg74cuYU4e8pi0AI1DtGN94hg=
-github.com/wagoodman/go-progress v0.0.0-20200621015745-33e4eae271f6/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
 github.com/wagoodman/go-progress v0.0.0-20200621122631-1a2120f0695a h1:lV3ioFpbqvfZ1bXSQfloLWzom1OPU/5UjyU0wmBlkNc=
 github.com/wagoodman/go-progress v0.0.0-20200621122631-1a2120f0695a/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
 github.com/xanzy/go-gitlab v0.31.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -5,7 +5,8 @@ import (
 )
 
 const (
-	FetchImage partybus.EventType = "fetch-image-event"
-	ReadImage  partybus.EventType = "read-image-event"
-	ReadLayer  partybus.EventType = "read-layer-event"
+	PullDockerImage partybus.EventType = "pull-docker-image-event"
+	FetchImage      partybus.EventType = "fetch-image-event"
+	ReadImage       partybus.EventType = "read-image-event"
+	ReadLayer       partybus.EventType = "read-layer-event"
 )

--- a/pkg/event/parsers/parsers.go
+++ b/pkg/event/parsers/parsers.go
@@ -3,6 +3,8 @@ package parsers
 import (
 	"fmt"
 
+	"github.com/anchore/stereoscope/pkg/image/docker"
+
 	"github.com/anchore/stereoscope/pkg/event"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/wagoodman/go-partybus"
@@ -32,6 +34,24 @@ func checkEventType(actual, expected partybus.EventType) error {
 		return newPayloadErr(expected, "Type", actual)
 	}
 	return nil
+}
+
+func ParsePullDockerImage(e partybus.Event) (string, *docker.PullStatus, error) {
+	if err := checkEventType(e.Type, event.PullDockerImage); err != nil {
+		return "", nil, err
+	}
+
+	imgName, ok := e.Source.(string)
+	if !ok {
+		return "", nil, newPayloadErr(e.Type, "Source", e.Source)
+	}
+
+	prog, ok := e.Value.(*docker.PullStatus)
+	if !ok {
+		return "", nil, newPayloadErr(e.Type, "Value", e.Value)
+	}
+
+	return imgName, prog, nil
 }
 
 func ParseFetchImage(e partybus.Event) (string, progress.StagedProgressable, error) {

--- a/pkg/image/docker/pull_status.go
+++ b/pkg/image/docker/pull_status.go
@@ -1,0 +1,145 @@
+package docker
+
+import (
+	"sync"
+
+	"github.com/wagoodman/go-progress"
+)
+
+const (
+	UnknownPhase PullPhase = iota
+	WaitingPhase
+	PullingFsPhase
+	DownloadingPhase
+	DownloadCompletePhase
+	ExtractingPhase
+	VerifyingChecksumPhase
+	AlreadyExistsPhase
+	PullCompletePhase
+)
+
+type PullPhase int
+type LayerID string
+
+type pullEvent struct {
+	ID             string `json:"id"`
+	Status         string `json:"status"`
+	Error          string `json:"error,omitempty"`
+	Progress       string `json:"progress,omitempty"`
+	ProgressDetail struct {
+		Current int `json:"current"`
+		Total   int `json:"total"`
+	} `json:"progressDetail"`
+}
+
+type LayerState struct {
+	Phase            PullPhase
+	PhaseProgress    progress.Progressable
+	DownloadProgress progress.Progressable
+}
+
+type PullStatus struct {
+	phaseProgress    map[LayerID]*progress.Manual
+	downloadProgress map[LayerID]*progress.Manual
+	phase            map[LayerID]PullPhase
+	layers           []LayerID
+	lock             sync.Mutex
+	complete         bool
+}
+
+func newPullStatus() *PullStatus {
+	return &PullStatus{
+		phaseProgress:    make(map[LayerID]*progress.Manual),
+		downloadProgress: make(map[LayerID]*progress.Manual),
+		phase:            make(map[LayerID]PullPhase),
+	}
+}
+
+func (p *PullStatus) Complete() bool {
+	return p.complete
+}
+
+func (p *PullStatus) Layers() []LayerID {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	return append([]LayerID{}, p.layers...)
+}
+
+func (p *PullStatus) Current(layer LayerID) LayerState {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	return LayerState{
+		Phase:            p.phase[layer],
+		PhaseProgress:    progress.Progressable(p.phaseProgress[layer]),
+		DownloadProgress: progress.Progressable(p.downloadProgress[layer]),
+	}
+}
+
+func (p *PullStatus) onEvent(event *pullEvent) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	layer := LayerID(event.ID)
+	if layer == "" {
+		return
+	}
+
+	if _, ok := p.phaseProgress[layer]; !ok {
+		// ignore the first layer as it's the image id
+		if p.layers == nil {
+			p.layers = make([]LayerID, 0)
+			return
+		}
+
+		// this is a new layer, initialize tracking info
+		p.phaseProgress[layer] = &progress.Manual{}
+		p.downloadProgress[layer] = &progress.Manual{}
+		p.layers = append(p.layers, layer)
+	}
+
+	// capture latest event info
+	currentPhase := parsePhase(event.Status)
+	p.phase[layer] = currentPhase
+	phaseProgress := p.phaseProgress[layer]
+
+	if currentPhase >= AlreadyExistsPhase {
+		phaseProgress.SetCompleted()
+	} else {
+		phaseProgress.N = int64(event.ProgressDetail.Current)
+		phaseProgress.Total = int64(event.ProgressDetail.Total)
+	}
+
+	if currentPhase == DownloadingPhase {
+		dl := p.downloadProgress[layer]
+		dl.N = int64(event.ProgressDetail.Current)
+		dl.Total = int64(event.ProgressDetail.Total)
+	} else if currentPhase >= DownloadCompletePhase {
+		dl := p.downloadProgress[layer]
+		dl.N = dl.Total
+		dl.SetCompleted()
+	}
+}
+
+func parsePhase(inputStr string) PullPhase {
+	switch inputStr {
+	case "Waiting":
+		return WaitingPhase
+	case "Pulling fs layer":
+		return PullingFsPhase
+	case "Downloading":
+		return DownloadingPhase
+	case "Download complete":
+		return DownloadCompletePhase
+	case "Extracting":
+		return ExtractingPhase
+	case "Verifying Checksum":
+		return VerifyingChecksumPhase
+	case "Already exists":
+		return AlreadyExistsPhase
+	case "Pull complete":
+		return PullCompletePhase
+	}
+	return UnknownPhase
+}


### PR DESCRIPTION
This PR adds:
- docker pull for non-existent images, using standard docker config credentials
- publishes the status on the event bus for detailed progress (by layer)

Closes #33 