### PR TITLE
Allow scheme separator in path for detector

### DIFF
--- a/pkg/image/source_test.go
+++ b/pkg/image/source_test.go
@@ -135,6 +135,14 @@ func TestDetectSource(t *testing.T) {
 			tarPath:          "~/a-potential/path",
 			tarPaths:         []string{"oci-layout"},
 		},
+		{
+			name:             "oci-tar-path-with-scheme-separator",
+			input:            "a-potential/path:version",
+			source:           OciTarballSource,
+			expectedLocation: "a-potential/path:version",
+			tarPath:          "a-potential/path:version",
+			tarPaths:         []string{"oci-layout"},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
This is to fix this https://github.com/anchore/stereoscope/issues/119. I ran into this issue when including ":" in a docker archive path and not specifying the scheme. This changes to call `detectSourceFromPath` if the scheme hint is invalid. I think this should be safe (for something like a docker image reference) since `detectSourceFromPath` method checks to see if the path exists.