### PR TITLE
Bump strset version to fix 386 builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,8 @@ require (
 	github.com/moby/sys/mount v0.3.1 // indirect
 	github.com/pelletier/go-toml v1.9.3
 	github.com/pkg/errors v0.9.1
-	github.com/scylladb/go-set v1.0.2
+	// pinned to pull in 386 arch fix: https://github.com/scylladb/go-set/commit/cc7b2070d91ebf40d233207b633e28f5bd8f03a5
+	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e
 	github.com/sergi/go-diff v1.1.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -723,8 +723,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
-github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
+github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e h1:7q6NSFZDeGfvvtIRwBrU/aegEYJYmvev0cHAwo17zZQ=
+github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=


### PR DESCRIPTION
Pull in fix from https://github.com/scylladb/go-set/commit/cc7b2070d91ebf40d233207b633e28f5bd8f03a5 to prevent compile issues on 32 bit architectures:

```bash
$ GOOS=linux GOARCH=386 go build  -o /tmp/out examples/basic.go
# github.com/scylladb/go-set/strset
../../.gvm/pkgsets/go1.18/global/pkg/mod/github.com/scylladb/go-set@v1.0.2/strset/strset.go:248:13: cannot use math.MaxInt64 (untyped int constant 9223372036854775807) as int value in assignment (overflows)
../../.gvm/pkgsets/go1.18/global/pkg/mod/github.com/scylladb/go-set@v1.0.2/strset/strset.go:255:16: math.MaxInt64 (untyped int constant 9223372036854775807) overflows int

$ go get -d github.com/scylladb/go-set@master
go: downloading github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e
go: upgraded github.com/scylladb/go-set v1.0.2 => v1.0.3-0.20200225121959-cc7b2070d91e

$ GOOS=linux GOARCH=386 go build  -o /tmp/out examples/basic.go
# success!
```