### PR TITLE
Reduce event runs in CI

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -10,7 +10,10 @@ on:
         description: "Tmate session duration"
         required: false
         default: 5
+
   push:
+    branches:
+      - main
   pull_request:
 
 env:


### PR DESCRIPTION
Similar to the changes made in syft and grype recently, let's cool off how many CI runs we perform