### PR TITLE
Add field logger to the logging interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,7 +23,9 @@ func GetImage(userStr string) (*image.Image, error) {
 		return nil, err
 	}
 
-	log.Debugf("image: source=%+v location=%+v", source, imgStr)
+	log.
+		WithFields("source", source, "image", imgStr).
+		Debug("obtaining image")
 
 	switch source {
 	case image.DockerTarballSource:
@@ -62,6 +64,8 @@ func SetBus(b *partybus.Bus) {
 
 func Cleanup() {
 	if err := tempDirGenerator.Cleanup(); err != nil {
-		log.Errorf("failed to cleanup: %w", err)
+		log.
+			WithFields("error", err.Error()).
+			Error("failed to cleanup temp directories")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/Microsoft/hcsshim v0.8.10 // indirect
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
-	github.com/apex/log v1.3.0
 	github.com/bmatcuk/doublestar/v2 v2.0.4
 	github.com/containerd/containerd v1.3.4 // indirect
 	github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,7 +104,6 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ=
-github.com/apex/log v1.3.0 h1:1fyfbPvUwD10nMoh3hY6MXzvZShJQn9/ck7ATgAt5pA=
 github.com/apex/log v1.3.0/go.mod h1:jd8Vpsr46WAe3EZSQ/IUMs2qQD/GOycT5rPWCO1yGcs=
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
@@ -650,7 +649,6 @@ github.com/tetafro/godot v0.3.7/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQx
 github.com/tetafro/godot v0.4.2/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
-github.com/tj/assert v0.0.0-20171129193455-018094318fb0 h1:Rw8kxzWo1mr6FSaYXjQELRe88y2KdfynXdnK72rdjtA=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -28,7 +28,10 @@ func GetClient() (*client.Client, error) {
 		if strings.HasPrefix(host, "ssh") {
 			helper, err := connhelper.GetConnectionHelper(host)
 			if err != nil {
-				log.Errorf("failed to fetch docker connection helper: %w", err)
+				log.
+					WithFields("error", err.Error()).
+					Error("failed to fetch docker connection helper")
+
 				instanceErr = err
 				return
 			}
@@ -47,14 +50,20 @@ func GetClient() (*client.Client, error) {
 		if os.Getenv("DOCKER_TLS_VERIFY") != "" && os.Getenv("DOCKER_CERT_PATH") == "" {
 			err := os.Setenv("DOCKER_CERT_PATH", "~/.docker")
 			if err != nil {
-				log.Errorf("failed create docker client: %w", err)
+				log.
+					WithFields("error", err.Error()).
+					Error("failed create docker client")
+
 				instanceErr = err
 				return
 			}
 		}
 		dockerClient, err := client.NewClientWithOpts(clientOpts...)
 		if err != nil {
-			log.Errorf("failed create docker client: %w", err)
+			log.
+				WithFields("error", err.Error()).
+				Error("failed create docker client")
+
 			instanceErr = err
 			return
 		}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -4,22 +4,42 @@ import "github.com/anchore/stereoscope/pkg/logger"
 
 var Log logger.Logger = &nopLogger{}
 
+// Errorf takes a formatted template string and template arguments for the error logging level.
 func Errorf(format string, args ...interface{}) {
 	Log.Errorf(format, args...)
 }
 
+// Error logs the given arguments at the error logging level.
+func Error(args ...interface{}) {
+	Log.Error(args...)
+}
+
+// Warnf takes a formatted template string and template arguments for the warning logging level.
+func Warnf(format string, args ...interface{}) {
+	Log.Warnf(format, args...)
+}
+
+// Warn logs the given arguments at the warning logging level.
+func Warn(args ...interface{}) {
+	Log.Warn(args...)
+}
+
+// Infof takes a formatted template string and template arguments for the info logging level.
 func Infof(format string, args ...interface{}) {
 	Log.Infof(format, args...)
 }
 
+// Info logs the given arguments at the info logging level.
 func Info(args ...interface{}) {
 	Log.Info(args...)
 }
 
+// Debugf takes a formatted template string and template arguments for the debug logging level.
 func Debugf(format string, args ...interface{}) {
 	Log.Debugf(format, args...)
 }
 
-func Debug(args ...interface{}) {
-	Log.Debug(args...)
+// WithFields returns a message logger with multiple key-value fields.
+func WithFields(fields ...interface{}) logger.MessageLogger {
+	return Log.WithFields(fields...)
 }

--- a/internal/log/nop.go
+++ b/internal/log/nop.go
@@ -1,9 +1,15 @@
 package log
 
+import "github.com/anchore/stereoscope/pkg/logger"
+
 type nopLogger struct{}
 
-func (l *nopLogger) Errorf(format string, args ...interface{}) {}
-func (l *nopLogger) Infof(format string, args ...interface{})  {}
-func (l *nopLogger) Info(args ...interface{})                  {}
-func (l *nopLogger) Debugf(format string, args ...interface{}) {}
-func (l *nopLogger) Debug(args ...interface{})                 {}
+func (l *nopLogger) Errorf(format string, args ...interface{})             {}
+func (l *nopLogger) Error(args ...interface{})                             {}
+func (l *nopLogger) Warnf(format string, args ...interface{})              {}
+func (l *nopLogger) Warn(args ...interface{})                              {}
+func (l *nopLogger) Infof(format string, args ...interface{})              {}
+func (l *nopLogger) Info(args ...interface{})                              {}
+func (l *nopLogger) Debugf(format string, args ...interface{})             {}
+func (l *nopLogger) Debug(args ...interface{})                             {}
+func (l *nopLogger) WithFields(fields ...interface{}) logger.MessageLogger { return l }

--- a/pkg/file/tarutil.go
+++ b/pkg/file/tarutil.go
@@ -148,7 +148,9 @@ func UntarToDirectory(reader io.Reader, dst string) error {
 			}
 
 			if err = f.Close(); err != nil {
-				log.Errorf("failed to close file during untar of path=%q: %w", f.Name(), err)
+				log.
+					WithFields("path", f.Name(), "error", err.Error()).
+					Error("failed to close file during untar")
 			}
 		}
 		return nil

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -84,14 +84,19 @@ func (p *DaemonImageProvider) trackSaveProgress() (*progress.TimedProgress, *pro
 
 // pull a docker image
 func (p *DaemonImageProvider) pull(ctx context.Context) error {
-	log.Debugf("pulling docker image=%q", p.imageStr)
+	log.
+		WithFields("image", p.imageStr).
+		Debug("pulling docker image")
 
 	// note: this will search the default config dir and allow for a DOCKER_CONFIG override
 	cfg, err := config.Load("")
 	if err != nil {
 		return fmt.Errorf("failed to load docker config: %w", err)
 	}
-	log.Debugf("using docker config=%q", cfg.Filename)
+
+	log.
+		WithFields("path", cfg.Filename).
+		Debug("using docker config")
 
 	var status = newPullStatus()
 	defer func() {
@@ -155,9 +160,10 @@ func (p *DaemonImageProvider) Provide() (*image.Image, error) {
 		return nil, fmt.Errorf("unable to create temp file for image: %w", err)
 	}
 	defer func() {
-		err := tempTarFile.Close()
-		if err != nil {
-			log.Errorf("unable to close temp file (%s): %w", tempTarFile.Name(), err)
+		if err := tempTarFile.Close(); err != nil {
+			log.
+				WithFields("path", tempTarFile.Name(), "error", err.Error()).
+				Error("unable to close temp file")
 		}
 	}()
 
@@ -192,9 +198,10 @@ func (p *DaemonImageProvider) Provide() (*image.Image, error) {
 		return nil, fmt.Errorf("unable to save image tar: %w", err)
 	}
 	defer func() {
-		err := readCloser.Close()
-		if err != nil {
-			log.Errorf("unable to close temp file (%s): %w", tempTarFile.Name(), err)
+		if err := readCloser.Close(); err != nil {
+			log.
+				WithFields("path", tempTarFile.Name(), "error", err.Error()).
+				Error("unable to close temp file")
 		}
 	}()
 

--- a/pkg/image/docker/manifest.go
+++ b/pkg/image/docker/manifest.go
@@ -51,9 +51,10 @@ func extractManifest(tarPath string) (*dockerManifest, error) {
 	}
 
 	defer func() {
-		err := f.Close()
-		if err != nil {
-			log.Errorf("unable to close tar file (%s): %w", f.Name(), err)
+		if err := f.Close(); err != nil {
+			log.
+				WithFields("path", f.Name(), "error", err.Error()).
+				Error("unable to close tar file")
 		}
 	}()
 
@@ -77,9 +78,10 @@ func generateOCIManifest(tarPath string, manifest *dockerManifest) (*v1.Manifest
 	}
 
 	defer func() {
-		err := f.Close()
-		if err != nil {
-			log.Errorf("unable to close tar file (%s): %w", f.Name(), err)
+		if err := f.Close(); err != nil {
+			log.
+				WithFields("path", f.Name(), "error", err.Error()).
+				Error("unable to close tar file")
 		}
 	}()
 

--- a/pkg/image/docker/tarball_provider.go
+++ b/pkg/image/docker/tarball_provider.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/internal/log"
 
 	"github.com/anchore/stereoscope/internal"
+	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
-	"github.com/apex/log"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
@@ -52,7 +52,9 @@ func (p *TarballImageProvider) Provide() (*image.Image, error) {
 
 	theManifest, err := extractManifest(p.path)
 	if err != nil {
-		log.Warnf("could not extract manifest: %+v", err)
+		log.
+			WithFields("error", err.Error()).
+			Warn("could not extract manifest")
 	}
 
 	var tags = internal.NewStringSet()
@@ -69,7 +71,9 @@ func (p *TarballImageProvider) Provide() (*image.Image, error) {
 
 		ociManifest, rawConfig, err = generateOCIManifest(p.path, theManifest)
 		if err != nil {
-			log.Warnf("failed to generate OCI manifest from docker archive: %+v", err)
+			log.
+				WithFields("error", err.Error()).
+				Warn("failed to generate OCI manifest from docker archive")
 		}
 
 		// we may have the config available, use it
@@ -81,7 +85,9 @@ func (p *TarballImageProvider) Provide() (*image.Image, error) {
 	if ociManifest != nil {
 		rawOCIManifest, err = json.Marshal(&ociManifest)
 		if err != nil {
-			log.Warnf("failed to serialize OCI manifest: %+v", err)
+			log.
+				WithFields("error", err.Error()).
+				Warn("failed to serialize OCI manifest")
 		} else {
 			metadata = append(metadata, image.WithManifest(rawOCIManifest))
 		}

--- a/pkg/image/file_catalog_test.go
+++ b/pkg/image/file_catalog_test.go
@@ -54,7 +54,7 @@ func getTarFixture(t *testing.T, name string) (*os.File, func()) {
 
 		err = cmd.Run()
 		if err != nil {
-			panic(err)
+			t.Fatalf("could not run command: %+v", err)
 		}
 	}
 

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -142,10 +142,9 @@ func (i *Image) Read() error {
 		return err
 	}
 
-	log.Debugf("image metadata: digest=%+v mediaType=%+v tags=%+v",
-		i.Metadata.ID,
-		i.Metadata.MediaType,
-		i.Metadata.Tags)
+	log.
+		WithFields("id", i.Metadata.ID, "mediaType", i.Metadata.MediaType, "tags", i.Metadata.Tags).
+		Debug("image metadata")
 
 	v1Layers, err := i.image.Layers()
 	if err != nil {

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -80,10 +80,9 @@ func (l *Layer) Read(catalog *FileCatalog, imgMetadata Metadata, idx int, uncomp
 		return err
 	}
 
-	log.Debugf("layer metadata: index=%+v digest=%+v mediaType=%+v",
-		l.Metadata.Index,
-		l.Metadata.Digest,
-		l.Metadata.MediaType)
+	log.
+		WithFields("index", l.Metadata.Index, "digest", l.Metadata.Digest, "mediaType", l.Metadata.MediaType).
+		Debug("layer metadata")
 
 	monitor := trackReadProgress(l.Metadata)
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,7 +1,19 @@
 package logger
 
 type Logger interface {
+	MessageLogger
+	FieldLogger
+}
+
+type FieldLogger interface {
+	WithFields(fields ...interface{}) MessageLogger
+}
+
+type MessageLogger interface {
 	Errorf(format string, args ...interface{})
+	Error(args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warn(args ...interface{})
 	Infof(format string, args ...interface{})
 	Info(args ...interface{})
 	Debugf(format string, args ...interface{})


### PR DESCRIPTION
There are several instances of key-value parameters that are captured into the log message. Since syft and grype support structured logging it would be ideal to capture these values outside of the log message. Additionally, when kept separate these fields can be individually formatted when using standard logging.

Additionally found and removed an instance of apex/log.