### PR TITLE
Add registry image source

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,7 +31,7 @@ func GetImageFromSource(imgStr string, source image.Source, registryOptions *ima
 	case image.OciTarballSource:
 		provider = oci.NewProviderFromTarball(imgStr, &tempDirGenerator)
 	case image.OciRegistrySource:
-		provider = oci.NewProviderFromRegistry(imgStr, &tempDirGenerator, registryOptions)
+		provider = oci.NewRegistryImageProvider(imgStr, &tempDirGenerator, registryOptions)
 	default:
 		return nil, fmt.Errorf("unable determine image source")
 	}

--- a/client.go
+++ b/client.go
@@ -15,14 +15,9 @@ import (
 
 var tempDirGenerator = file.NewTempDirGenerator()
 
-// GetImage parses the user provided image string and provides an image object
-func GetImage(userStr string) (*image.Image, error) {
+// GetImage returns an image from the explicitly provided source.
+func GetImageFromSource(imgStr string, source image.Source, registryOptions *image.RegistryOptions) (*image.Image, error) {
 	var provider image.Provider
-	source, imgStr, err := image.DetectSource(userStr)
-	if err != nil {
-		return nil, err
-	}
-
 	log.Debugf("image: source=%+v location=%+v", source, imgStr)
 
 	switch source {
@@ -35,6 +30,8 @@ func GetImage(userStr string) (*image.Image, error) {
 		provider = oci.NewProviderFromPath(imgStr, &tempDirGenerator)
 	case image.OciTarballSource:
 		provider = oci.NewProviderFromTarball(imgStr, &tempDirGenerator)
+	case image.OciRegistrySource:
+		provider = oci.NewProviderFromRegistry(imgStr, &tempDirGenerator, registryOptions)
 	default:
 		return nil, fmt.Errorf("unable determine image source")
 	}
@@ -50,6 +47,16 @@ func GetImage(userStr string) (*image.Image, error) {
 	}
 
 	return img, nil
+}
+
+// GetImage parses the user provided image string and provides an image object; note: the source where the image should
+// be referenced from is automatically inferred.
+func GetImage(userStr string, registryOptions *image.RegistryOptions) (*image.Image, error) {
+	source, imgStr, err := image.DetectSource(userStr)
+	if err != nil {
+		return nil, err
+	}
+	return GetImageFromSource(imgStr, source, registryOptions)
 }
 
 func SetLogger(logger logger.Logger) {

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -19,7 +19,7 @@ func main() {
 	//    ./path/to.tar
 	//
 	// This will catalog the file metadata and resolve all squash trees
-	image, err := stereoscope.GetImage(os.Args[1])
+	image, err := stereoscope.GetImage(os.Args[1], nil)
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/scylladb/go-set v1.0.2
 	github.com/sergi/go-diff v1.1.0
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
+github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
 github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -586,6 +588,8 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
+github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
+github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/securego/gosec v0.0.0-20200103095621-79fbf3af8d83/go.mod h1:vvbZ2Ae7AzSq3/kywjUDxSNq2SJ27RxCz2un0H3ePqE=
 github.com/securego/gosec v0.0.0-20200401082031-e946c8c39989/go.mod h1:i9l/TNj+yDFh9SZXUTvspXTjbFXgZGP/UvhU1S65A4A=

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -1,0 +1,92 @@
+package oci
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	"github.com/anchore/stereoscope/internal/log"
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// RegistryImageProvider is a image.Provider capable of fetching and representing a container image fetched from a remote registry (described by the OCI distribution spec).
+type RegistryImageProvider struct {
+	imageStr        string
+	tmpDirGen       *file.TempDirGenerator
+	registryOptions *image.RegistryOptions
+}
+
+// NewProviderFromRegistry creates a new provider instance for a specific image that will later be cached to the given directory.
+func NewProviderFromRegistry(imgStr string, tmpDirGen *file.TempDirGenerator, registryOptions *image.RegistryOptions) *RegistryImageProvider {
+	return &RegistryImageProvider{
+		imageStr:        imgStr,
+		tmpDirGen:       tmpDirGen,
+		registryOptions: registryOptions,
+	}
+}
+
+// Provide an image object that represents the cached docker image tar fetched a registry.
+func (p *RegistryImageProvider) Provide() (*image.Image, error) {
+	log.Debugf("pulling image info directly from registry image=%q", p.imageStr)
+
+	imageTempDir, err := p.tmpDirGen.NewTempDir()
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := name.ParseReference(p.imageStr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse registry reference=%q: %+v", p.imageStr, err)
+	}
+
+	img, err := remote.Image(ref, prepareRemoteOptions(ref, p.registryOptions)...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create image from registry: %+v", err)
+	}
+
+	return image.NewImage(img, imageTempDir), nil
+}
+
+func prepareRemoteOptions(ref name.Reference, registryOptions *image.RegistryOptions) []remote.Option {
+	var opts []remote.Option
+	if registryOptions.InsecureSkipTLSVerify {
+		t := &http.Transport{
+			// nolint: gosec
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		opts = append(opts, remote.WithTransport(t))
+	}
+	registry := ref.Context().RegistryStr()
+	discoveredConfiguredAuth := false
+	for idx, auth := range registryOptions.Auth {
+		if auth.Authority == registry {
+			if auth.Username != "" && auth.Password != "" {
+				log.Debugf("using registry credentials for %q (config idx=%d)", auth.Authority, idx)
+				opts = append(opts, remote.WithAuth(&authn.Basic{
+					Username: auth.Username,
+					Password: auth.Password,
+				}))
+				discoveredConfiguredAuth = true
+				break
+			} else if auth.Token != "" {
+				log.Debugf("using registry token for %q (config idx=%d)", auth.Authority, idx)
+				opts = append(opts, remote.WithAuth(&authn.Bearer{
+					Token: auth.Token,
+				}))
+				discoveredConfiguredAuth = true
+				break
+			}
+		}
+	}
+
+	if !discoveredConfiguredAuth {
+		// use the Keychain specified from a docker config file.
+		log.Debugf("using registry credentials from default keychain")
+		opts = append(opts, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	}
+	return opts
+}

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -68,7 +68,7 @@ func prepareRemoteOptions(ref name.Reference, registryOptions *image.RegistryOpt
 		opts = append(opts, remote.WithAuth(authenticator))
 	} else {
 		// use the Keychain specified from a docker config file.
-		log.Debugf("using registry credentials from default keychain")
+		log.Debugf("no registry credentials configured, using the default keychain")
 		opts = append(opts, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	}
 

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -62,7 +62,7 @@ func prepareRemoteOptions(ref name.Reference, registryOptions *image.RegistryOpt
 	}
 	registry := ref.Context().RegistryStr()
 	discoveredConfiguredAuth := false
-	for idx, auth := range registryOptions.Auth {
+	for idx, auth := range registryOptions.Credentials {
 		if auth.Authority == registry {
 			if auth.Username != "" && auth.Password != "" {
 				log.Debugf("using registry credentials for %q (config idx=%d)", auth.Authority, idx)

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -20,8 +20,8 @@ type RegistryImageProvider struct {
 	registryOptions *image.RegistryOptions
 }
 
-// NewProviderFromRegistry creates a new provider instance for a specific image that will later be cached to the given directory.
-func NewProviderFromRegistry(imgStr string, tmpDirGen *file.TempDirGenerator, registryOptions *image.RegistryOptions) *RegistryImageProvider {
+// NewRegistryImageProvider creates a new provider instance for a specific image that will later be cached to the given directory.
+func NewRegistryImageProvider(imgStr string, tmpDirGen *file.TempDirGenerator, registryOptions *image.RegistryOptions) *RegistryImageProvider {
 	return &RegistryImageProvider{
 		imageStr:        imgStr,
 		tmpDirGen:       tmpDirGen,

--- a/pkg/image/registry_options.go
+++ b/pkg/image/registry_options.go
@@ -3,7 +3,7 @@ package image
 // RegistryOptions for the OCI registry provider.
 type RegistryOptions struct {
 	InsecureSkipTLSVerify bool
-	Auth                  []RegistryCredentials
+	Credentials           []RegistryCredentials
 }
 
 // RegistryCredentials contains any information necessary to authenticate against an OCI-distribution-compliant

--- a/pkg/image/registry_options.go
+++ b/pkg/image/registry_options.go
@@ -24,18 +24,19 @@ type RegistryCredentials struct {
 // given registry, or there is partial information configured, then nil is returned.
 func (r *RegistryOptions) Authenticator(registry string) authn.Authenticator {
 	for idx, auth := range r.Credentials {
-		if auth.Authority == registry {
-			if auth.Username != "" && auth.Password != "" {
-				log.Debugf("using registry credentials for %q (config idx=%d)", auth.Authority, idx)
-				return &authn.Basic{
-					Username: auth.Username,
-					Password: auth.Password,
-				}
-			} else if auth.Token != "" {
-				log.Debugf("using registry token for %q (config idx=%d)", auth.Authority, idx)
-				return &authn.Bearer{
-					Token: auth.Token,
-				}
+		if auth.Authority != registry {
+			continue
+		}
+		if auth.Username != "" && auth.Password != "" {
+			log.Debugf("using registry credentials for %q (config idx=%d)", auth.Authority, idx)
+			return &authn.Basic{
+				Username: auth.Username,
+				Password: auth.Password,
+			}
+		} else if auth.Token != "" {
+			log.Debugf("using registry token for %q (config idx=%d)", auth.Authority, idx)
+			return &authn.Bearer{
+				Token: auth.Token,
 			}
 		}
 	}

--- a/pkg/image/registry_options.go
+++ b/pkg/image/registry_options.go
@@ -1,0 +1,16 @@
+package image
+
+// RegistryOptions for the OCI registry provider.
+type RegistryOptions struct {
+	InsecureSkipTLSVerify bool
+	Auth                  []RegistryCredentials
+}
+
+// RegistryCredentials contains any information necessary to authenticate against an OCI-distribution-compliant
+// registry (either with basic auth or bearer token). Note: only valid for the OCI registry provider.
+type RegistryCredentials struct {
+	Authority string
+	Username  string
+	Password  string
+	Token     string
+}

--- a/pkg/image/registry_options.go
+++ b/pkg/image/registry_options.go
@@ -1,5 +1,10 @@
 package image
 
+import (
+	"github.com/anchore/stereoscope/internal/log"
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
 // RegistryOptions for the OCI registry provider.
 type RegistryOptions struct {
 	InsecureSkipTLSVerify bool
@@ -13,4 +18,27 @@ type RegistryCredentials struct {
 	Username  string
 	Password  string
 	Token     string
+}
+
+// Authenticator returns an object capable of authenticating against the given registry. If no credentials match the
+// given registry, or there is partial information configured, then nil is returned.
+func (r *RegistryOptions) Authenticator(registry string) authn.Authenticator {
+	for idx, auth := range r.Credentials {
+		if auth.Authority == registry {
+			if auth.Username != "" && auth.Password != "" {
+				log.Debugf("using registry credentials for %q (config idx=%d)", auth.Authority, idx)
+				return &authn.Basic{
+					Username: auth.Username,
+					Password: auth.Password,
+				}
+			} else if auth.Token != "" {
+				log.Debugf("using registry token for %q (config idx=%d)", auth.Authority, idx)
+				return &authn.Bearer{
+					Token: auth.Token,
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/image/registry_options_test.go
+++ b/pkg/image/registry_options_test.go
@@ -187,6 +187,31 @@ func TestRegistryOptions_Authenticator_Bearer(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name:     "mismatched registry",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{
+						Authority: "localhost",
+						Token:     "JRR",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:     "missing registry",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{
+						Token: "JRR",
+					},
+				},
+			},
+			expected: nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/image/registry_options_test.go
+++ b/pkg/image/registry_options_test.go
@@ -1,0 +1,206 @@
+package image
+
+import (
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRegistryOptions_Authenticator_Basic(t *testing.T) {
+	tests := []struct {
+		name     string
+		registry string
+		input    *RegistryOptions
+		expected *authn.Basic
+	}{
+		{
+			name:     "require user pass success",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{
+						Authority: "localhost:5000",
+						Username:  "username",
+						Password:  "tOpsYKrets",
+					},
+				},
+			},
+			expected: &authn.Basic{
+				Username: "username",
+				Password: "tOpsYKrets",
+			},
+		},
+		{
+			name:     "mismatched registry",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{
+						Authority: "localhost",
+						Username:  "username",
+						Password:  "tOpsYKrets",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:     "no password",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{
+						Authority: "localhost:5000",
+						Username:  "username",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:     "no username",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{
+						Authority: "localhost:5000",
+						Password:  "awesome-sauce",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:     "no username or password",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{
+						Authority: "localhost:5000",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:     "empty struct",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:     "multiple matches",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{
+						Authority: "localhost:5000",
+						Username:  "username",
+						Password:  "tOpsYKrets",
+					},
+					{
+						Authority: "localhost:5000",
+						Username:  "SOMETHING ELSE",
+						Password:  "BLERG",
+					},
+				},
+			},
+			expected: &authn.Basic{
+				Username: "username",
+				Password: "tOpsYKrets",
+			},
+		},
+		{
+			name:     "basic auth over bearer",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{
+						Authority: "localhost:5000",
+						Username:  "username",
+						Password:  "tOpsYKrets",
+					},
+					{
+						Authority: "localhost:5000",
+						Token:     "BLERG",
+					},
+				},
+			},
+			expected: &authn.Basic{
+				Username: "username",
+				Password: "tOpsYKrets",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualAuth := test.input.Authenticator(test.registry)
+			if test.expected == nil && actualAuth == nil {
+				// pass
+				return
+			}
+			actual, ok := actualAuth.(*authn.Basic)
+			if !ok {
+				t.Fatalf("unable to get basic auth obj: %+v", actualAuth)
+			}
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestRegistryOptions_Authenticator_Bearer(t *testing.T) {
+	tests := []struct {
+		name     string
+		registry string
+		input    *RegistryOptions
+		expected *authn.Bearer
+	}{
+		{
+			name:     "require bearer token success",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{
+						Authority: "localhost:5000",
+						Token:     "JRR",
+					},
+				},
+			},
+			expected: &authn.Bearer{
+				Token: "JRR",
+			},
+		},
+		{
+			name:     "missing bearer token",
+			registry: "localhost:5000",
+			input: &RegistryOptions{
+				Credentials: []RegistryCredentials{
+					{
+						Authority: "localhost:5000",
+					},
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualAuth := test.input.Authenticator(test.registry)
+			if test.expected == nil && actualAuth == nil {
+				// pass
+				return
+			}
+			actual, ok := actualAuth.(*authn.Bearer)
+			if !ok {
+				t.Fatalf("unable to get bearer obj: %+v", actualAuth)
+			}
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/pkg/image/source.go
+++ b/pkg/image/source.go
@@ -118,7 +118,7 @@ func detectSource(fs afero.Fs, userInput string) (Source, string, error) {
 			// verify that the docker daemon is accessible before assuming we can suggest to use it
 			dockerClient, err := docker.GetClient()
 			if err == nil {
-				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 				pong, err := dockerClient.Ping(ctx)
 				if err == nil && pong.APIVersion != "" {

--- a/pkg/imagetest/image_fixtures.go
+++ b/pkg/imagetest/image_fixtures.go
@@ -54,7 +54,7 @@ func PrepareFixtureImage(t testing.TB, source, name string) string {
 func GetFixtureImage(t testing.TB, source, name string) *image.Image {
 	request := PrepareFixtureImage(t, source, name)
 
-	i, err := stereoscope.GetImage(request)
+	i, err := stereoscope.GetImage(request, nil)
 	if err != nil {
 		t.Fatal("could not get tar image:", err)
 	}
@@ -105,7 +105,7 @@ func skopeoCopyDockerArchiveToPath(t testing.TB, dockerArchivePath, destination 
 func getFixtureImageFromTar(t testing.TB, tarPath string) *image.Image {
 	request := fmt.Sprintf("docker-archive:%s", tarPath)
 
-	i, err := stereoscope.GetImage(request)
+	i, err := stereoscope.GetImage(request, nil)
 	if err != nil {
 		t.Fatal("could not get tar image:", err)
 	}

--- a/test/integration/fixture_image_symlinks_test.go
+++ b/test/integration/fixture_image_symlinks_test.go
@@ -2,13 +2,14 @@ package integration
 
 import (
 	"fmt"
-	"github.com/anchore/stereoscope/pkg/filetree"
 	"io/ioutil"
 	"testing"
 
 	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/stereoscope/pkg/imagetest"
+	"github.com/scylladb/go-set"
 )
 
 type linkFetchConfig struct {
@@ -43,6 +44,13 @@ func TestImageSymlinks(t *testing.T) {
 			source: "oci-dir",
 		},
 	}
+
+	expectedSet := set.NewIntSet()
+	for _, src := range image.AllSources {
+		expectedSet.Add(int(src))
+	}
+	expectedSet.Remove(int(image.OciRegistrySource))
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			i := imagetest.GetFixtureImage(t, c.source, "image-symlinks")
@@ -50,7 +58,7 @@ func TestImageSymlinks(t *testing.T) {
 		})
 	}
 
-	if len(cases) < len(image.AllSources) {
+	if len(cases) < expectedSet.Size() {
 		t.Fatalf("probably missed a source during testing, double check that all image.sources are covered")
 	}
 


### PR DESCRIPTION
Adds the `oci-registry` / `registry` image source, enabling the ability to pull images directly from a registry (not through the docker daemon). This brings with it the requirement to provide credentials in the form of username/password or token.

What this PR does _**NOT**_ bring in yet it credential helpers for common registries (see #65 ):
 - ECR (via https://github.com/awslabs/amazon-ecr-credential-helper)
 - GCR (via https://github.com/GoogleCloudPlatform/docker-credential-gcr)
 - ACR (via https://github.com/Azure/acr-docker-credential-helper)

Addresses https://github.com/anchore/grype/issues/264