### PR TITLE
Skip cleanup for non-existent images

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -305,6 +305,9 @@ func (i *Image) ResolveLinkByImageSquash(ref file.Reference, options ...filetree
 
 // Cleanup removes all temporary files created from parsing the image. Future calls to image will not function correctly after this call.
 func (i *Image) Cleanup() error {
+	if i == nil {
+		return nil
+	}
 	if i.contentCacheDir != "" {
 		if err := os.RemoveAll(i.contentCacheDir); err != nil {
 			return err


### PR DESCRIPTION
Should always be safe to call Cleanup on an image, even if it wasn't created (makes it easier for the caller)

Existing problem:
```
$ syft  docker:alpine:latest
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x45a5d74]

goroutine 70 [running]:
github.com/anchore/stereoscope/pkg/image.(*Image).Cleanup(0xc00014c0c0?)
        /Users/wagoodman/.gvm/pkgsets/go1.18/global/pkg/mod/github.com/anchore/stereoscope@v0.0.0-20220315185520-25183ec78f40/pkg/image/image.go:308 +0x14
github.com/anchore/syft/syft/source.getImageWithRetryStrategy.func2()
        /Users/wagoodman/code/syft/syft/source/source.go:199 +0x2d
github.com/anchore/syft/cmd.packagesExecWorker.func1()
        /Users/wagoodman/code/syft/cmd/packages.go:305 +0x319
created by github.com/anchore/syft/cmd.packagesExecWorker
        /Users/wagoodman/code/syft/cmd/packages.go:296 +0x10a
exit status 2

```