### PR TITLE
Windows compatible development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ RESET := $(shell tput -T linux sgr0)
 TITLE := $(BOLD)$(PURPLE)
 SUCCESS := $(BOLD)$(GREEN)
 # the quality gate lower threshold for unit test total % coverage (by function statements)
-COVERAGE_THRESHOLD := 45
+COVERAGE_THRESHOLD := 40
 
 ifeq "$(strip $(VERSION))" ""
     override VERSION = $(shell git describe --always --tags --dirty)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ RESET := $(shell tput -T linux sgr0)
 TITLE := $(BOLD)$(PURPLE)
 SUCCESS := $(BOLD)$(GREEN)
 # the quality gate lower threshold for unit test total % coverage (by function statements)
-COVERAGE_THRESHOLD := 44
+COVERAGE_THRESHOLD := 48
 
 ifeq "$(strip $(VERSION))" ""
     override VERSION = $(shell git describe --always --tags --dirty)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ RESET := $(shell tput -T linux sgr0)
 TITLE := $(BOLD)$(PURPLE)
 SUCCESS := $(BOLD)$(GREEN)
 # the quality gate lower threshold for unit test total % coverage (by function statements)
-COVERAGE_THRESHOLD := 40
+COVERAGE_THRESHOLD := 44
 
 ifeq "$(strip $(VERSION))" ""
     override VERSION = $(shell git describe --always --tags --dirty)

--- a/pkg/file/metadata_test.go
+++ b/pkg/file/metadata_test.go
@@ -1,11 +1,15 @@
+//go:build linux
+// +build linux
+
 package file
 
 import (
-	"github.com/go-test/deep"
 	"io"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/go-test/deep"
 )
 
 func TestFileMetadataFromTar(t *testing.T) {

--- a/pkg/file/metadata_test.go
+++ b/pkg/file/metadata_test.go
@@ -1,4 +1,3 @@
-//go:build linux
 // +build linux
 
 package file

--- a/pkg/file/metadata_test.go
+++ b/pkg/file/metadata_test.go
@@ -1,4 +1,5 @@
-// +build linux
+//go:build !windows
+// +build !windows
 
 package file
 

--- a/pkg/file/tar_index_test.go
+++ b/pkg/file/tar_index_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package file
 
 import (

--- a/pkg/file/tar_index_test.go
+++ b/pkg/file/tar_index_test.go
@@ -1,4 +1,3 @@
-//go:build linux
 // +build linux
 
 package file

--- a/pkg/file/tar_index_test.go
+++ b/pkg/file/tar_index_test.go
@@ -1,4 +1,5 @@
-// +build linux
+//go:build !windows
+// +build !windows
 
 package file
 

--- a/pkg/file/tarutil_test.go
+++ b/pkg/file/tarutil_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+// +build linux
 
 package file
 

--- a/pkg/file/tarutil_test.go
+++ b/pkg/file/tarutil_test.go
@@ -1,9 +1,10 @@
+//go:build linux
+
 package file
 
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,6 +12,8 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/pkg/file/tarutil_test.go
+++ b/pkg/file/tarutil_test.go
@@ -1,4 +1,5 @@
-// +build linux
+//go:build !windows
+// +build !windows
 
 package file
 

--- a/pkg/filetree/filenode/filenode.go
+++ b/pkg/filetree/filenode/filenode.go
@@ -1,7 +1,7 @@
 package filenode
 
 import (
-	"path/filepath"
+	"path"
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/tree/node"
@@ -41,7 +41,7 @@ func NewSymLink(p, linkPath file.Path, ref *file.Reference) *FileNode {
 
 func NewHardLink(p, linkPath file.Path, ref *file.Reference) *FileNode {
 	// hard link MUST be interpreted as an absolute path
-	linkPath = file.Path(filepath.Clean(file.DirSeparator + string(linkPath)))
+	linkPath = file.Path(path.Clean(file.DirSeparator + string(linkPath)))
 	return &FileNode{
 		RealPath:  p,
 		FileType:  file.TypeHardLink,

--- a/pkg/filetree/filetree.go
+++ b/pkg/filetree/filetree.go
@@ -106,7 +106,7 @@ func (t *FileTree) ListPaths(dir file.Path) ([]file.Path, error) {
 			return nil, err
 		}
 
-		listing = append(listing, file.Path(filepath.Join(string(dir), fn.RealPath.Basename())))
+		listing = append(listing, file.Path(path.Join(string(dir), fn.RealPath.Basename())))
 	}
 	return listing, nil
 }
@@ -307,7 +307,7 @@ func (t *FileTree) resolveNodeLinks(n *filenode.FileNode, followDeadBasenameLink
 			var parentDir string
 			parentDir, _ = filepath.Split(string(currentNode.RealPath))
 			// assemble relative link path by normalizing: "/cur/dir/../file1.txt" --> "/cur/file1.txt"
-			nextPath = file.Path(filepath.Clean(path.Join(parentDir, string(currentNode.LinkPath))))
+			nextPath = file.Path(path.Clean(path.Join(parentDir, string(currentNode.LinkPath))))
 		}
 
 		// no more links to follow

--- a/pkg/filetree/glob_test.go
+++ b/pkg/filetree/glob_test.go
@@ -1,13 +1,11 @@
 package filetree
 
 import (
-	"io/fs"
 	"testing"
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree/filenode"
 	"github.com/go-test/deep"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestFileInfoAdapter(t *testing.T) {

--- a/pkg/filetree/glob_test.go
+++ b/pkg/filetree/glob_test.go
@@ -1,11 +1,13 @@
 package filetree
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree/filenode"
 	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFileInfoAdapter(t *testing.T) {
@@ -174,12 +176,7 @@ func TestFileInfoAdapter_PreventInfiniteLoop(t *testing.T) {
 }
 
 func TestOSAdapter_Lstat(t *testing.T) {
-	tr := NewFileTree()
-	tr.AddFile("/home/thing.txt")
-	tr.AddDir("/home/wagoodman")
-	tr.AddSymLink("/home/thing", "./thing.txt")
-	// note: link destination does not exist
-	tr.AddHardLink("/home/place", "/somewhere-else")
+	tr := newHelperTree()
 
 	tests := []struct {
 		name                         string
@@ -267,13 +264,7 @@ func TestOSAdapter_Lstat(t *testing.T) {
 }
 
 func TestOSAdapter_Stat(t *testing.T) {
-	tr := NewFileTree()
-	tr.AddFile("/home/thing.txt")
-	tr.AddDir("/home/wagoodman")
-	tr.AddSymLink("/home/thing", "./thing.txt")
-	// note: link destination does not exist
-	tr.AddHardLink("/home/place", "/somewhere-else")
-
+	tr := newHelperTree()
 	tests := []struct {
 		name                         string
 		doNotFollowDeadBasenameLinks bool
@@ -356,4 +347,15 @@ func TestOSAdapter_Stat(t *testing.T) {
 		})
 	}
 
+}
+
+func newHelperTree() *FileTree {
+	tr := NewFileTree()
+	tr.AddFile("/home/thing.txt")
+	tr.AddDir("/home/wagoodman")
+	tr.AddSymLink("/home/thing", "./thing.txt")
+	// note: link destination does not exist
+	tr.AddHardLink("/home/place", "/somewhere-else")
+
+	return tr
 }

--- a/pkg/filetree/glob_test.go
+++ b/pkg/filetree/glob_test.go
@@ -117,6 +117,55 @@ func TestFileInfoAdapter(t *testing.T) {
 	}
 }
 
+func TestOsAdapter_PreventInfiniteLoop(t *testing.T) {
+	tr := NewFileTree()
+	tr.AddFile("/usr/bin/busybox")
+	tr.AddSymLink("/usr/bin/X11", ".")
+
+	tests := []struct {
+		name       string
+		path       string
+		childCount int
+	}{
+		{
+			name:       "children on real path",
+			path:       "/usr/bin",
+			childCount: 2,
+		},
+		{
+			name:       "first link iteration shows children",
+			path:       "/usr/bin/X11",
+			childCount: 2,
+		},
+		{
+			name:       "second link iteration DOES NOT show children",
+			path:       "/usr/bin/X11/X11",
+			childCount: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			adapter := &osAdapter{
+				filetree:                     tr,
+				doNotFollowDeadBasenameLinks: false,
+			}
+			fileInfos, err := adapter.ReadDir(test.path)
+			if err != nil {
+				t.Fatalf("could not read dir: %+v", err)
+			}
+
+			if len(fileInfos) != test.childCount {
+				for _, f := range fileInfos {
+					t.Logf("   actual: %+v", f)
+				}
+				t.Errorf("unexpected number of files: %d != %d", len(fileInfos), test.childCount)
+			}
+
+		})
+	}
+}
+
 func TestFileInfoAdapter_PreventInfiniteLoop(t *testing.T) {
 	tr := NewFileTree()
 	tr.AddFile("/usr/bin/busybox")

--- a/pkg/filetree/glob_test.go
+++ b/pkg/filetree/glob_test.go
@@ -1,6 +1,7 @@
 package filetree
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/anchore/stereoscope/pkg/file"
@@ -228,6 +229,13 @@ func TestOSAdapter_ReadDir(t *testing.T) {
 				fi := fileInfo.(*fileinfoAdapter)
 				fi.Node.Reference = nil
 				actual = append(actual, *fi)
+			}
+
+			// sort outputs for compare
+			for _, fi := range [][]fileinfoAdapter{actual, test.expected} {
+				sort.Slice(fi, func(i, j int) bool {
+					return fi[i].VirtualPath > fi[j].VirtualPath
+				})
 			}
 
 			for _, d := range deep.Equal(test.expected, actual) {

--- a/pkg/filetree/glob_test.go
+++ b/pkg/filetree/glob_test.go
@@ -181,9 +181,10 @@ func TestOSAdapter_ReadDir(t *testing.T) {
 		doNotFollowDeadBasenameLinks bool
 		path                         string
 		expected                     []fileinfoAdapter
+		shouldErr                    bool
 	}{
 		{
-			name:                         "readDir",
+			name:                         "ReadDir fetches the filesInfos correctly",
 			doNotFollowDeadBasenameLinks: false,
 			path:                         "/home",
 			expected: []fileinfoAdapter{
@@ -205,6 +206,7 @@ func TestOSAdapter_ReadDir(t *testing.T) {
 					Node:        filenode.FileNode{RealPath: "/home/place", FileType: 49, LinkPath: "/somewhere-else"},
 				},
 			},
+			shouldErr: false,
 		},
 	}
 

--- a/pkg/image/file_catalog_test.go
+++ b/pkg/image/file_catalog_test.go
@@ -1,4 +1,5 @@
-// +build linux
+//go:build !windows
+// +build !windows
 
 package image
 

--- a/pkg/image/file_catalog_test.go
+++ b/pkg/image/file_catalog_test.go
@@ -1,11 +1,11 @@
+//go:build linux
+// +build linux
+
 package image
 
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/go-test/deep"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/types"
 	"io"
 	"io/ioutil"
 	"os"
@@ -13,6 +13,10 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+
+	"github.com/go-test/deep"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 
 	"github.com/anchore/stereoscope/pkg/file"
 )

--- a/pkg/image/file_catalog_test.go
+++ b/pkg/image/file_catalog_test.go
@@ -1,4 +1,3 @@
-//go:build linux
 // +build linux
 
 package image

--- a/test/integration/fixture_image_simple_test.go
+++ b/test/integration/fixture_image_simple_test.go
@@ -1,4 +1,3 @@
-//go:build linux
 // +build linux
 
 package integration

--- a/test/integration/fixture_image_simple_test.go
+++ b/test/integration/fixture_image_simple_test.go
@@ -1,4 +1,5 @@
-// +build linux
+//go:build windows
+// +build windows
 
 package integration
 

--- a/test/integration/fixture_image_simple_test.go
+++ b/test/integration/fixture_image_simple_test.go
@@ -1,14 +1,18 @@
+//go:build linux
+// +build linux
+
 package integration
 
 import (
 	"fmt"
-	"github.com/anchore/stereoscope"
-	"github.com/anchore/stereoscope/pkg/filetree"
-	"github.com/scylladb/go-set"
 	"io"
 	"io/ioutil"
 	"strings"
 	"testing"
+
+	"github.com/anchore/stereoscope"
+	"github.com/anchore/stereoscope/pkg/filetree"
+	"github.com/scylladb/go-set"
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"

--- a/test/integration/fixture_image_symlinks_test.go
+++ b/test/integration/fixture_image_symlinks_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package integration
 
 import (

--- a/test/integration/fixture_image_symlinks_test.go
+++ b/test/integration/fixture_image_symlinks_test.go
@@ -1,4 +1,3 @@
-//go:build linux
 // +build linux
 
 package integration

--- a/test/integration/fixture_image_symlinks_test.go
+++ b/test/integration/fixture_image_symlinks_test.go
@@ -1,4 +1,5 @@
-// +build linux
+//go:build !windows
+// +build !windows
 
 package integration
 


### PR DESCRIPTION
## Update stereoscope to be compatible with development on windows

Running tests on windows would prove difficult for the following reasons:
- bash shells called during testing for state configuration
  - (solution add build tags until future improvements can be made to orchestrate state correctly on each OS)
- skopeo does not have a windows release
  - (solution add build tags to ignore tests leveraging skopeo for windows until skopeo is supported) 
  - https://github.com/containers/skopeo/issues/715
- posix test paths were being incorrectly converted to windows paths causing mutliple tests to fail


Screen shots of behavior in order:
Bash Errors
![Screenshot 2021-12-21 034531](https://user-images.githubusercontent.com/32073428/146900295-e1c2b82f-9fff-47fd-b5a6-e6906adfcc0a.png)

Skopeo Errors
![Screenshot 2021-12-21 034556](https://user-images.githubusercontent.com/32073428/146900332-3efed201-21d0-47c5-968b-34a35804f579.png)

Inadvertant filepath conversion
![Screenshot 2021-12-21 034504](https://user-images.githubusercontent.com/32073428/146900338-f2441719-a38e-4f99-a8dd-b034008d2802.png)

