### PR TITLE
Allow for empty authority value and refactor

### DIFF
--- a/pkg/image/registry_credentials.go
+++ b/pkg/image/registry_credentials.go
@@ -1,0 +1,53 @@
+package image
+
+import (
+	"github.com/anchore/stereoscope/internal/log"
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+// RegistryCredentials contains any information necessary to authenticate against an OCI-distribution-compliant
+// registry (either with basic auth or bearer token). Note: only valid for the OCI registry provider.
+type RegistryCredentials struct {
+	Authority string
+	Username  string
+	Password  string
+	Token     string
+}
+
+// authenticator returns an authn.Authenticator for the given credentials.
+// Authentication methods are attempted in the following order until a viable method is found: (1) basic auth,
+// (2) bearer token. If no viable authentication method is found, authenticator returns nil.
+func (c RegistryCredentials) authenticator() authn.Authenticator {
+	if c.Username != "" && c.Password != "" {
+		log.Debugf("using basic auth for registry %q", c.Authority)
+		return &authn.Basic{
+			Username: c.Username,
+			Password: c.Password,
+		}
+	}
+
+	if c.Token != "" {
+		log.Debugf("using token for registry %q", c.Authority)
+		return &authn.Bearer{
+			Token: c.Token,
+		}
+	}
+
+	return nil
+}
+
+// canBeUsedWithRegistry returns a bool indicating if these credentials should be used when accessing the given registry.
+func (c RegistryCredentials) canBeUsedWithRegistry(registry string) bool {
+	if !c.hasAuthoritySpecified() {
+		return true
+	}
+
+	return registry == c.Authority
+}
+
+// hasAuthoritySpecified returns a bool indicating if there is a specified "authority" value,
+// meaning that the user has requested these credentials to be used for retrieving only the images whose registry
+// matches this "authority" value.
+func (c RegistryCredentials) hasAuthoritySpecified() bool {
+	return c.Authority != ""
+}

--- a/pkg/image/registry_credentials_test.go
+++ b/pkg/image/registry_credentials_test.go
@@ -83,23 +83,31 @@ func TestRegistryCredentials_Authenticator(t *testing.T) {
 
 func basicAuth(expected authn.Basic) func(*testing.T, authn.Authenticator) {
 	return func(t *testing.T, actual authn.Authenticator) {
+		t.Helper()
+
 		assertBasicAuth(t, expected, actual)
 	}
 }
 
 func bearerToken(expected authn.Bearer) func(*testing.T, authn.Authenticator) {
 	return func(t *testing.T, actual authn.Authenticator) {
+		t.Helper()
+
 		assertBearerToken(t, expected, actual)
 	}
 }
 
 func nilAuthenticator() func(*testing.T, authn.Authenticator) {
 	return func(t *testing.T, actual authn.Authenticator) {
+		t.Helper()
+
 		assert.Nil(t, actual)
 	}
 }
 
 func assertBasicAuth(t *testing.T, expected authn.Basic, actual authn.Authenticator) {
+	t.Helper()
+
 	actualBasic, ok := actual.(*authn.Basic)
 	if !ok {
 		t.Fatalf("unable to get basicAuth object: %+v", actual)
@@ -109,6 +117,8 @@ func assertBasicAuth(t *testing.T, expected authn.Basic, actual authn.Authentica
 }
 
 func assertBearerToken(t *testing.T, expected authn.Bearer, actual authn.Authenticator) {
+	t.Helper()
+
 	actualBearer, ok := actual.(*authn.Bearer)
 	if !ok {
 		t.Fatalf("unable to get bearer object: %+v", actual)

--- a/pkg/image/registry_credentials_test.go
+++ b/pkg/image/registry_credentials_test.go
@@ -1,0 +1,118 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+func TestRegistryCredentials_Authenticator(t *testing.T) {
+	const exampleUsername = "some-example-username"
+	const examplePassword = "some-example-password"
+	const exampleToken = "some-example-token"
+
+	tests := []struct {
+		name                   string
+		credentials            RegistryCredentials
+		authenticatorAssertion func(t *testing.T, actual authn.Authenticator)
+	}{
+		{
+			name: "basic auth",
+			credentials: RegistryCredentials{
+				Username: exampleUsername,
+				Password: examplePassword,
+			},
+			authenticatorAssertion: basicAuth(authn.Basic{
+				Username: exampleUsername,
+				Password: examplePassword,
+			}),
+		},
+		{
+			name: "basic auth without username",
+			credentials: RegistryCredentials{
+				Username: "",
+				Password: examplePassword,
+			},
+			authenticatorAssertion: nilAuthenticator(),
+		},
+		{
+			name: "basic auth without password",
+			credentials: RegistryCredentials{
+				Username: exampleUsername,
+				Password: "",
+			},
+			authenticatorAssertion: nilAuthenticator(),
+		},
+		{
+			name: "bearer token",
+			credentials: RegistryCredentials{
+				Token: exampleToken,
+			},
+			authenticatorAssertion: bearerToken(authn.Bearer{
+				Token: exampleToken,
+			}),
+		},
+		{
+			name: "basic auth preferred over bearer token",
+			credentials: RegistryCredentials{
+				Username: exampleUsername,
+				Password: examplePassword,
+				Token:    exampleToken,
+			},
+			authenticatorAssertion: basicAuth(authn.Basic{
+				Username: exampleUsername,
+				Password: examplePassword,
+			}),
+		},
+		{
+			name:                   "no values provided",
+			credentials:            RegistryCredentials{},
+			authenticatorAssertion: nilAuthenticator(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.credentials.authenticator()
+			test.authenticatorAssertion(t, actual)
+		})
+	}
+}
+
+func basicAuth(expected authn.Basic) func(*testing.T, authn.Authenticator) {
+	return func(t *testing.T, actual authn.Authenticator) {
+		assertBasicAuth(t, expected, actual)
+	}
+}
+
+func bearerToken(expected authn.Bearer) func(*testing.T, authn.Authenticator) {
+	return func(t *testing.T, actual authn.Authenticator) {
+		assertBearerToken(t, expected, actual)
+	}
+}
+
+func nilAuthenticator() func(*testing.T, authn.Authenticator) {
+	return func(t *testing.T, actual authn.Authenticator) {
+		assert.Nil(t, actual)
+	}
+}
+
+func assertBasicAuth(t *testing.T, expected authn.Basic, actual authn.Authenticator) {
+	actualBasic, ok := actual.(*authn.Basic)
+	if !ok {
+		t.Fatalf("unable to get basicAuth object: %+v", actual)
+	}
+
+	assert.Equal(t, expected, *actualBasic)
+}
+
+func assertBearerToken(t *testing.T, expected authn.Bearer, actual authn.Authenticator) {
+	actualBearer, ok := actual.(*authn.Bearer)
+	if !ok {
+		t.Fatalf("unable to get bearer object: %+v", actual)
+	}
+
+	assert.Equal(t, expected, *actualBearer)
+}

--- a/pkg/image/registry_options.go
+++ b/pkg/image/registry_options.go
@@ -11,34 +11,21 @@ type RegistryOptions struct {
 	Credentials           []RegistryCredentials
 }
 
-// RegistryCredentials contains any information necessary to authenticate against an OCI-distribution-compliant
-// registry (either with basic auth or bearer token). Note: only valid for the OCI registry provider.
-type RegistryCredentials struct {
-	Authority string
-	Username  string
-	Password  string
-	Token     string
-}
-
 // Authenticator returns an object capable of authenticating against the given registry. If no credentials match the
 // given registry, or there is partial information configured, then nil is returned.
-func (r *RegistryOptions) Authenticator(registry string) authn.Authenticator {
-	for idx, auth := range r.Credentials {
-		if auth.Authority != registry {
+func (r RegistryOptions) Authenticator(registry string) authn.Authenticator {
+	for idx, credentials := range r.Credentials {
+		if !credentials.canBeUsedWithRegistry(registry) {
 			continue
 		}
-		if auth.Username != "" && auth.Password != "" {
-			log.Debugf("using registry credentials for %q (config idx=%d)", auth.Authority, idx)
-			return &authn.Basic{
-				Username: auth.Username,
-				Password: auth.Password,
-			}
-		} else if auth.Token != "" {
-			log.Debugf("using registry token for %q (config idx=%d)", auth.Authority, idx)
-			return &authn.Bearer{
-				Token: auth.Token,
-			}
+
+		authenticator := credentials.authenticator()
+		if authenticator == nil {
+			continue
 		}
+
+		log.Debugf("using registry credentials from config index %d", idx)
+		return authenticator
 	}
 
 	return nil

--- a/pkg/image/registry_options_test.go
+++ b/pkg/image/registry_options_test.go
@@ -1,22 +1,22 @@
 package image
 
 import (
-	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
 )
 
-func TestRegistryOptions_Authenticator_Basic(t *testing.T) {
+func TestRegistryOptions_Authenticator(t *testing.T) {
 	tests := []struct {
-		name     string
-		registry string
-		input    *RegistryOptions
-		expected *authn.Basic
+		name                   string
+		registry               string
+		input                  RegistryOptions
+		authenticatorAssertion func(t *testing.T, actual authn.Authenticator)
 	}{
 		{
-			name:     "require user pass success",
+			name:     "basicAuth credentials match registry",
 			registry: "localhost:5000",
-			input: &RegistryOptions{
+			input: RegistryOptions{
 				Credentials: []RegistryCredentials{
 					{
 						Authority: "localhost:5000",
@@ -25,15 +25,15 @@ func TestRegistryOptions_Authenticator_Basic(t *testing.T) {
 					},
 				},
 			},
-			expected: &authn.Basic{
+			authenticatorAssertion: basicAuth(authn.Basic{
 				Username: "username",
 				Password: "tOpsYKrets",
-			},
+			}),
 		},
 		{
-			name:     "mismatched registry",
+			name:     "basicAuth credentials don't match registry",
 			registry: "localhost:5000",
-			input: &RegistryOptions{
+			input: RegistryOptions{
 				Credentials: []RegistryCredentials{
 					{
 						Authority: "localhost",
@@ -42,60 +42,42 @@ func TestRegistryOptions_Authenticator_Basic(t *testing.T) {
 					},
 				},
 			},
-			expected: nil,
+			authenticatorAssertion: nilAuthenticator(),
 		},
 		{
-			name:     "no password",
+			name:     "authority with missing credentials",
 			registry: "localhost:5000",
-			input: &RegistryOptions{
-				Credentials: []RegistryCredentials{
-					{
-						Authority: "localhost:5000",
-						Username:  "username",
-					},
-				},
-			},
-			expected: nil,
-		},
-		{
-			name:     "no username",
-			registry: "localhost:5000",
-			input: &RegistryOptions{
-				Credentials: []RegistryCredentials{
-					{
-						Authority: "localhost:5000",
-						Password:  "awesome-sauce",
-					},
-				},
-			},
-			expected: nil,
-		},
-		{
-			name:     "no username or password",
-			registry: "localhost:5000",
-			input: &RegistryOptions{
+			input: RegistryOptions{
 				Credentials: []RegistryCredentials{
 					{
 						Authority: "localhost:5000",
 					},
 				},
 			},
-			expected: nil,
+			authenticatorAssertion: nilAuthenticator(),
 		},
 		{
 			name:     "empty struct",
 			registry: "localhost:5000",
-			input: &RegistryOptions{
+			input: RegistryOptions{
 				Credentials: []RegistryCredentials{
 					{},
 				},
 			},
-			expected: nil,
+			authenticatorAssertion: nilAuthenticator(),
 		},
 		{
-			name:     "multiple matches",
+			name:     "empty credentials slice",
 			registry: "localhost:5000",
-			input: &RegistryOptions{
+			input: RegistryOptions{
+				Credentials: []RegistryCredentials{},
+			},
+			authenticatorAssertion: nilAuthenticator(),
+		},
+		{
+			name:     "given multiple matches, select first match",
+			registry: "localhost:5000",
+			input: RegistryOptions{
 				Credentials: []RegistryCredentials{
 					{
 						Authority: "localhost:5000",
@@ -109,61 +91,31 @@ func TestRegistryOptions_Authenticator_Basic(t *testing.T) {
 					},
 				},
 			},
-			expected: &authn.Basic{
+			authenticatorAssertion: basicAuth(authn.Basic{
 				Username: "username",
 				Password: "tOpsYKrets",
-			},
+			}),
 		},
 		{
-			name:     "basic auth over bearer",
+			name:     "basic auth without authority",
 			registry: "localhost:5000",
-			input: &RegistryOptions{
+			input: RegistryOptions{
 				Credentials: []RegistryCredentials{
 					{
-						Authority: "localhost:5000",
-						Username:  "username",
-						Password:  "tOpsYKrets",
-					},
-					{
-						Authority: "localhost:5000",
-						Token:     "BLERG",
+						Username: "username",
+						Password: "tOpsYKrets",
 					},
 				},
 			},
-			expected: &authn.Basic{
+			authenticatorAssertion: basicAuth(authn.Basic{
 				Username: "username",
 				Password: "tOpsYKrets",
-			},
+			}),
 		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actualAuth := test.input.Authenticator(test.registry)
-			if test.expected == nil && actualAuth == nil {
-				// pass
-				return
-			}
-			actual, ok := actualAuth.(*authn.Basic)
-			if !ok {
-				t.Fatalf("unable to get basic auth obj: %+v", actualAuth)
-			}
-			assert.Equal(t, test.expected, actual)
-		})
-	}
-}
-
-func TestRegistryOptions_Authenticator_Bearer(t *testing.T) {
-	tests := []struct {
-		name     string
-		registry string
-		input    *RegistryOptions
-		expected *authn.Bearer
-	}{
 		{
-			name:     "require bearer token success",
+			name:     "bearer token credentials match registry",
 			registry: "localhost:5000",
-			input: &RegistryOptions{
+			input: RegistryOptions{
 				Credentials: []RegistryCredentials{
 					{
 						Authority: "localhost:5000",
@@ -171,26 +123,14 @@ func TestRegistryOptions_Authenticator_Bearer(t *testing.T) {
 					},
 				},
 			},
-			expected: &authn.Bearer{
+			authenticatorAssertion: bearerToken(authn.Bearer{
 				Token: "JRR",
-			},
+			}),
 		},
 		{
-			name:     "missing bearer token",
+			name:     "bearer token credentials don't match registry",
 			registry: "localhost:5000",
-			input: &RegistryOptions{
-				Credentials: []RegistryCredentials{
-					{
-						Authority: "localhost:5000",
-					},
-				},
-			},
-			expected: nil,
-		},
-		{
-			name:     "mismatched registry",
-			registry: "localhost:5000",
-			input: &RegistryOptions{
+			input: RegistryOptions{
 				Credentials: []RegistryCredentials{
 					{
 						Authority: "localhost",
@@ -198,34 +138,28 @@ func TestRegistryOptions_Authenticator_Bearer(t *testing.T) {
 					},
 				},
 			},
-			expected: nil,
+			authenticatorAssertion: nilAuthenticator(),
 		},
 		{
-			name:     "missing registry",
+			name:     "bearer token without authority",
 			registry: "localhost:5000",
-			input: &RegistryOptions{
+			input: RegistryOptions{
 				Credentials: []RegistryCredentials{
 					{
 						Token: "JRR",
 					},
 				},
 			},
-			expected: nil,
+			authenticatorAssertion: bearerToken(authn.Bearer{
+				Token: "JRR",
+			}),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actualAuth := test.input.Authenticator(test.registry)
-			if test.expected == nil && actualAuth == nil {
-				// pass
-				return
-			}
-			actual, ok := actualAuth.(*authn.Bearer)
-			if !ok {
-				t.Fatalf("unable to get bearer obj: %+v", actualAuth)
-			}
-			assert.Equal(t, test.expected, actual)
+			test.authenticatorAssertion(t, actualAuth)
 		})
 	}
 }


### PR DESCRIPTION
Addresses #68 

- Allows for empty `Authority` value for registry credentials, which will be usable with any registry
- Breaks out individual "credentials" concerns from "registry options" concerns (i.e. a collection of credentials)
- Refactors authenticator-creation logic and adds tests for new code paths