### PR TITLE
Add raw config image option + enhance tags

### DIFF
--- a/integration/fixture_image_simple_test.go
+++ b/integration/fixture_image_simple_test.go
@@ -34,7 +34,9 @@ func TestSimpleImage(t *testing.T) {
 			source:         "docker",
 			imageMediaType: v1Types.DockerManifestSchema2,
 			layerMediaType: v1Types.DockerLayer,
-			tagCount:       1,
+			// name:hash
+			// name:latest
+			tagCount: 2,
 		},
 		{
 			name:           "FromOciTarball",
@@ -78,7 +80,7 @@ func assertImageSimpleMetadata(t *testing.T, i *image.Image, expectedValues test
 		t.Errorf("unexpected image media type: %+v", i.Metadata.MediaType)
 	}
 	if len(i.Metadata.Tags) != expectedValues.tagCount {
-		t.Errorf("unexpected number of tags: %d", len(i.Metadata.Tags))
+		t.Errorf("unexpected number of tags: %d : %+v", len(i.Metadata.Tags), i.Metadata.Tags)
 	} else if expectedValues.tagCount > 0 {
 		if !strings.HasPrefix(i.Metadata.Tags[0].String(), fmt.Sprintf("%s-image-simple:", imagetest.ImagePrefix)) {
 			t.Errorf("unexpected image tag: %+v", i.Metadata.Tags)

--- a/internal/stringset.go
+++ b/internal/stringset.go
@@ -1,5 +1,7 @@
 package internal
 
+import "sort"
+
 type Set map[string]struct{}
 
 func NewStringSet() Set {
@@ -17,4 +19,16 @@ func (s Set) Remove(i string) {
 func (s Set) Contains(i string) bool {
 	_, ok := s[i]
 	return ok
+}
+
+// ToSlice returns a sorted slice of strings that are contained within the set.
+func (s Set) ToSlice() []string {
+	ret := make([]string, len(s))
+	idx := 0
+	for v := range s {
+		ret[idx] = v
+		idx++
+	}
+	sort.Strings(ret)
+	return ret
 }

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -161,7 +161,7 @@ func (p *DaemonImageProvider) Provide() (*image.Image, error) {
 	}
 
 	// check if the image exists locally
-	_, _, err = dockerClient.ImageInspectWithRaw(context.Background(), p.ImageStr)
+	inspectResult, _, err := dockerClient.ImageInspectWithRaw(context.Background(), p.ImageStr)
 
 	if err != nil {
 		if client.IsErrNotFound(err) {
@@ -206,7 +206,7 @@ func (p *DaemonImageProvider) Provide() (*image.Image, error) {
 	}
 
 	// use the existing tarball provider to process what was pulled from the docker daemon
-	return NewProviderFromTarball(tempTarFile.Name()).Provide()
+	return NewProviderFromTarball(tempTarFile.Name(), inspectResult.RepoTags...).Provide()
 }
 
 func newPullOptions(image string, cfg *configfile.ConfigFile) (types.ImagePullOptions, error) {

--- a/pkg/image/image_metadata.go
+++ b/pkg/image/image_metadata.go
@@ -18,6 +18,7 @@ type Metadata struct {
 	Tags           []name.Tag
 	RawManifest    []byte
 	ManifestDigest string
+	RawConfig      []byte
 }
 
 // readImageMetadata extracts the most pertinent information from the underlying image tar.
@@ -37,9 +38,15 @@ func readImageMetadata(img v1.Image) (Metadata, error) {
 		return Metadata{}, err
 	}
 
+	rawConfig, err := img.RawConfigFile()
+	if err != nil {
+		return Metadata{}, err
+	}
+
 	return Metadata{
 		ID:        id.String(),
 		Config:    *config,
 		MediaType: mediaType,
+		RawConfig: rawConfig,
 	}, nil
 }

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -48,7 +48,7 @@ func TestImageAdditionalMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "with digest",
+			name: "with manifest digest",
 			options: []AdditionalMetadata{
 				WithManifestDigest("the-digest"),
 			},
@@ -58,11 +58,25 @@ func TestImageAdditionalMetadata(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with config",
+			options: []AdditionalMetadata{
+				WithConfig([]byte("some bytes")),
+			},
+			image: Image{
+				Metadata: Metadata{
+					RawConfig: []byte("some bytes"),
+					ID:        fmt.Sprintf("sha256:%x", sha256.Sum256([]byte("some bytes"))),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			img, err := NewImage(nil, test.options...)
+			img := NewImage(nil, test.options...)
+
+			err = img.applyOverrideMetadata()
 			if err != nil {
 				t.Fatalf("could not create image: %+v", err)
 			}

--- a/pkg/image/oci/directory_provider.go
+++ b/pkg/image/oci/directory_provider.go
@@ -57,5 +57,5 @@ func (p *DirectoryImageProvider) Provide() (*image.Image, error) {
 		metadata = append(metadata, image.WithManifest(rawManifest))
 	}
 
-	return image.NewImage(img, metadata...)
+	return image.NewImage(img, metadata...), nil
 }


### PR DESCRIPTION
- Adds the `WithConfig` option to attach an image config to the metadata
- Enhances the sourcing of tags from the docker daemon to include `RepoTags` from a `docker inspect` call (API, not CLI) for cases when only the ID or partial ID is given (in which case no tags would be included unless explicitly retrieved from an inspect call).