### PR TITLE
add optional link resolution options to FileTree.HasPath()

### DIFF
--- a/pkg/filetree/filetree.go
+++ b/pkg/filetree/filetree.go
@@ -659,9 +659,9 @@ func (t *FileTree) Equal(other *FileTree) bool {
 	return len(extra) == 0 && len(missing) == 0
 }
 
-// HasPath indicates is the given path is in the file Tree.
-func (t *FileTree) HasPath(path file.Path) bool {
-	exists, _, err := t.File(path, FollowBasenameLinks)
+// HasPath indicates is the given path is in the file Tree (with optional link resolution options).
+func (t *FileTree) HasPath(path file.Path, options ...LinkResolutionOption) bool {
+	exists, _, err := t.File(path, options...)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Since the link resolution PR has changed the semantics of when a file.Reference is expected, there is more link resolution options needed when querying to see if a path exists (the file.Reference is no longer good enough).