### PR TITLE
Correct docker auth config usage

### DIFF
--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -156,12 +156,13 @@ func (p *DaemonImageProvider) pullOptions() (types.ImagePullOptions, error) {
 
 	url, err := authURL(p.imageStr)
 	if err != nil {
-		return options, fmt.Errorf("unable to determine auth hostname: %w", err)
+		log.Warnf("failed to determine auth url from image=%q: %+v", p.imageStr, err)
+		return options, nil
 	}
 
 	authConfig, err := cfg.GetAuthConfig(url)
 	if err != nil {
-		log.Warnf("failed to fetch registry auth (hostname=%s): %+v", url, err)
+		log.Warnf("failed to fetch registry auth (url=%s): %+v", url, err)
 		return options, nil
 	}
 
@@ -169,7 +170,7 @@ func (p *DaemonImageProvider) pullOptions() (types.ImagePullOptions, error) {
 
 	options.RegistryAuth, err = encodeCredentials(authConfig)
 	if err != nil {
-		log.Warnf("failed to encode registry auth (hostname=%s): %+v", url, err)
+		log.Warnf("failed to encode registry auth (url=%s): %+v", url, err)
 	}
 
 	return options, nil

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -160,6 +160,12 @@ func (p *DaemonImageProvider) pullOptions() (types.ImagePullOptions, error) {
 	}
 
 	hostname := ref.Context().RegistryStr()
+	if hostname == "index.docker.io" {
+		// why do this? There is an upstream issue here: https://github.com/docker/docker-credential-helpers/blob/e595cd69465c6b0f7af2d49582b82fdeddecbf75/wincred/wincred_windows.go#L113-L127
+		// where the hostname used for the auth config lookup requires this or else even pulling public images
+		// will fail with auth related problems (bad username/password, bad personal access token, etc).
+		hostname += "/v1/"
+	}
 
 	authConfig, err := cfg.GetAuthConfig(hostname)
 	if err != nil {

--- a/pkg/image/docker/daemon_provider_test.go
+++ b/pkg/image/docker/daemon_provider_test.go
@@ -35,3 +35,38 @@ func TestEncodeCredentials(t *testing.T) {
 	assert.Equal(t, user, actualCfg.Username)
 	assert.Equal(t, pass, actualCfg.Password)
 }
+
+func Test_authURL(t *testing.T) {
+	tests := []struct {
+		imageStr string
+		want     string
+		wantErr  require.ErrorAssertionFunc
+	}{
+		{
+			imageStr: "alpine:latest",
+			want:     "index.docker.io/v1/",
+		},
+		{
+			imageStr: "myhost.io/alpine:latest",
+			want:     "myhost.io",
+		},
+		{
+			imageStr: "someone/something:latest",
+			want:     "index.docker.io/v1/",
+		},
+		{
+			imageStr: "somewhere.io/someone/something:latest",
+			want:     "somewhere.io",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.imageStr, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+			got, err := authURL(tt.imageStr)
+			tt.wantErr(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/image/docker/daemon_provider_test.go
+++ b/pkg/image/docker/daemon_provider_test.go
@@ -58,6 +58,10 @@ func Test_authURL(t *testing.T) {
 			imageStr: "somewhere.io/someone/something:latest",
 			want:     "somewhere.io",
 		},
+		{
+			imageStr: "host.io:5000/image:latest",
+			want:     "host.io:5000",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.imageStr, func(t *testing.T) {


### PR DESCRIPTION
This PR makes a few alterations:
- Passes the entire auth config along into docker pull options (not just the username/password portion)
- Some user auth configurations can lead to error messages indicating bad username/password or bad personal access token, even when pulling public images from dockerhub. The fix was to ensure that auth URLs used for `index.docker.io` should resolve to `index.docker.io/v1/`.

Huge thanks to @thaJeztah , @crazy-max, and @chris-crone on troubleshooting this and finding a fix!