### PR TITLE
deps: Remove squashfs replacement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/anchore/stereoscope
 go 1.16
 
 require (
-	github.com/CalebQ42/squashfs v0.5.4
 	github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220517224237-e6f29200ae04
@@ -28,10 +27,8 @@ require (
 	github.com/spf13/afero v1.6.0
 	github.com/stretchr/testify v1.7.0
 	github.com/sylabs/sif/v2 v2.7.0
+	github.com/sylabs/squashfs v0.5.5-0.20220803150326-9393a0b4cef5
 	github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d
 	github.com/wagoodman/go-progress v0.0.0-20200621122631-1a2120f0695a
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 )
-
-// Forked to remove https://github.com/rasky/go-lzo dependency, which is GPLv2 licensed.
-replace github.com/CalebQ42/squashfs => github.com/sylabs/squashfs v0.5.5-0.20220526223455-67e0f4cd95c5

--- a/go.sum
+++ b/go.sum
@@ -777,8 +777,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/sylabs/sif/v2 v2.7.0 h1:VFzN8alnJ/3n1JA0K9DyUtfSzezWgWrzLDcYGhgBskk=
 github.com/sylabs/sif/v2 v2.7.0/go.mod h1:TiyBWsgWeh5yBeQFNuQnvROwswqK7YJT8JA1L53bsXQ=
-github.com/sylabs/squashfs v0.5.5-0.20220526223455-67e0f4cd95c5 h1:cFtGHruT2MgOXuJXoUsVa3YnMjWRLyfWQimYqgHfEYQ=
-github.com/sylabs/squashfs v0.5.5-0.20220526223455-67e0f4cd95c5/go.mod h1:KcAcFI40g5WprgOdtjLeKjZ4cpNCwdRJPdP2jM92Slc=
+github.com/sylabs/squashfs v0.5.5-0.20220803150326-9393a0b4cef5 h1:OfmBgc/n/FAKrtK5TEkX2sqQo5zMBb/4EFEQQAKKrro=
+github.com/sylabs/squashfs v0.5.5-0.20220803150326-9393a0b4cef5/go.mod h1:lGupCIjaVP476d0G7UppFr3h123OsNLGRCtm6rgwPwA=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/pkg/file/metadata.go
+++ b/pkg/file/metadata.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/CalebQ42/squashfs"
+	"github.com/sylabs/squashfs"
 )
 
 // Metadata represents all file metadata of interest (used today for in-tar file resolution).

--- a/pkg/file/squashfs_walk.go
+++ b/pkg/file/squashfs_walk.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"io/fs"
 
-	"github.com/CalebQ42/squashfs"
+	"github.com/sylabs/squashfs"
 )
 
 // SquashFSVisitor is the type of the function called by WalkSquashFS to visit each file or

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/CalebQ42/squashfs"
 	"github.com/anchore/stereoscope/internal/bus"
 	"github.com/anchore/stereoscope/internal/log"
 	"github.com/anchore/stereoscope/pkg/event"
@@ -17,6 +16,7 @@ import (
 	"github.com/anchore/stereoscope/pkg/filetree"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sylabs/squashfs"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
 )


### PR DESCRIPTION
Remove the replacement for CalebQ42/squashfs => sylabs/squashfs by
updating to commit in sylabs/squashfs that has renamed the module.

Signed-off-by: David Trudgian <david.trudgian@sylabs.io>