### PR TITLE
Improved whitespace support in paths

### DIFF
--- a/pkg/file/path.go
+++ b/pkg/file/path.go
@@ -17,11 +17,20 @@ type Path string
 
 // Normalize returns the cleaned file path representation (trimmed of spaces and resolve relative notations)
 func (p Path) Normalize() Path {
-	trimmed := strings.Trim(string(p), " ")
-	if trimmed == "/" {
-		return Path(trimmed)
+	// note: when normalizing we cannot trim trailing whitespace since it is valid for a path to have suffix whitespace
+	var trimmed = string(p)
+	if strings.Count(trimmed, " ") < len(trimmed) {
+		trimmed = strings.TrimLeft(string(p), " ")
 	}
-	return Path(path.Clean(strings.TrimRight(trimmed, DirSeparator)))
+
+	// remove trailing dir separators
+	trimmed = strings.TrimRight(trimmed, DirSeparator)
+
+	// special case for root "/"
+	if trimmed == "" {
+		return DirSeparator
+	}
+	return Path(path.Clean(trimmed))
 }
 
 func (p Path) IsAbsolutePath() bool {

--- a/pkg/file/path_test.go
+++ b/pkg/file/path_test.go
@@ -9,14 +9,9 @@ func TestPath_Normalize(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "Trim Right Whitespace",
-			path:     "/some/path ",
-			expected: "/some/path",
-		},
-		{
-			name:     "Trim Left Whitespace",
-			path:     "   /some/path ",
-			expected: "/some/path",
+			name:     "Preserve trailing whitespace (Not prefixed whitespace)",
+			path:     " /some/path ",
+			expected: "/some/path ",
 		},
 		{
 			name:     "Trim extra slashes",
@@ -24,7 +19,27 @@ func TestPath_Normalize(t *testing.T) {
 			expected: "/some/path",
 		},
 		{
-			name:     "Special case: /",
+			name:     "Dir as space /",
+			path:     "// /",
+			expected: "/ ",
+		},
+		{
+			name:     "Padded /",
+			path:     "///",
+			expected: "/",
+		},
+		{
+			name:     "Rooted space",
+			path:     "/ ",
+			expected: "/ ",
+		},
+		{
+			name:     "space only",
+			path:     " ",
+			expected: " ",
+		},
+		{
+			name:     "Special case for root",
 			path:     "/",
 			expected: "/",
 		},


### PR DESCRIPTION
Fixes anchore/grype#460

When normalizing a path we should not be removing trailing spaces from the given path since whitespace characters are allowed within paths (e.g. `/example<space>` is valid whereas `<space>/example/` should normalize to `/example`).