### PR TITLE
expand lazy reader interface

### DIFF
--- a/pkg/file/lazy_bounded_read_closer.go
+++ b/pkg/file/lazy_bounded_read_closer.go
@@ -8,7 +8,7 @@ import (
 
 var _ io.ReadCloser = (*lazyBoundedReadCloser)(nil)
 var _ io.ReaderAt = (*lazyBoundedReadCloser)(nil)
-var _ LazyReader = (*lazyBoundedReadCloser)(nil)
+var _ io.Seeker = (*lazyBoundedReadCloser)(nil)
 
 // lazyBoundedReadCloser is a "lazy" read closer, allocating a file descriptor for the given path only upon the first Read() call.
 // Only part of the file is allowed to be read, starting at a given position.

--- a/pkg/file/lazy_bounded_read_closer.go
+++ b/pkg/file/lazy_bounded_read_closer.go
@@ -7,16 +7,18 @@ import (
 )
 
 var _ io.ReadCloser = (*lazyBoundedReadCloser)(nil)
+var _ io.ReaderAt = (*lazyBoundedReadCloser)(nil)
+var _ LazyReader = (*lazyBoundedReadCloser)(nil)
 
 // lazyBoundedReadCloser is a "lazy" read closer, allocating a file descriptor for the given path only upon the first Read() call.
-// Additionally only part of the file is allowed to be read, starting at a given position.
+// Only part of the file is allowed to be read, starting at a given position.
 type lazyBoundedReadCloser struct {
 	// path is the path to be opened
 	path string
 	// file is the active file handle for the given path
 	file *os.File
 	// reader is the LimitedReader that wraps the open file
-	reader io.Reader
+	reader *io.SectionReader
 	start  int64
 	size   int64
 }
@@ -32,20 +34,10 @@ func newLazyBoundedReadCloser(path string, start, size int64) *lazyBoundedReadCl
 
 // Read implements the io.Reader interface for the previously loaded path, opening the file upon the first invocation.
 func (d *lazyBoundedReadCloser) Read(b []byte) (int, error) {
-	if d.reader == nil {
-		file, err := os.Open(d.path)
-		if err != nil {
-			return 0, err
-		}
-
-		_, err = file.Seek(d.start, io.SeekStart)
-		if err != nil {
-			return 0, err
-		}
-
-		d.file = file
-		d.reader = io.LimitReader(d.file, d.size)
+	if err := d.isFileOpen(); err != nil {
+		return 0, err
 	}
+
 	n, err := d.reader.Read(b)
 	if err != nil && errors.Is(err, io.EOF) {
 		// we've reached the end of the file, force a release of the file descriptor. If the file has already been
@@ -71,4 +63,43 @@ func (d *lazyBoundedReadCloser) Close() error {
 	d.file = nil
 	d.reader = nil
 	return err
+}
+
+func (d *lazyBoundedReadCloser) Seek(offset int64, whence int) (int64, error) {
+	if err := d.isFileOpen(); err != nil {
+		return 0, err
+	}
+
+	return d.reader.Seek(offset, whence)
+}
+
+func (d *lazyBoundedReadCloser) ReadAt(b []byte, off int64) (n int, err error) {
+	if err := d.isFileOpen(); err != nil {
+		return 0, err
+	}
+
+	n, err = d.reader.ReadAt(b, off)
+	if err != nil && errors.Is(err, io.EOF) {
+		// we've reached the end of the file, force a release of the file descriptor. If the file has already been
+		// closed, ignore the error.
+		if closeErr := d.file.Close(); !errors.Is(closeErr, os.ErrClosed) {
+			return n, closeErr
+		}
+	}
+	return n, err
+}
+
+func (d *lazyBoundedReadCloser) isFileOpen() error {
+	if d.reader != nil {
+		return nil
+	}
+
+	file, err := os.Open(d.path)
+	if err != nil {
+		return err
+	}
+
+	d.file = file
+	d.reader = io.NewSectionReader(d.file, d.start, d.size)
+	return nil
 }

--- a/pkg/file/lazy_bounded_read_closer.go
+++ b/pkg/file/lazy_bounded_read_closer.go
@@ -34,7 +34,7 @@ func newLazyBoundedReadCloser(path string, start, size int64) *lazyBoundedReadCl
 
 // Read implements the io.Reader interface for the previously loaded path, opening the file upon the first invocation.
 func (d *lazyBoundedReadCloser) Read(b []byte) (int, error) {
-	if err := d.isFileOpen(); err != nil {
+	if err := d.openFile(); err != nil {
 		return 0, err
 	}
 
@@ -66,7 +66,7 @@ func (d *lazyBoundedReadCloser) Close() error {
 }
 
 func (d *lazyBoundedReadCloser) Seek(offset int64, whence int) (int64, error) {
-	if err := d.isFileOpen(); err != nil {
+	if err := d.openFile(); err != nil {
 		return 0, err
 	}
 
@@ -74,7 +74,7 @@ func (d *lazyBoundedReadCloser) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (d *lazyBoundedReadCloser) ReadAt(b []byte, off int64) (n int, err error) {
-	if err := d.isFileOpen(); err != nil {
+	if err := d.openFile(); err != nil {
 		return 0, err
 	}
 
@@ -89,7 +89,7 @@ func (d *lazyBoundedReadCloser) ReadAt(b []byte, off int64) (n int, err error) {
 	return n, err
 }
 
-func (d *lazyBoundedReadCloser) isFileOpen() error {
+func (d *lazyBoundedReadCloser) openFile() error {
 	if d.reader != nil {
 		return nil
 	}

--- a/pkg/file/lazy_bounded_read_closer_test.go
+++ b/pkg/file/lazy_bounded_read_closer_test.go
@@ -1,114 +1,48 @@
 package file
 
 import (
-	"bytes"
-	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func getFixture(t *testing.T, filepath string) []byte {
+	p := "test-fixtures/a-file.txt"
+	fh, err := os.Open(p)
+	require.NoError(t, err)
+	expectedContents, err := ioutil.ReadAll(fh)
+	require.NoError(t, err)
+
+	return expectedContents
+}
 
 func TestDeferredPartialReadCloser(t *testing.T) {
 	p := "test-fixtures/a-file.txt"
-	fh, err := os.Open(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectedContents, err := ioutil.ReadAll(fh)
-	if err != nil {
-		t.Fatal(err)
-	}
+	contents := getFixture(t, p)
 
-	dReader := newLazyBoundedReadCloser(p, 0, int64(len(expectedContents)))
-
-	if dReader.file != nil {
-		t.Fatalf("should not have a file, but we do somehow")
-	}
+	dReader := newLazyBoundedReadCloser(p, 0, int64(len(contents)))
+	require.Nil(t, dReader.file)
 
 	actualContents, err := ioutil.ReadAll(dReader)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if !bytes.Equal(expectedContents, actualContents) {
-		t.Fatalf("unexpected contents: %s", string(actualContents))
-	}
+	require.Equal(t, contents, actualContents)
+	require.NotNil(t, dReader.file)
 
-	if dReader.file == nil {
-		t.Fatalf("should have a file, but we do not somehow")
-	}
-
-	if err := dReader.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	if dReader.file != nil {
-		t.Fatalf("should not have a file, but we do somehow")
-	}
+	require.NoError(t, dReader.Close())
+	require.Nil(t, dReader.file, "should not have a file, but we do somehow")
 }
 
 func TestDeferredPartialReadCloser_PartialRead(t *testing.T) {
 	p := "test-fixtures/a-file.txt"
-	fh, err := os.Open(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	contents, err := ioutil.ReadAll(fh)
-	if err != nil {
-		t.Fatal(err)
-	}
+	contents := getFixture(t, p)
 
-	var start, size = 10, 7
-	dReader := newLazyBoundedReadCloser(p, int64(start), int64(size))
+	var start, size int64 = 10, 7
+	dReader := newLazyBoundedReadCloser(p, start, size)
 
 	actualContents, err := ioutil.ReadAll(dReader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(contents[start:start+size], actualContents) {
-		t.Fatalf("unexpected contents: %s", string(actualContents))
-	}
-
-}
-
-func Test_lazyBoundedReadCloser_Read(t *testing.T) {
-	type fields struct {
-		path   string
-		file   *os.File
-		reader *io.SectionReader
-		start  int64
-		size   int64
-	}
-	type args struct {
-		b []byte
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    int
-		wantErr assert.ErrorAssertionFunc
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			d := &lazyBoundedReadCloser{
-				path:   tt.fields.path,
-				file:   tt.fields.file,
-				reader: tt.fields.reader,
-				start:  tt.fields.start,
-				size:   tt.fields.size,
-			}
-			got, err := d.Read(tt.args.b)
-			if !tt.wantErr(t, err, fmt.Sprintf("Read(%v)", tt.args.b)) {
-				return
-			}
-			assert.Equalf(t, tt.want, got, "Read(%v)", tt.args.b)
-		})
-	}
+	require.NoError(t, err)
+	require.Equal(t, contents[start:start+size], actualContents)
 }

--- a/pkg/file/lazy_bounded_read_closer_test.go
+++ b/pkg/file/lazy_bounded_read_closer_test.go
@@ -2,9 +2,13 @@ package file
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDeferredPartialReadCloser(t *testing.T) {
@@ -69,4 +73,42 @@ func TestDeferredPartialReadCloser_PartialRead(t *testing.T) {
 		t.Fatalf("unexpected contents: %s", string(actualContents))
 	}
 
+}
+
+func Test_lazyBoundedReadCloser_Read(t *testing.T) {
+	type fields struct {
+		path   string
+		file   *os.File
+		reader *io.SectionReader
+		start  int64
+		size   int64
+	}
+	type args struct {
+		b []byte
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    int
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &lazyBoundedReadCloser{
+				path:   tt.fields.path,
+				file:   tt.fields.file,
+				reader: tt.fields.reader,
+				start:  tt.fields.start,
+				size:   tt.fields.size,
+			}
+			got, err := d.Read(tt.args.b)
+			if !tt.wantErr(t, err, fmt.Sprintf("Read(%v)", tt.args.b)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "Read(%v)", tt.args.b)
+		})
+	}
 }

--- a/pkg/file/lazy_read_closer.go
+++ b/pkg/file/lazy_read_closer.go
@@ -27,7 +27,7 @@ func NewLazyReadCloser(path string) *LazyReadCloser {
 
 // Read implements the io.Reader interface for the previously loaded path, opening the file upon the first invocation.
 func (d *LazyReadCloser) Read(b []byte) (n int, err error) {
-	if err := d.isFileOpen(); err != nil {
+	if err := d.openFile(); err != nil {
 		return 0, err
 	}
 	return d.file.Read(b)
@@ -48,7 +48,7 @@ func (d *LazyReadCloser) Close() error {
 }
 
 func (d *LazyReadCloser) Seek(offset int64, whence int) (int64, error) {
-	if err := d.isFileOpen(); err != nil {
+	if err := d.openFile(); err != nil {
 		return 0, err
 	}
 
@@ -56,14 +56,14 @@ func (d *LazyReadCloser) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (d *LazyReadCloser) ReadAt(p []byte, off int64) (n int, err error) {
-	if err := d.isFileOpen(); err != nil {
+	if err := d.openFile(); err != nil {
 		return 0, err
 	}
 
 	return d.file.ReadAt(p, off)
 }
 
-func (d *LazyReadCloser) isFileOpen() error {
+func (d *LazyReadCloser) openFile() error {
 	if d.file != nil {
 		return nil
 	}

--- a/pkg/file/lazy_read_closer.go
+++ b/pkg/file/lazy_read_closer.go
@@ -7,16 +7,8 @@ import (
 )
 
 var _ io.ReadCloser = (*LazyReadCloser)(nil)
-var _ LazyReader = (*LazyReadCloser)(nil)
-
-// LazyReader is a single interface with all reading functions we want to use
-// across clients. The transition from io.ReadCloser should happen gradually.
-type LazyReader interface {
-	io.Reader
-	io.ReaderAt
-	io.Seeker
-	io.Closer
-}
+var _ io.Seeker = (*LazyReadCloser)(nil)
+var _ io.ReaderAt = (*LazyReadCloser)(nil)
 
 // LazyReadCloser is a "lazy" read closer, allocating a file descriptor for the given path only upon the first Read() call.
 type LazyReadCloser struct {

--- a/pkg/file/lazy_read_closer.go
+++ b/pkg/file/lazy_read_closer.go
@@ -7,6 +7,16 @@ import (
 )
 
 var _ io.ReadCloser = (*LazyReadCloser)(nil)
+var _ LazyReader = (*LazyReadCloser)(nil)
+
+// LazyReader is a single interface with all reading functions we want to use
+// across clients. The transition from io.ReadCloser should happen gradually.
+type LazyReader interface {
+	io.Reader
+	io.ReaderAt
+	io.Seeker
+	io.Closer
+}
 
 // LazyReadCloser is a "lazy" read closer, allocating a file descriptor for the given path only upon the first Read() call.
 type LazyReadCloser struct {
@@ -25,12 +35,15 @@ func NewLazyReadCloser(path string) *LazyReadCloser {
 
 // Read implements the io.Reader interface for the previously loaded path, opening the file upon the first invocation.
 func (d *LazyReadCloser) Read(b []byte) (n int, err error) {
-	if d.file == nil {
-		var err error
-		d.file, err = os.Open(d.path)
-		if err != nil {
-			return 0, err
-		}
+	//if d.file == nil {
+	//	var err error
+	//	d.file, err = os.Open(d.path)
+	//	if err != nil {
+	//		return 0, err
+	//	}
+	//}
+	if err := d.isFileOpen(); err != nil {
+		return 0, err
 	}
 	return d.file.Read(b)
 }
@@ -46,5 +59,31 @@ func (d *LazyReadCloser) Close() error {
 		err = nil
 	}
 	d.file = nil
+	return err
+}
+
+func (d *LazyReadCloser) Seek(offset int64, whence int) (int64, error) {
+	if err := d.isFileOpen(); err != nil {
+		return 0, err
+	}
+
+	return d.file.Seek(offset, whence)
+}
+
+func (d *LazyReadCloser) ReadAt(p []byte, off int64) (n int, err error) {
+	if err := d.isFileOpen(); err != nil {
+		return 0, err
+	}
+
+	return d.file.ReadAt(p, off)
+}
+
+func (d *LazyReadCloser) isFileOpen() error {
+	if d.file != nil {
+		return nil
+	}
+
+	var err error
+	d.file, err = os.Open(d.path)
 	return err
 }

--- a/pkg/file/lazy_read_closer.go
+++ b/pkg/file/lazy_read_closer.go
@@ -35,13 +35,6 @@ func NewLazyReadCloser(path string) *LazyReadCloser {
 
 // Read implements the io.Reader interface for the previously loaded path, opening the file upon the first invocation.
 func (d *LazyReadCloser) Read(b []byte) (n int, err error) {
-	//if d.file == nil {
-	//	var err error
-	//	d.file, err = os.Open(d.path)
-	//	if err != nil {
-	//		return 0, err
-	//	}
-	//}
 	if err := d.isFileOpen(); err != nil {
 		return 0, err
 	}

--- a/pkg/file/lazy_read_closer_test.go
+++ b/pkg/file/lazy_read_closer_test.go
@@ -1,47 +1,44 @@
 package file
 
 import (
-	"bytes"
 	"io/ioutil"
-	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeferredReadCloser(t *testing.T) {
-	p := "test-fixtures/a-file.txt"
-	fh, err := os.Open(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectedContents, err := ioutil.ReadAll(fh)
-	if err != nil {
-		t.Fatal(err)
-	}
+	filepath := "test-fixtures/a-file.txt"
+	allContent := getFixture(t, filepath)
 
-	dReader := NewLazyReadCloser(p)
-
-	if dReader.file != nil {
-		t.Fatalf("should not have a file, but we do somehow")
-	}
+	dReader := NewLazyReadCloser(filepath)
+	require.Nil(t, dReader.file, "should not have a file, but we do somehow")
 
 	actualContents, err := ioutil.ReadAll(dReader)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NotNil(t, dReader.file, "should have a file, but we do not somehow")
+	require.NoError(t, err)
+	require.Equal(t, allContent, actualContents)
 
-	if !bytes.Equal(expectedContents, actualContents) {
-		t.Fatalf("unexpected contents: %s", string(actualContents))
-	}
+	require.NoError(t, dReader.Close())
+	require.Nil(t, dReader.file, "should not have a file, but we do somehow")
+}
 
-	if dReader.file == nil {
-		t.Fatalf("should have a file, but we do not somehow")
-	}
+func TestLazyReader_ReatAt(t *testing.T) {
+	filepath := "test-fixtures/a-file.txt"
+	allContent := getFixture(t, filepath)
 
-	if err := dReader.Close(); err != nil {
-		t.Fatal(err)
-	}
+	dReader := NewLazyReadCloser(filepath)
+	require.Nil(t, dReader.file, "should not have a file, but we do somehow")
 
-	if dReader.file != nil {
-		t.Fatalf("should not have a file, but we do somehow")
-	}
+	off := 5
+	left := len(allContent) - off
+	s := make([]byte, left)
+	n, err := dReader.ReadAt(s, int64(off))
+	require.NoError(t, err)
+	require.Equal(t, left, n)
+	require.Equal(t, allContent[off:], s)
+
+	require.NoError(t, dReader.Close())
+	require.Nil(t, dReader.file, "should not have a file, but we do somehow")
+
 }

--- a/pkg/file/lazy_read_closer_test.go
+++ b/pkg/file/lazy_read_closer_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"io"
 	"io/ioutil"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestDeferredReadCloser(t *testing.T) {
 	require.Nil(t, dReader.file, "should not have a file, but we do somehow")
 }
 
-func TestLazyReader_ReatAt(t *testing.T) {
+func TestLazyReader_ReadAt(t *testing.T) {
 	filepath := "test-fixtures/a-file.txt"
 	allContent := getFixture(t, filepath)
 
@@ -41,4 +42,27 @@ func TestLazyReader_ReatAt(t *testing.T) {
 	require.NoError(t, dReader.Close())
 	require.Nil(t, dReader.file, "should not have a file, but we do somehow")
 
+}
+
+func TestLazyReader_Seek(t *testing.T) {
+	filepath := "test-fixtures/a-file.txt"
+	allContent := getFixture(t, filepath)
+
+	dReader := NewLazyReadCloser(filepath)
+	require.Nil(t, dReader.file, "should not have a file, but we do somehow")
+
+	off := 5
+	left := len(allContent) - off
+	s := make([]byte, left)
+	seek, err := dReader.Seek(int64(off), io.SeekStart)
+	require.NoError(t, err)
+	require.Equal(t, seek, int64(off))
+
+	n, err := dReader.Read(s)
+	require.NoError(t, err)
+	require.Equal(t, left, n)
+	require.Equal(t, allContent[off:], s)
+
+	require.NoError(t, dReader.Close())
+	require.Nil(t, dReader.file, "should not have a file, but we do somehow")
 }


### PR DESCRIPTION
TLDR; Expands lazy reader interface to support io.ReadAt, which is necessary for cataloging golang binaries.

If that interface makes sense for other use cases let's expand it for more catalogers and file resolvers.
Helps with https://github.com/anchore/syft/issues/718
Signed-off-by: Jonas Galvão Xavier <jonas.agx@gmail.com>