### PR TITLE
Add locking to FileCatalog

### DIFF
--- a/pkg/image/file_catalog.go
+++ b/pkg/image/file_catalog.go
@@ -3,6 +3,7 @@ package image
 import (
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/anchore/stereoscope/pkg/file"
 )
@@ -12,6 +13,7 @@ var ErrFileNotFound = fmt.Errorf("could not find file")
 // FileCatalog represents all file metadata and source tracing for all files contained within the image layer
 // blobs (i.e. everything except for the image index/manifest/metadata files).
 type FileCatalog struct {
+	sync.RWMutex
 	catalog    map[file.ID]FileCatalogEntry
 	byMIMEType map[string][]file.ID
 }
@@ -35,6 +37,8 @@ func NewFileCatalog() FileCatalog {
 // Add creates a new FileCatalogEntry for the given file reference and metadata, cataloged by the ID of the
 // file reference (overwriting any existing entries without warning).
 func (c *FileCatalog) Add(f file.Reference, m file.Metadata, l *Layer, opener file.Opener) {
+	c.Lock()
+	defer c.Unlock()
 	if m.MIMEType != "" {
 		// an empty MIME type means that we didn't have the contents of the file to determine the MIME type. If we have
 		// the contents and the MIME type could not be determined then the default value is application/octet-stream.
@@ -50,6 +54,8 @@ func (c *FileCatalog) Add(f file.Reference, m file.Metadata, l *Layer, opener fi
 
 // Exists indicates if the given file reference exists in the catalog.
 func (c *FileCatalog) Exists(f file.Reference) bool {
+	c.RLock()
+	defer c.RUnlock()
 	_, ok := c.catalog[f.ID()]
 	return ok
 }
@@ -57,6 +63,8 @@ func (c *FileCatalog) Exists(f file.Reference) bool {
 // Get fetches a FileCatalogEntry for the given file reference, or returns an error if the file reference has not
 // been added to the catalog.
 func (c *FileCatalog) Get(f file.Reference) (FileCatalogEntry, error) {
+	c.RLock()
+	defer c.RUnlock()
 	value, ok := c.catalog[f.ID()]
 	if !ok {
 		return FileCatalogEntry{}, ErrFileNotFound
@@ -65,6 +73,8 @@ func (c *FileCatalog) Get(f file.Reference) (FileCatalogEntry, error) {
 }
 
 func (c *FileCatalog) GetByMIMEType(mType string) ([]FileCatalogEntry, error) {
+	c.RLock()
+	defer c.RUnlock()
 	fileIDs, ok := c.byMIMEType[mType]
 	if !ok {
 		return nil, nil
@@ -84,6 +94,8 @@ func (c *FileCatalog) GetByMIMEType(mType string) ([]FileCatalogEntry, error) {
 // FetchContents reads the file contents for the given file reference from the underlying image/layer blob. An error
 // is returned if there is no file at the given path and layer or the read operation cannot continue.
 func (c *FileCatalog) FileContents(f file.Reference) (io.ReadCloser, error) {
+	c.RLock()
+	defer c.RUnlock()
 	catalogEntry, ok := c.catalog[f.ID()]
 	if !ok {
 		return nil, fmt.Errorf("could not find file: %+v", f.RealPath)


### PR DESCRIPTION
Adds a sync.RWMutex to FileCatalog to prevent concurrent use of `source.FileResolver` on the same image from causing a concurrent map write panic.

This is a prerequisite to making Catalogers safe to use concurrently.