### PR TITLE
Add repo digest and raw manifest to registry source

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,7 +31,7 @@ func GetImageFromSource(imgStr string, source image.Source, registryOptions *ima
 	case image.OciTarballSource:
 		provider = oci.NewProviderFromTarball(imgStr, &tempDirGenerator)
 	case image.OciRegistrySource:
-		provider = oci.NewRegistryImageProvider(imgStr, &tempDirGenerator, registryOptions)
+		provider = oci.NewProviderFromRegistry(imgStr, &tempDirGenerator, registryOptions)
 	default:
 		return nil, fmt.Errorf("unable determine image source")
 	}

--- a/test/integration/oci_registry_source_test.go
+++ b/test/integration/oci_registry_source_test.go
@@ -1,0 +1,43 @@
+package integration
+
+import (
+	"fmt"
+	"github.com/anchore/stereoscope"
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOciRegistrySourceMetadata(t *testing.T) {
+	rawManifest := `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "config": {
+      "mediaType": "application/vnd.docker.container.image.v1+json",
+      "size": 1509,
+      "digest": "sha256:a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e"
+   },
+   "layers": [
+      {
+         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+         "size": 2797541,
+         "digest": "sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c"
+      }
+   ]
+}`
+	digest := "sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65"
+	imgStr := "anchore/test_images"
+	ref := fmt.Sprintf("%s@%s", imgStr, digest)
+
+	img, err := stereoscope.GetImage("registry:"+ref, &image.RegistryOptions{})
+	if err != nil {
+		t.Fatalf("unable to get image: %+v", err)
+	}
+	if err := img.Read(); err != nil {
+		t.Fatalf("failed to read image: %+v", err)
+	}
+
+	assert.Len(t, img.Metadata.RepoDigests, 1)
+	assert.Equal(t, "index.docker.io/"+ref, img.Metadata.RepoDigests[0])
+	assert.Equal(t, []byte(rawManifest), img.Metadata.RawManifest)
+}


### PR DESCRIPTION
- adds the repo digest + raw manifest as optional metadata for images fetched from a registry
- adds an integration test to cover testing registry metadata (repo digest + raw manifest). Note: this references an image from the `anchore/test_images` repository.
- note: I've renamed `oci.NewRegistryImageProvider` back to `oci.NewProviderFromRegistry` to be consistent with the package-oriented convention throughout this repo.