### PR TITLE
Respond to docker TLS config options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	// docker/distribution for https://github.com/advisories/GHSA-qq97-vm5h-rrhg
 	github.com/docker/distribution v2.8.0+incompatible // indirect
 	github.com/docker/docker v20.10.12+incompatible
+	github.com/docker/go-connections v0.4.0
 	github.com/fvbommel/sortorder v1.0.2 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.0
 	github.com/go-test/deep v1.0.8


### PR DESCRIPTION
This PR is a follow up to https://github.com/anchore/stereoscope/pull/114:
- Removes the `client.FromEnv` which is not a compatible open when getting options from the `DockerEndpoint` object
- Adds TLS-specific configuration to the common flags used to generate the client