### PR TITLE
Remove replace directive for sylabs/squashfs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/anchore/stereoscope
 go 1.16
 
 require (
-	github.com/CalebQ42/squashfs v0.5.4
 	github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220517224237-e6f29200ae04
@@ -28,10 +27,8 @@ require (
 	github.com/spf13/afero v1.6.0
 	github.com/stretchr/testify v1.7.0
 	github.com/sylabs/sif/v2 v2.7.0
+	github.com/sylabs/squashfs v0.5.5-0.20220803145443-2636f95ece7f
 	github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d
 	github.com/wagoodman/go-progress v0.0.0-20200621122631-1a2120f0695a
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 )
-
-// Forked to remove https://github.com/rasky/go-lzo dependency, which is GPLv2 licensed.
-replace github.com/CalebQ42/squashfs => github.com/sylabs/squashfs v0.5.5-0.20220526223455-67e0f4cd95c5

--- a/go.sum
+++ b/go.sum
@@ -777,8 +777,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/sylabs/sif/v2 v2.7.0 h1:VFzN8alnJ/3n1JA0K9DyUtfSzezWgWrzLDcYGhgBskk=
 github.com/sylabs/sif/v2 v2.7.0/go.mod h1:TiyBWsgWeh5yBeQFNuQnvROwswqK7YJT8JA1L53bsXQ=
-github.com/sylabs/squashfs v0.5.5-0.20220526223455-67e0f4cd95c5 h1:cFtGHruT2MgOXuJXoUsVa3YnMjWRLyfWQimYqgHfEYQ=
-github.com/sylabs/squashfs v0.5.5-0.20220526223455-67e0f4cd95c5/go.mod h1:KcAcFI40g5WprgOdtjLeKjZ4cpNCwdRJPdP2jM92Slc=
+github.com/sylabs/squashfs v0.5.5-0.20220803145443-2636f95ece7f h1:hbXbCqSp1TqH90JdO7mfzduykxuGzCRy4/C/YnxfnmU=
+github.com/sylabs/squashfs v0.5.5-0.20220803145443-2636f95ece7f/go.mod h1:cGTBoGT3UOspgoDKFmf/XG25EUytbVhDt0zCulc+vIQ=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/pkg/file/metadata.go
+++ b/pkg/file/metadata.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/CalebQ42/squashfs"
+	"github.com/sylabs/squashfs"
 )
 
 // Metadata represents all file metadata of interest (used today for in-tar file resolution).

--- a/pkg/file/squashfs_walk.go
+++ b/pkg/file/squashfs_walk.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"io/fs"
 
-	"github.com/CalebQ42/squashfs"
+	"github.com/sylabs/squashfs"
 )
 
 // SquashFSVisitor is the type of the function called by WalkSquashFS to visit each file or
@@ -21,7 +21,7 @@ type SquashFSVisitor func(fsys *squashfs.FS, path string, d fs.DirEntry) error
 // WalkSquashFS walks the file tree within the SquashFS filesystem read from r, calling fn for each
 // file or directory in the tree, including root.
 func WalkSquashFS(r io.ReaderAt, fn SquashFSVisitor) error {
-	fsys, err := squashfs.NewSquashfsReader(r)
+	fsys, err := squashfs.NewReader(r)
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func WalkSquashFS(r io.ReaderAt, fn SquashFSVisitor) error {
 // fn for each file or directory in the tree, including root. Callers should use WalkSquashFS
 // where possible, as this function is considerably less efficient.
 func WalkSquashFSFromReader(r io.Reader, fn SquashFSVisitor) error {
-	fsys, err := squashfs.NewSquashfsReaderFromReader(r)
+	fsys, err := squashfs.NewReaderFromReader(r)
 	if err != nil {
 		return err
 	}
@@ -48,6 +48,6 @@ func walkDir(fsys fs.FS, fn SquashFSVisitor) fs.WalkDirFunc {
 			return err
 		}
 
-		return fn(&fsys.(*squashfs.Reader).FS, path, d)
+		return fn(fsys.(*squashfs.Reader).FS, path, d)
 	}
 }

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/CalebQ42/squashfs"
 	"github.com/anchore/stereoscope/internal/bus"
 	"github.com/anchore/stereoscope/internal/log"
 	"github.com/anchore/stereoscope/pkg/event"
@@ -17,6 +16,7 @@ import (
 	"github.com/anchore/stereoscope/pkg/filetree"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sylabs/squashfs"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
 )


### PR DESCRIPTION
This PR updates the reference to `sylabs` fork of `squashfs` and removes the `replace` directive to use it.