### PR TITLE
Use functional options for GetImage functions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
+    - exportloopref
     - funlen
     - gocognit
     - goconst
@@ -19,18 +20,16 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - maligned
     - misspell
     - nakedret
     - nolintlint
+    - revive
     - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
     - stylecheck
@@ -47,11 +46,14 @@ linters:
 #    - godot
 #    - godox
 #    - goerr113
+#    - golint      # deprecated
 #    - gomnd       # this is too aggressive
 #    - interfacer  # this is a good idea, but is no longer supported and is prone to false positives
 #    - lll         # without a way to specify per-line exception cases, this is not usable
+#    - maligned    # this is an excellent linter, but tricky to optimize and we are not sensitive to memory layout optimizations
 #    - nestif
 #    - prealloc    # following this rule isn't consistently a good idea, as it sometimes forces unnecessary allocations that result in less idiomatic code
+#    - scopelint   # deprecated
 #    - testpackage
-#    - wsl
+#    - wsl         # this doens't have an auto-fixer yet and is pretty noisy (https://github.com/bombsimon/wsl/issues/90)
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ bootstrap: $(RESULTSDIR) ## Download and install all project dependencies (+ pre
 	go mod download
 	# install utilities
 	[ -f "$(TEMPDIR)/benchstat" ] || GO111MODULE=off GOBIN=$(shell realpath $(TEMPDIR)) go get -u golang.org/x/perf/cmd/benchstat
-	[ -f "$(TEMPDIR)/golangci" ] || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.26.0
+	[ -f "$(TEMPDIR)/golangci" ] || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.44.0
 	[ -f "$(TEMPDIR)/bouncer" ] || curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.2.0
 
 .PHONY: static-analysis

--- a/client.go
+++ b/client.go
@@ -18,17 +18,62 @@ import (
 
 var rootTempDirGenerator = file.NewTempDirGenerator("stereoscope")
 
+func WithRegistryOptions(options image.RegistryOptions) Option {
+	return func(c *config) error {
+		c.Registry = options
+		return nil
+	}
+}
+
+func WithInsecureSkipTLSVerify() Option {
+	return func(c *config) error {
+		c.Registry.InsecureSkipTLSVerify = true
+		return nil
+	}
+}
+
+func WithInsecureAllowHTTP() Option {
+	return func(c *config) error {
+		c.Registry.InsecureUseHTTP = true
+		return nil
+	}
+}
+
+func WithCredentials(credentials ...image.RegistryCredentials) Option {
+	return func(c *config) error {
+		c.Registry.Credentials = append(c.Registry.Credentials, credentials...)
+		return nil
+	}
+}
+
+func WithAdditionalMetadata(metadata ...image.AdditionalMetadata) Option {
+	return func(c *config) error {
+		c.AdditionalMetadata = append(c.AdditionalMetadata, metadata...)
+		return nil
+	}
+}
+
 // GetImageFromSource returns an image from the explicitly provided source.
-func GetImageFromSource(ctx context.Context, imgStr string, source image.Source, registryOptions *image.RegistryOptions) (*image.Image, error) {
+func GetImageFromSource(ctx context.Context, imgStr string, source image.Source, options ...Option) (*image.Image, error) {
 	var provider image.Provider
 	log.Debugf("image: source=%+v location=%+v", source, imgStr)
 
 	tempDirGenerator := rootTempDirGenerator.NewGenerator()
 
+	var cfg config
+	for _, option := range options {
+		if option == nil {
+			continue
+		}
+		if err := option(&cfg); err != nil {
+			return nil, fmt.Errorf("unable to parse option: %w", err)
+		}
+	}
+
 	switch source {
 	case image.DockerTarballSource:
 		// note: the imgStr is the path on disk to the tar file
-		provider = docker.NewProviderFromTarball(imgStr, tempDirGenerator, nil, nil)
+		provider = docker.NewProviderFromTarball(imgStr, tempDirGenerator)
 	case image.DockerDaemonSource:
 		c, err := dockerClient.GetClient()
 		if err != nil {
@@ -46,12 +91,12 @@ func GetImageFromSource(ctx context.Context, imgStr string, source image.Source,
 	case image.OciTarballSource:
 		provider = oci.NewProviderFromTarball(imgStr, tempDirGenerator)
 	case image.OciRegistrySource:
-		provider = oci.NewProviderFromRegistry(imgStr, tempDirGenerator, registryOptions)
+		provider = oci.NewProviderFromRegistry(imgStr, tempDirGenerator, cfg.Registry)
 	default:
 		return nil, fmt.Errorf("unable determine image source")
 	}
 
-	img, err := provider.Provide(ctx)
+	img, err := provider.Provide(ctx, cfg.AdditionalMetadata...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to use %s source: %w", source, err)
 	}
@@ -66,12 +111,12 @@ func GetImageFromSource(ctx context.Context, imgStr string, source image.Source,
 
 // GetImage parses the user provided image string and provides an image object;
 // note: the source where the image should be referenced from is automatically inferred.
-func GetImage(ctx context.Context, userStr string, registryOptions *image.RegistryOptions) (*image.Image, error) {
+func GetImage(ctx context.Context, userStr string, options ...Option) (*image.Image, error) {
 	source, imgStr, err := image.DetectSource(userStr)
 	if err != nil {
 		return nil, err
 	}
-	return GetImageFromSource(ctx, imgStr, source, registryOptions)
+	return GetImageFromSource(ctx, imgStr, source, options...)
 }
 
 func SetLogger(logger logger.Logger) {

--- a/config.go
+++ b/config.go
@@ -1,0 +1,10 @@
+package stereoscope
+
+import (
+	"github.com/anchore/stereoscope/pkg/image"
+)
+
+type config struct {
+	Registry           image.RegistryOptions
+	AdditionalMetadata []image.AdditionalMetadata
+}

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -27,7 +27,7 @@ func main() {
 	//    ./path/to.tar
 	//
 	// This will catalog the file metadata and resolve all squash trees
-	image, err := stereoscope.GetImage(ctx, os.Args[1], nil)
+	image, err := stereoscope.GetImage(ctx, os.Args[1])
 	if err != nil {
 		panic(err)
 	}

--- a/internal/podman/ssh.go
+++ b/internal/podman/ssh.go
@@ -164,7 +164,7 @@ func httpClientOverSSH(params *sshClientConfig) (*http.Client, error) {
 		},
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "connection to bastion host (%s) failed.", params.host)
+		return nil, fmt.Errorf("connection to bastion host=%q failed: %w", params.host, err)
 	}
 
 	return &http.Client{

--- a/option.go
+++ b/option.go
@@ -1,0 +1,3 @@
+package stereoscope
+
+type Option func(*config) error

--- a/pkg/image/oci/directory_provider.go
+++ b/pkg/image/oci/directory_provider.go
@@ -24,7 +24,7 @@ func NewProviderFromPath(path string, tmpDirGen *file.TempDirGenerator) *Directo
 }
 
 // Provide an image object that represents the OCI image as a directory.
-func (p *DirectoryImageProvider) Provide(context.Context) (*image.Image, error) {
+func (p *DirectoryImageProvider) Provide(_ context.Context, userMetadata ...image.AdditionalMetadata) (*image.Image, error) {
 	pathObj, err := layout.FromPath(p.path)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read image from OCI directory path %q: %w", p.path, err)
@@ -60,6 +60,9 @@ func (p *DirectoryImageProvider) Provide(context.Context) (*image.Image, error) 
 	if err == nil {
 		metadata = append(metadata, image.WithManifest(rawManifest))
 	}
+
+	// apply user-supplied metadata last to override any default behavior
+	metadata = append(metadata, userMetadata...)
 
 	contentTempDir, err := p.tmpDirGen.NewDirectory("oci-dir-image")
 	if err != nil {

--- a/pkg/image/oci/registry_provider_test.go
+++ b/pkg/image/oci/registry_provider_test.go
@@ -31,7 +31,7 @@ func Test_prepareReferenceOptions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			out := prepareReferenceOptions(&test.input)
+			out := prepareReferenceOptions(test.input)
 			assert.Equal(t, len(test.expected), len(out))
 			if test.expected == nil {
 				assert.Equal(t, test.expected, out)

--- a/pkg/image/oci/tarball_provider.go
+++ b/pkg/image/oci/tarball_provider.go
@@ -24,7 +24,7 @@ func NewProviderFromTarball(path string, tmpDirGen *file.TempDirGenerator) *Tarb
 }
 
 // Provide an image object that represents the OCI image from a tarball.
-func (p *TarballImageProvider) Provide(ctx context.Context) (*image.Image, error) {
+func (p *TarballImageProvider) Provide(ctx context.Context, metadata ...image.AdditionalMetadata) (*image.Image, error) {
 	// note: we are untaring the image and using the existing directory provider, we could probably enhance the google
 	// container registry lib to do this without needing to untar to a temp dir (https://github.com/google/go-containerregistry/issues/726)
 	f, err := os.Open(p.path)
@@ -41,5 +41,5 @@ func (p *TarballImageProvider) Provide(ctx context.Context) (*image.Image, error
 		return nil, err
 	}
 
-	return NewProviderFromPath(tempDir, p.tmpDirGen).Provide(ctx)
+	return NewProviderFromPath(tempDir, p.tmpDirGen).Provide(ctx, metadata...)
 }

--- a/pkg/image/provider.go
+++ b/pkg/image/provider.go
@@ -5,5 +5,5 @@ import "context"
 // Provider is an abstraction for any object that provides image objects (e.g. the docker daemon API, a tar file of
 // an OCI image, podman varlink API, etc.).
 type Provider interface {
-	Provide(ctx context.Context) (*Image, error)
+	Provide(context.Context, ...AdditionalMetadata) (*Image, error)
 }

--- a/pkg/imagetest/image_fixtures.go
+++ b/pkg/imagetest/image_fixtures.go
@@ -57,7 +57,7 @@ func PrepareFixtureImage(t testing.TB, source, name string) string {
 
 func GetFixtureImage(t testing.TB, source, name string) *image.Image {
 	request := PrepareFixtureImage(t, source, name)
-	
+
 	i, err := stereoscope.GetImage(context.TODO(), request)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -113,7 +113,7 @@ func getFixtureImageFromTar(t testing.TB, tarPath string) *image.Image {
 
 	t.Cleanup(func() {
 		if err := i.Cleanup(); err != nil {
-			t.Errorf("could not cleanup tarPath=%q: %w", tarPath, err)
+			t.Errorf("could not cleanup tarPath=%q: %+v", tarPath, err)
 		}
 	})
 

--- a/pkg/imagetest/image_fixtures.go
+++ b/pkg/imagetest/image_fixtures.go
@@ -57,8 +57,8 @@ func PrepareFixtureImage(t testing.TB, source, name string) string {
 
 func GetFixtureImage(t testing.TB, source, name string) *image.Image {
 	request := PrepareFixtureImage(t, source, name)
-
-	i, err := stereoscope.GetImage(context.TODO(), request, nil)
+	
+	i, err := stereoscope.GetImage(context.TODO(), request)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, i.Cleanup())
@@ -108,7 +108,7 @@ func skopeoCopyDockerArchiveToPath(t testing.TB, dockerArchivePath, destination 
 func getFixtureImageFromTar(t testing.TB, tarPath string) *image.Image {
 	request := fmt.Sprintf("docker-archive:%s", tarPath)
 
-	i, err := stereoscope.GetImage(context.TODO(), request, nil)
+	i, err := stereoscope.GetImage(context.TODO(), request)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/test/integration/fixture_image_simple_test.go
+++ b/test/integration/fixture_image_simple_test.go
@@ -105,10 +105,12 @@ func BenchmarkSimpleImage_GetImage(b *testing.B) {
 		b.Run(c.name, func(b *testing.B) {
 			var bi *image.Image
 			for i := 0; i < b.N; i++ {
-				bi, err = stereoscope.GetImage(context.TODO(), request, nil)
+
+				bi, err = stereoscope.GetImage(context.TODO(), request)
 				b.Cleanup(func() {
 					require.NoError(b, bi.Cleanup())
 				})
+
 				if err != nil {
 					b.Fatal("could not get fixture image:", err)
 				}

--- a/test/integration/mime_type_detection_test.go
+++ b/test/integration/mime_type_detection_test.go
@@ -11,7 +11,9 @@ import (
 
 func TestContentMIMETypeDetection(t *testing.T) {
 	request := imagetest.PrepareFixtureImage(t, "docker-archive", "image-simple")
-	img, err := stereoscope.GetImage(context.TODO(), request, nil)
+
+	img, err := stereoscope.GetImage(context.TODO(), request)
+
 	assert.NoError(t, err)
 	t.Cleanup(stereoscope.Cleanup)
 

--- a/test/integration/oci_registry_source_test.go
+++ b/test/integration/oci_registry_source_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/anchore/stereoscope"
@@ -31,13 +32,12 @@ func TestOciRegistrySourceMetadata(t *testing.T) {
 	ref := fmt.Sprintf("%s@%s", imgStr, digest)
 
 	img, err := stereoscope.GetImage(context.TODO(), "registry:"+ref)
-	if err != nil {
-		t.Fatalf("unable to get image: %+v", err)
-	}
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, img.Cleanup())
+	})
 
-	if err := img.Read(); err != nil {
-		t.Fatalf("failed to read image: %+v", err)
-	}
+	require.NoError(t, img.Read())
 
 	assert.Len(t, img.Metadata.RepoDigests, 1)
 	assert.Equal(t, "index.docker.io/"+ref, img.Metadata.RepoDigests[0])

--- a/test/integration/oci_registry_source_test.go
+++ b/test/integration/oci_registry_source_test.go
@@ -6,9 +6,7 @@ import (
 	"testing"
 
 	"github.com/anchore/stereoscope"
-	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestOciRegistrySourceMetadata(t *testing.T) {
@@ -32,11 +30,10 @@ func TestOciRegistrySourceMetadata(t *testing.T) {
 	imgStr := "anchore/test_images"
 	ref := fmt.Sprintf("%s@%s", imgStr, digest)
 
-	img, err := stereoscope.GetImage(context.TODO(), "registry:"+ref, &image.RegistryOptions{})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, img.Cleanup())
-	})
+	img, err := stereoscope.GetImage(context.TODO(), "registry:"+ref)
+	if err != nil {
+		t.Fatalf("unable to get image: %+v", err)
+	}
 
 	if err := img.Read(); err != nil {
 		t.Fatalf("failed to read image: %+v", err)

--- a/test/integration/podman_test.go
+++ b/test/integration/podman_test.go
@@ -105,15 +105,15 @@ func TestPodmanConnections(t *testing.T) {
 
 			tt.setup(t)
 			c, err := tt.constructor()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotEmpty(t, c.ClientVersion())
 
 			p, err := c.Ping(context.Background())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, p)
 
 			version, err := c.ServerVersion(context.Background())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotEmpty(t, version)
 		})
 	}


### PR DESCRIPTION
This PR does a few things:
1. encapsulates data passed to individual image providers as functional options
2. surfaces `image.AdditionalMetadata` and `image.RegistryOptions` through new functional options
3. upgrades the linter version + configuration