### PR TITLE
Accept image ID as input

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/stereoscope/pkg/image/docker"
 	"github.com/anchore/stereoscope/pkg/logger"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/hashicorp/go-multierror"
 	"github.com/wagoodman/go-partybus"
 )
@@ -57,7 +56,7 @@ func (t *tracker) cleanup() error {
 	return allErrors
 }
 
-// GetImage parses the user provided image string and provides a image object
+// GetImage parses the user provided image string and provides an image object
 func GetImage(userStr string, options ...Option) (*image.Image, error) {
 	var provider image.Provider
 	source, imgStr := image.ParseImageSpec(userStr)
@@ -80,12 +79,8 @@ func GetImage(userStr string, options ...Option) (*image.Image, error) {
 		// note: the imgStr is the path on disk to the tar file
 		provider = docker.NewProviderFromTarball(imgStr)
 	case image.DockerDaemonSource:
-		imgRef, err := name.ParseReference(imgStr)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse image identifier: %w", err)
-		}
 		cacheDir := trackerInstance.newTempDir()
-		provider = docker.NewProviderFromDaemon(imgRef, cacheDir)
+		provider = docker.NewProviderFromDaemon(imgStr, cacheDir)
 	default:
 		return nil, fmt.Errorf("unable determine image source")
 	}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -16,7 +16,7 @@ var instanceErr error
 var instance *client.Client
 var once sync.Once
 
-func GetClient() (*client.Client, error) {
+func NewClient() (*client.Client, error) {
 	once.Do(func() {
 		var clientOpts = []client.Opt{
 			client.FromEnv,

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -16,7 +16,7 @@ var instanceErr error
 var instance *client.Client
 var once sync.Once
 
-func NewClient() (*client.Client, error) {
+func GetClient() (*client.Client, error) {
 	once.Do(func() {
 		var clientOpts = []client.Opt{
 			client.FromEnv,

--- a/pkg/file/test-fixtures/generators/fixture-1.sh
+++ b/pkg/file/test-fixtures/generators/fixture-1.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -ue
 
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
 FIXTURE_TAR_PATH=$1
 FIXTURE_NAME=$(basename $FIXTURE_TAR_PATH)
 FIXTURE_DIR=$(realpath $(dirname $FIXTURE_TAR_PATH))

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -43,7 +43,7 @@ func NewProviderFromDaemon(imgStr, cacheDir string) *DaemonImageProvider {
 }
 
 func (p *DaemonImageProvider) trackSaveProgress() (*progress.TimedProgress, *progress.Writer, *progress.Stage, error) {
-	dockerClient, err := docker.NewClient()
+	dockerClient, err := docker.GetClient()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to get docker client: %w", err)
 	}
@@ -104,7 +104,7 @@ func (p *DaemonImageProvider) pull(ctx context.Context) error {
 		Value:  status,
 	})
 
-	dockerClient, err := docker.NewClient()
+	dockerClient, err := docker.GetClient()
 	if err != nil {
 		return fmt.Errorf("failed to load docker client: %w", err)
 	}
@@ -155,8 +155,8 @@ func (p *DaemonImageProvider) Provide() (*image.Image, error) {
 		}
 	}()
 
-	// create a new Docker client
-	dockerClient, err := docker.NewClient()
+	// obtain a Docker client
+	dockerClient, err := docker.GetClient()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a docker client: %w", err)
 	}

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/google/go-containerregistry/pkg/name"
+
 	"github.com/anchore/stereoscope/internal/bus"
 	"github.com/anchore/stereoscope/internal/docker"
 	"github.com/anchore/stereoscope/internal/log"
@@ -20,7 +23,6 @@ import (
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
@@ -28,31 +30,31 @@ import (
 
 // DaemonImageProvider is a image.Provider capable of fetching and representing a docker image from the docker daemon API.
 type DaemonImageProvider struct {
-	ImageRef name.Reference
+	ImageStr string
 	cacheDir string
 }
 
 // NewProviderFromDaemon creates a new provider instance for a specific image that will later be cached to the given directory.
-func NewProviderFromDaemon(imgRef name.Reference, cacheDir string) *DaemonImageProvider {
+func NewProviderFromDaemon(imgStr, cacheDir string) *DaemonImageProvider {
 	return &DaemonImageProvider{
-		ImageRef: imgRef,
+		ImageStr: imgStr,
 		cacheDir: cacheDir,
 	}
 }
 
 func (p *DaemonImageProvider) trackSaveProgress() (*progress.TimedProgress, *progress.Writer, *progress.Stage, error) {
-	dockerClient, err := docker.GetClient()
+	dockerClient, err := docker.NewClient()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to get docker client: %w", err)
 	}
 
 	// fetch the expected image size to estimate and measure progress
-	inspect, _, err := dockerClient.ImageInspectWithRaw(context.Background(), p.ImageRef.Name())
+	inspect, _, err := dockerClient.ImageInspectWithRaw(context.Background(), p.ImageStr)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to inspect image: %w", err)
 	}
 
-	// docker image save clocks in at ~125MB/sec on my laptop... milage may vary, of course :shrug:
+	// docker image save clocks in at ~125MB/sec on my laptop... mileage may vary, of course :shrug:
 	mb := math.Pow(2, 20)
 	sec := float64(inspect.VirtualSize) / (mb * 125)
 	approxSaveTime := time.Duration(sec*1000) * time.Millisecond
@@ -66,7 +68,7 @@ func (p *DaemonImageProvider) trackSaveProgress() (*progress.TimedProgress, *pro
 
 	bus.Publish(partybus.Event{
 		Type:   event.FetchImage,
-		Source: p.ImageRef.Name(),
+		Source: p.ImageStr,
 		Value: progress.StagedProgressable(&struct {
 			progress.Stager
 			*progress.Aggregator
@@ -81,7 +83,7 @@ func (p *DaemonImageProvider) trackSaveProgress() (*progress.TimedProgress, *pro
 
 // pull a docker image
 func (p *DaemonImageProvider) pull(ctx context.Context) error {
-	log.Debugf("pulling docker image=%q", p.ImageRef.String())
+	log.Debugf("pulling docker image=%q", p.ImageStr)
 
 	// note: this will search the default config dir and allow for a DOCKER_CONFIG override
 	cfg, err := config.Load("")
@@ -89,28 +91,6 @@ func (p *DaemonImageProvider) pull(ctx context.Context) error {
 		return fmt.Errorf("failed to load docker config: %w", err)
 	}
 	log.Debugf("using docker config=%q", cfg.Filename)
-
-	hostname := p.ImageRef.Context().RegistryStr()
-	creds, err := cfg.GetAuthConfig(hostname)
-	if err != nil {
-		return fmt.Errorf("failed to fetch registry auth (hostname=%s): %w", hostname, err)
-	}
-
-	dockerClient, err := docker.GetClient()
-	if err != nil {
-		return fmt.Errorf("failed to load docker client: %w", err)
-	}
-
-	var opts types.ImagePullOptions
-
-	if creds.Username != "" {
-		log.Debugf("using docker credentials for %q", hostname)
-		jsonBytes, _ := json.Marshal(map[string]string{
-			"username": creds.Username,
-			"password": creds.Password,
-		})
-		opts.RegistryAuth = base64.StdEncoding.EncodeToString(jsonBytes)
-	}
 
 	var status = newPullStatus()
 	defer func() {
@@ -120,11 +100,21 @@ func (p *DaemonImageProvider) pull(ctx context.Context) error {
 	// publish a pull event on the bus, allowing for read-only consumption of status
 	bus.Publish(partybus.Event{
 		Type:   event.PullDockerImage,
-		Source: p.ImageRef.Name(),
+		Source: p.ImageStr,
 		Value:  status,
 	})
 
-	resp, err := dockerClient.ImagePull(ctx, p.ImageRef.Name(), opts)
+	dockerClient, err := docker.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to load docker client: %w", err)
+	}
+
+	options, err := newPullOptions(p.ImageStr, cfg)
+	if err != nil {
+		return err
+	}
+
+	resp, err := dockerClient.ImagePull(ctx, p.ImageStr, options)
 	if err != nil {
 		return fmt.Errorf("pull failed: %w", err)
 	}
@@ -165,14 +155,15 @@ func (p *DaemonImageProvider) Provide() (*image.Image, error) {
 		}
 	}()
 
-	// fetch the image from the docker daemon
-	dockerClient, err := docker.GetClient()
+	// create a new Docker client
+	dockerClient, err := docker.NewClient()
 	if err != nil {
-		return nil, fmt.Errorf("unable to get docker client: %w", err)
+		return nil, fmt.Errorf("unable to create a docker client: %w", err)
 	}
 
-	// check if the image exists, if not pull it...
-	_, _, err = dockerClient.ImageInspectWithRaw(context.Background(), p.ImageRef.Name())
+	// check if the image exists locally
+	_, _, err = dockerClient.ImageInspectWithRaw(context.Background(), p.ImageStr)
+
 	if err != nil {
 		if client.IsErrNotFound(err) {
 			if err = p.pull(context.Background()); err != nil {
@@ -190,7 +181,7 @@ func (p *DaemonImageProvider) Provide() (*image.Image, error) {
 	}
 
 	stage.Current = "requesting image from docker"
-	readCloser, err := dockerClient.ImageSave(context.Background(), []string{p.ImageRef.Name()})
+	readCloser, err := dockerClient.ImageSave(context.Background(), []string{p.ImageStr})
 	if err != nil {
 		return nil, fmt.Errorf("unable to save image tar: %w", err)
 	}
@@ -227,4 +218,31 @@ func (p *DaemonImageProvider) Provide() (*image.Image, error) {
 	}
 
 	return image.NewImageWithTags(img, tags), nil
+}
+
+func newPullOptions(image string, cfg *configfile.ConfigFile) (types.ImagePullOptions, error) {
+	var options types.ImagePullOptions
+
+	ref, err := name.ParseReference(image)
+	if err != nil {
+		return options, err
+	}
+
+	hostname := ref.Context().RegistryStr()
+
+	creds, err := cfg.GetAuthConfig(hostname)
+	if err != nil {
+		return options, fmt.Errorf("failed to fetch registry auth (hostname=%s): %w", hostname, err)
+	}
+
+	if creds.Username != "" {
+		log.Debugf("using docker credentials for %q", hostname)
+		jsonBytes, _ := json.Marshal(map[string]string{
+			"username": creds.Username,
+			"password": creds.Password,
+		})
+		options.RegistryAuth = base64.StdEncoding.EncodeToString(jsonBytes)
+	}
+
+	return options, nil
 }


### PR DESCRIPTION
Fixes #34 

This allows us to use local container image IDs in addition to the existing methods of specifying a Docker image. If an image cannot be found locally by specifying the image ID, we fallback to the existing logic for obtaining the image (i.e. pulling).

**Fun fact:** Similar to commands like `docker run`, `docker stop`, and the like, we can now specify images with only a partial image ID. For example...

```
$ syft 6f
...
$ grype a83
...
```

(The above examples require updates to `go.mod` for syft and grype. These PRs coming soon to a theater near you.)