### PR TITLE
Remove assertion that all files in the FileTree exist in the FileCatalog

### DIFF
--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -1,8 +1,6 @@
 package image
 
 import (
-	"errors"
-
 	"github.com/anchore/stereoscope/internal/bus"
 	"github.com/anchore/stereoscope/internal/log"
 	"github.com/anchore/stereoscope/pkg/event"
@@ -89,9 +87,9 @@ func (l *Layer) Read(catalog *FileCatalog, imgMetadata Metadata, idx int) error 
 		monitor.N++
 	}
 
-	if !catalog.HasEntriesForAllFilesInTree(*l.Tree) {
-		return errors.New("layer read failed: FileCatalog doesn't have an entry for all files in FileTree")
-	}
+	// TODO: It's possible that directories can be added to the FileTree that aren't stored in the FileCatalog.
+	//  Given this, we should think about the extent to which entries in the tree should be present in the catalog,
+	//  and we should consider the impact to consumers as they query this library for "directories" in the image.
 
 	monitor.SetCompleted()
 


### PR DESCRIPTION
While discussing the resolution for https://github.com/anchore/stereoscope/issues/48, it was decided that we should check to make sure that during a layer read, all files in a layer's FileTree have corresponding entries in the FileCatalog. This was because previously, tree merges had been adding files to source trees on the fly if they were missing.

This PR removes the assertion that all files in the tree exist in the FileCatalog.

This case was surfaced in https://github.com/anchore/syft/issues/284.