### PR TITLE
Extract out the pull source detector from source detection path

### DIFF
--- a/pkg/image/source.go
+++ b/pkg/image/source.go
@@ -109,7 +109,6 @@ func detectSource(fs afero.Fs, userInput string) (Source, string, error) {
 		source = ParseSourceScheme(sourceHint)
 	default:
 		source = UnknownSource
-
 	}
 
 	switch source {

--- a/pkg/image/source.go
+++ b/pkg/image/source.go
@@ -109,7 +109,7 @@ func detectSource(fs afero.Fs, userInput string) (Source, string, error) {
 		source = ParseSourceScheme(sourceHint)
 	default:
 		source = UnknownSource
-		location = ""
+
 	}
 
 	switch source {
@@ -119,6 +119,8 @@ func detectSource(fs afero.Fs, userInput string) (Source, string, error) {
 		if err != nil {
 			return UnknownSource, "", fmt.Errorf("unable to expand potential home dir expression: %w", err)
 		}
+	case UnknownSource:
+		location = ""
 	}
 
 	return source, location, nil

--- a/pkg/image/source.go
+++ b/pkg/image/source.go
@@ -109,6 +109,7 @@ func detectSource(fs afero.Fs, userInput string) (Source, string, error) {
 		source = ParseSourceScheme(sourceHint)
 	default:
 		source = UnknownSource
+		location = ""
 	}
 
 	switch source {
@@ -118,25 +119,17 @@ func detectSource(fs afero.Fs, userInput string) (Source, string, error) {
 		if err != nil {
 			return UnknownSource, "", fmt.Errorf("unable to expand potential home dir expression: %w", err)
 		}
-	case UnknownSource:
-		// Ignore any source hint since the source is still unknown. See if this could be a Docker image.
-		if imagePullSource := DetermineImagePullSource(userInput); imagePullSource != UnknownSource {
-			return imagePullSource, userInput, nil
-		}
-
-		// Invalidate any previous processing if the source is still unknown.
-		location = ""
 	}
 
 	return source, location, nil
 }
 
-// DetermineImagePullSource takes an image reference string as input, and
+// DetermineDefaultImagePullSource takes an image reference string as input, and
 // determines a Source to use to pull the image. If the input doesn't specify an
 // image reference (i.e. an image that can be _pulled_), UnknownSource is
 // returned. Otherwise, if the Docker daemon is available, DockerDaemonSource is
 // returned, and if not, OciRegistrySource is returned.
-func DetermineImagePullSource(userInput string) Source {
+func DetermineDefaultImagePullSource(userInput string) Source {
 	if !isRegistryReference(userInput) {
 		return UnknownSource
 	}

--- a/pkg/image/source_test.go
+++ b/pkg/image/source_test.go
@@ -36,8 +36,8 @@ func TestDetectSource(t *testing.T) {
 		{
 			name:             "docker-engine-by-possible-id",
 			input:            "a5e",
-			source:           DockerDaemonSource,
-			expectedLocation: "a5e",
+			source:           UnknownSource,
+			expectedLocation: "",
 		},
 		{
 			name: "docker-engine-impossible-id",
@@ -75,8 +75,8 @@ func TestDetectSource(t *testing.T) {
 		{
 			name:             "infer-docker-engine",
 			input:            "something/something:latest",
-			source:           DockerDaemonSource,
-			expectedLocation: "something/something:latest",
+			source:           UnknownSource,
+			expectedLocation: "",
 		},
 		{
 			name:             "bad-hint",
@@ -113,8 +113,8 @@ func TestDetectSource(t *testing.T) {
 		{
 			name:             "unparsable-existing-path",
 			input:            "a-potential/path",
-			source:           DockerDaemonSource,
-			expectedLocation: "a-potential/path",
+			source:           UnknownSource,
+			expectedLocation: "",
 			tarPath:          "a-potential/path",
 			tarPaths:         []string{},
 		},


### PR DESCRIPTION
This gives the caller the ability to do some automatic determination when the source is unknown (as opposed to taking action here in `detectSource`) --let the caller decide.