### PR TITLE
fix registry auth regression

### DIFF
--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -78,13 +78,6 @@ func prepareReferenceOptions(registryOptions *image.RegistryOptions) []name.Opti
 }
 
 func prepareRemoteOptions(ref name.Reference, registryOptions *image.RegistryOptions) (opts []remote.Option) {
-	if registryOptions == nil {
-		// use the Keychain specified from a docker config file.
-		log.Debugf("no registry credentials configured, using the default keychain")
-		opts = append(opts, remote.WithAuthFromKeychain(authn.DefaultKeychain))
-		return
-	}
-
 	if registryOptions.InsecureSkipTLSVerify {
 		t := &http.Transport{
 			// nolint: gosec
@@ -98,6 +91,10 @@ func prepareRemoteOptions(ref name.Reference, registryOptions *image.RegistryOpt
 	authenticator := registryOptions.Authenticator(ref.Context().RegistryStr())
 	if authenticator != nil {
 		opts = append(opts, remote.WithAuth(authenticator))
+	} else {
+		// use the Keychain specified from a docker config file.
+		log.Debugf("no registry credentials configured, using the default keychain")
+		opts = append(opts, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	}
 
 	return

--- a/pkg/image/source_test.go
+++ b/pkg/image/source_test.go
@@ -22,6 +22,12 @@ func TestDetectSource(t *testing.T) {
 		tarPaths         []string
 	}{
 		{
+			name:             "podman-engine",
+			input:            "podman:something:latest",
+			source:           PodmanDaemonSource,
+			expectedLocation: "something:latest",
+		},
+		{
 			name:             "docker-archive",
 			input:            "docker-archive:a/place.tar",
 			source:           DockerTarballSource,


### PR DESCRIPTION
While adding Podman I mistakenly removed a registry condition[1]. The problem was spotted by tests in Syft and Grype.

Question: should that behavior be enforced by tests in Stereoscope?
 
[1] commit: c30d664f2d826936fe54d3ba5fca015b467098e0

Signed-off-by: Jonas Galvão Xavier <jonas.agx@gmail.com>