### PR TITLE
Add option to allow registry connections over http (supersedes #73)

### DIFF
--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -38,7 +38,12 @@ func (p *RegistryImageProvider) Provide() (*image.Image, error) {
 		return nil, err
 	}
 
-	ref, err := name.ParseReference(p.imageStr)
+	options := make([]name.Option, 0, 2)
+	if p.registryOptions.InsecureSkipTLSVerify {
+		options = append(options, name.Insecure)
+	}
+
+	ref, err := name.ParseReference(p.imageStr, options...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse registry reference=%q: %+v", p.imageStr, err)
 	}

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -39,7 +39,7 @@ func (p *RegistryImageProvider) Provide() (*image.Image, error) {
 	}
 
 	options := make([]name.Option, 0, 2)
-	if p.registryOptions.InsecureSkipTLSVerify {
+	if p.registryOptions.InsecureUseHTTP {
 		options = append(options, name.Insecure)
 	}
 

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -38,7 +38,7 @@ func (p *RegistryImageProvider) Provide() (*image.Image, error) {
 		return nil, err
 	}
 
-	options := make([]name.Option, 0)
+	var options []name.Option
 	if p.registryOptions.InsecureUseHTTP {
 		options = append(options, name.Insecure)
 	}

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -38,7 +38,7 @@ func (p *RegistryImageProvider) Provide() (*image.Image, error) {
 		return nil, err
 	}
 
-	options := make([]name.Option, 0, 2)
+	options := make([]name.Option, 0)
 	if p.registryOptions.InsecureUseHTTP {
 		options = append(options, name.Insecure)
 	}

--- a/pkg/image/registry_options.go
+++ b/pkg/image/registry_options.go
@@ -8,6 +8,7 @@ import (
 // RegistryOptions for the OCI registry provider.
 type RegistryOptions struct {
 	InsecureSkipTLSVerify bool
+	InsecureUseHTTP       bool
 	Credentials           []RegistryCredentials
 }
 


### PR DESCRIPTION
Updated #73 to use another option, because TLS validation and http/https are different concerns.

NOTE: this is a prerequisite of https://github.com/anchore/grype/issues/334