### PR TITLE
Export function for determining image pull source

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ import (
 
 var tempDirGenerator = file.NewTempDirGenerator()
 
-// GetImage returns an image from the explicitly provided source.
+// GetImageFromSource returns an image from the explicitly provided source.
 func GetImageFromSource(imgStr string, source image.Source, registryOptions *image.RegistryOptions) (*image.Image, error) {
 	var provider image.Provider
 	log.Debugf("image: source=%+v location=%+v", source, imgStr)

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -187,7 +187,7 @@ func (p *DaemonImageProvider) Provide() (*image.Image, error) {
 		return nil, fmt.Errorf("unable to trace image save progress: %w", err)
 	}
 
-	stage.Current = "requesting image from docker"
+	stage.Current = "requesting image from Docker"
 	readCloser, err := dockerClient.ImageSave(context.Background(), []string{p.imageStr})
 	if err != nil {
 		return nil, fmt.Errorf("unable to save image tar: %w", err)


### PR DESCRIPTION
This PR doesn't change behavior, but factors out a function that's useful for consumers that need to specify an `image.Source` parameter in calls to Stereoscope's functions, such as `stereoscope.GetImageFromSource`.

This function centrally defines behavior for determining if a referenced image should be pulled via the Docker daemon or directly from an OCI registry.