### PR TITLE
chore: refactor prepareReferenceOptions and tests

### DIFF
--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -38,12 +38,7 @@ func (p *RegistryImageProvider) Provide() (*image.Image, error) {
 		return nil, err
 	}
 
-	var options []name.Option
-	if p.registryOptions.InsecureUseHTTP {
-		options = append(options, name.Insecure)
-	}
-
-	ref, err := name.ParseReference(p.imageStr, options...)
+	ref, err := name.ParseReference(p.imageStr, prepareReferenceOptions(p.registryOptions)...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse registry reference=%q: %+v", p.imageStr, err)
 	}
@@ -72,6 +67,14 @@ func (p *RegistryImageProvider) Provide() (*image.Image, error) {
 	}
 
 	return image.NewImage(img, imageTempDir, metadata...), nil
+}
+
+func prepareReferenceOptions(registryOptions *image.RegistryOptions) []name.Option {
+	var options []name.Option
+	if registryOptions.InsecureUseHTTP {
+		options = append(options, name.Insecure)
+	}
+	return options
 }
 
 func prepareRemoteOptions(ref name.Reference, registryOptions *image.RegistryOptions) []remote.Option {

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -71,7 +71,7 @@ func (p *RegistryImageProvider) Provide() (*image.Image, error) {
 
 func prepareReferenceOptions(registryOptions *image.RegistryOptions) []name.Option {
 	var options []name.Option
-	if registryOptions.InsecureUseHTTP {
+	if registryOptions != nil && registryOptions.InsecureUseHTTP {
 		options = append(options, name.Insecure)
 	}
 	return options

--- a/pkg/image/oci/registry_provider_test.go
+++ b/pkg/image/oci/registry_provider_test.go
@@ -1,0 +1,46 @@
+package oci
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_prepareReferenceOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    image.RegistryOptions
+		expected []name.Option
+	}{
+		{
+			name:     "not InsecureUseHTTP",
+			input:    image.RegistryOptions{},
+			expected: nil,
+		},
+		{
+			name: "use InsecureUseHTTP",
+			input: image.RegistryOptions{
+				InsecureUseHTTP: true,
+			},
+			expected: []name.Option{name.Insecure},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := prepareReferenceOptions(&test.input)
+			assert.Equal(t, len(test.expected), len(out))
+			if test.expected == nil {
+				assert.Equal(t, test.expected, out)
+			} else {
+				// cannot compare functions directly
+				e1 := reflect.ValueOf(test.expected[0])
+				e2 := reflect.ValueOf(out[0])
+				assert.Equal(t, e1, e2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #75 to add a basic unit test