### PR TITLE
upgrade github validations to go 1.17

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -14,7 +14,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.16.x"
+  GO_VERSION: "1.17.x"
 
 jobs:
 


### PR DESCRIPTION
Signed-off-by: Jonas Galvão Xavier <jonas.agx@gmail.com>