### PR TITLE
Ensure that credentials are not HTML encoded

### DIFF
--- a/pkg/image/docker/daemon_provoder_test.go
+++ b/pkg/image/docker/daemon_provoder_test.go
@@ -1,0 +1,22 @@
+package docker
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEncodeCredentials(t *testing.T) {
+	// regression test for https://github.com/anchore/grype/issues/254
+	// the JSON encoded credentials should NOT escape characters
+
+	user, pass := "dockerusertest", "WL[cC-<sN#K(zk~NVspmw.PL)3K?v"
+	// encoded string: expected := base64encode(`{"password":"WL[cC-<sN#K(zk~NVspmw.PL)3K?v","username":"dockerusertest"}\n`)
+	// where the problem character is the "<" within the password, which should NOT be encoded to \u003c
+	expected := "eyJwYXNzd29yZCI6IldMW2NDLTxzTiNLKHprfk5Wc3Btdy5QTCkzSz92IiwidXNlcm5hbWUiOiJkb2NrZXJ1c2VydGVzdCJ9Cg=="
+	actual, err := encodeCredentials(user, pass)
+	if err != nil {
+		t.Fatalf("unable to encode credentials: %+v", err)
+	}
+
+	assert.Equal(t, expected, actual, "unexpected output")
+}


### PR DESCRIPTION
Today when setting docker pull options we are responsible for base64 encoding the `RegistryAuth` JSON, which is an object containing username and password. Before base64 encoding we are not making certain that the JSON marshaling will not escape specific characters typical to HTML documents. This PR swaps out the JSON unmarshal with a JSON encoder with HTML escaping turned off.

Related to https://github.com/anchore/grype/issues/254