### PR TITLE
Add per-image scoped temp dir cleanup functions

### DIFF
--- a/examples/basic.go
+++ b/examples/basic.go
@@ -13,8 +13,6 @@ import (
 )
 
 func main() {
-	// note: we are writing out temp files which should be cleaned up after you're done with the image object
-	defer stereoscope.Cleanup()
 
 	// context for network requests
 	ctx, cancel := context.WithCancel(context.Background())
@@ -34,12 +32,15 @@ func main() {
 		panic(err)
 	}
 
+	// note: we are writing out temp files which should be cleaned up after you're done with the image object
+	defer image.Cleanup()
+
 	for _, layer := range image.Layers {
 		fmt.Printf("layer: %s\n", layer.Metadata.Digest)
 	}
 
-	//////////////////////////////////////////////////////////////////
-	//// Show the filetree for each layer
+	////////////////////////////////////////////////////////////////
+	// Show the filetree for each layer
 	for idx, layer := range image.Layers {
 		fmt.Printf("Walking layer: %d", idx)
 		err = layer.Tree.Walk(func(path file.Path, f filenode.FileNode) error {
@@ -53,7 +54,7 @@ func main() {
 	}
 
 	//////////////////////////////////////////////////////////////////
-	//// Show the squashed filetree for each layer
+	// Show the squashed filetree for each layer
 	for idx, layer := range image.Layers {
 		fmt.Printf("Walking squashed layer: %d", idx)
 		err = layer.SquashedTree.Walk(func(path file.Path, f filenode.FileNode) error {
@@ -67,7 +68,7 @@ func main() {
 	}
 
 	//////////////////////////////////////////////////////////////////
-	//// Show the final squashed tree
+	// Show the final squashed tree
 	fmt.Printf("Walking squashed image (same as the last layer squashed tree)")
 	err = image.SquashedTree().Walk(func(path file.Path, f filenode.FileNode) error {
 		fmt.Println("   ", path)
@@ -78,7 +79,7 @@ func main() {
 	}
 
 	//////////////////////////////////////////////////////////////////
-	//// Fetch file contents from the (squashed) image
+	// Fetch file contents from the (squashed) image
 	filePath := file.Path("/etc/group")
 	contentReader, err := image.FileContentsFromSquash(filePath)
 	if err != nil {

--- a/pkg/file/temp_dir_generator.go
+++ b/pkg/file/temp_dir_generator.go
@@ -10,7 +10,7 @@ import (
 type TempDirGenerator struct {
 	rootPrefix   string
 	rootLocation string
-	generators   []*TempDirGenerator
+	children     []*TempDirGenerator
 }
 
 func NewTempDirGenerator(name string) *TempDirGenerator {
@@ -34,7 +34,7 @@ func (t *TempDirGenerator) getOrCreateRootLocation() (string, error) {
 // NewGenerator creates a child generator capable of making sibling temp directories.
 func (t *TempDirGenerator) NewGenerator() *TempDirGenerator {
 	gen := NewTempDirGenerator(t.rootPrefix)
-	t.generators = append(t.generators, gen)
+	t.children = append(t.children, gen)
 	return gen
 }
 
@@ -51,7 +51,7 @@ func (t *TempDirGenerator) NewDirectory(name ...string) (string, error) {
 // Cleanup deletes all temp dirs created by this generator and any child generator.
 func (t *TempDirGenerator) Cleanup() error {
 	var allErrs error
-	for _, gen := range t.generators {
+	for _, gen := range t.children {
 		if err := gen.Cleanup(); err != nil {
 			allErrs = multierror.Append(allErrs, err)
 		}

--- a/pkg/file/temp_dir_generator_test.go
+++ b/pkg/file/temp_dir_generator_test.go
@@ -1,0 +1,91 @@
+package file
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTempDirGenerator(t *testing.T) {
+	tests := []struct {
+		name            string
+		genPrefix       string
+		names           []string
+		extraGenerators int
+	}{
+		{
+			name:      "3 temp dirs",
+			genPrefix: "a-special-prefix",
+			names: []string{
+				"a",
+				"bee",
+				"si",
+			},
+		},
+		{
+			name:      "3 temp dirs on the root generator + 2 extra generators",
+			genPrefix: "b-special-prefix",
+			names: []string{
+				"a",
+				"bee",
+				"si",
+			},
+			extraGenerators: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			expectedPrefix := path.Join(os.TempDir(), test.genPrefix)
+
+			assert.True(t, !doesGlobExist(t, expectedPrefix+"*"),
+				"prefix temp dir already exists before test started")
+
+			root := NewTempDirGenerator(test.genPrefix)
+
+			for _, n := range test.names {
+				d, err := root.NewDirectory(n)
+				assert.NoError(t, err)
+				assert.True(t, doesGlobExist(t, d), "sub-temp dir does not exist (root)")
+				assert.Contains(t, d, expectedPrefix)
+				assert.NotEmpty(t, root.rootLocation)
+				assert.Contains(t, d, root.rootLocation)
+			}
+
+			assert.True(t, doesGlobExist(t, expectedPrefix+"*"), "prefix temp dir does not exist")
+
+			var gen *TempDirGenerator
+			for i := 0; i < test.extraGenerators; i++ {
+				gen = root.NewGenerator()
+				for _, n := range test.names {
+					d, err := gen.NewDirectory(n)
+					assert.NoError(t, err)
+					assert.True(t, doesGlobExist(t, d), "sub-temp dir does not exist (sub)")
+					assert.Contains(t, d, expectedPrefix)
+					assert.NotEmpty(t, gen.rootLocation)
+					assert.Contains(t, d, gen.rootLocation)
+				}
+
+			}
+
+			assert.NoError(t, root.Cleanup())
+
+			assert.True(t, !doesGlobExist(t, expectedPrefix+"*"), "cleanup did not remove prefix temp dir")
+
+		})
+	}
+}
+
+func doesGlobExist(t *testing.T, pattern string) bool {
+	t.Helper()
+	m, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m) > 0 {
+		return true
+	}
+	return false
+}

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -139,7 +139,7 @@ func (p *DaemonImageProvider) pull(ctx context.Context) error {
 
 // Provide an image object that represents the cached docker image tar fetched from a docker daemon.
 func (p *DaemonImageProvider) Provide(ctx context.Context) (*image.Image, error) {
-	imageTempDir, err := p.tmpDirGen.NewTempDir()
+	imageTempDir, err := p.tmpDirGen.NewDirectory("docker-daemon-image")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/docker/tarball_provider.go
+++ b/pkg/image/docker/tarball_provider.go
@@ -93,7 +93,7 @@ func (p *TarballImageProvider) Provide(context.Context) (*image.Image, error) {
 
 	metadata = append(metadata, image.WithRepoDigests(p.repoDigests))
 
-	contentTempDir, err := p.tmpDirGen.NewTempDir()
+	contentTempDir, err := p.tmpDirGen.NewDirectory("docker-tarball-image")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/anchore/stereoscope/internal/bus"
 	"github.com/anchore/stereoscope/internal/log"
@@ -251,10 +252,20 @@ func (i *Image) ResolveLinkByLayerSquash(ref file.Reference, layer int, options 
 	return resolvedRef, err
 }
 
-// ResolveLinkByLayerSquash resolves a symlink or hardlink for the given file reference relative to the result from the image squash.
+// ResolveLinkByImageSquash resolves a symlink or hardlink for the given file reference relative to the result from the image squash.
 // If the given file reference is not a link type, or is a unresolvable (dead) link, then the given file reference is returned.
 func (i *Image) ResolveLinkByImageSquash(ref file.Reference, options ...filetree.LinkResolutionOption) (*file.Reference, error) {
 	allOptions := append([]filetree.LinkResolutionOption{filetree.FollowBasenameLinks}, options...)
 	_, resolvedRef, err := i.Layers[len(i.Layers)-1].SquashedTree.File(ref.RealPath, allOptions...)
 	return resolvedRef, err
+}
+
+// Cleanup removes all temporary files created from parsing the image. Future calls to image will not function correctly after this call.
+func (i *Image) Cleanup() error {
+	if i.contentCacheDir != "" {
+		if err := os.RemoveAll(i.contentCacheDir); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/image/oci/directory_provider.go
+++ b/pkg/image/oci/directory_provider.go
@@ -61,7 +61,7 @@ func (p *DirectoryImageProvider) Provide(context.Context) (*image.Image, error) 
 		metadata = append(metadata, image.WithManifest(rawManifest))
 	}
 
-	contentTempDir, err := p.tmpDirGen.NewTempDir()
+	contentTempDir, err := p.tmpDirGen.NewDirectory("oci-dir-image")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -34,7 +34,7 @@ func NewProviderFromRegistry(imgStr string, tmpDirGen *file.TempDirGenerator, re
 func (p *RegistryImageProvider) Provide(ctx context.Context) (*image.Image, error) {
 	log.Debugf("pulling image info directly from registry image=%q", p.imageStr)
 
-	imageTempDir, err := p.tmpDirGen.NewTempDir()
+	imageTempDir, err := p.tmpDirGen.NewDirectory("oci-registry-image")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/oci/tarball_provider.go
+++ b/pkg/image/oci/tarball_provider.go
@@ -32,7 +32,7 @@ func (p *TarballImageProvider) Provide(ctx context.Context) (*image.Image, error
 		return nil, fmt.Errorf("unable to open OCI tarball: %w", err)
 	}
 
-	tempDir, err := p.tmpDirGen.NewTempDir()
+	tempDir, err := p.tmpDirGen.NewDirectory("oci-tarball-image")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imagetest/image_fixtures.go
+++ b/pkg/imagetest/image_fixtures.go
@@ -59,11 +59,10 @@ func GetFixtureImage(t testing.TB, source, name string) *image.Image {
 	request := PrepareFixtureImage(t, source, name)
 
 	i, err := stereoscope.GetImage(context.TODO(), request, nil)
-	if err != nil {
-		t.Fatal("could not get tar image:", err)
-	}
-	t.Cleanup(stereoscope.Cleanup)
-
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, i.Cleanup())
+	})
 	return i
 }
 
@@ -110,9 +109,13 @@ func getFixtureImageFromTar(t testing.TB, tarPath string) *image.Image {
 	request := fmt.Sprintf("docker-archive:%s", tarPath)
 
 	i, err := stereoscope.GetImage(context.TODO(), request, nil)
-	if err != nil {
-		t.Fatal("could not get tar image:", err)
-	}
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if err := i.Cleanup(); err != nil {
+			t.Errorf("could not cleanup tarPath=%q: %w", tarPath, err)
+		}
+	})
 
 	return i
 }

--- a/test/integration/oci_registry_source_test.go
+++ b/test/integration/oci_registry_source_test.go
@@ -3,10 +3,12 @@ package integration
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/stretchr/testify/assert"
-	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOciRegistrySourceMetadata(t *testing.T) {
@@ -31,9 +33,11 @@ func TestOciRegistrySourceMetadata(t *testing.T) {
 	ref := fmt.Sprintf("%s@%s", imgStr, digest)
 
 	img, err := stereoscope.GetImage(context.TODO(), "registry:"+ref, &image.RegistryOptions{})
-	if err != nil {
-		t.Fatalf("unable to get image: %+v", err)
-	}
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, img.Cleanup())
+	})
+
 	if err := img.Read(); err != nil {
 		t.Fatalf("failed to read image: %+v", err)
 	}


### PR DESCRIPTION
This PR changes the tempfile generation to share the same parent directory for the same call to `GetImage` or `GetImageFromSource`. This change requires that cleanup functions are exposed on these `GetImage*` calls to cleanup temp dirs created by that particular call. 

Today the temp file generation is globally handled with the `Cleanup` function, which (correctly) breaks when used as a test cleanup function, since it affects global state. Test cleanup calls now leverage the more narrowly-scoped cleanup function returned from `GetImage*` functions. 

This PR also opts to leave the global `Cleanup` function in tact. Why? Callers (such as syft and grype) may need to interrupt the process and exit, but also make certain that any temp directories are cleaned up. This PR updates the `file.TempDirGenerator` tracks all temp generators created and temp directories created from a root object such that the root object can cleanup all temp directories from all nested generators. This allows callers to have the "clean everything up and exit" option for exceptional cases (today, syft needs this).

Specific changes:
- Removes locking and individual dir creation tracking from `file.TempDirGenerator`
- A single `TempDirGenerator` now keeps all created temp dirs within a shared parent dir.
- Adds the ability to create additional `TempDirGenerators` from a `TempDirGenerator`, which will create a sibling temp dir with the same prefix as the parent prefix. All directories created from the child generator are persisted in the sibling temp dir from the parent generator.
- `TempDirGenerator.Cleanup` calls cleanup on all child generators as well as removing the shared top directory among all created temp dirs for the generator.
- adds `image.Image.Cleanup()` deletes the temp dir scoped for that particular image.

Partially addresses https://github.com/anchore/syft/issues/416 
Fixes https://github.com/anchore/stereoscope/issues/96