### PR TITLE
add latest as default tag for container images

### DIFF
--- a/client.go
+++ b/client.go
@@ -114,13 +114,19 @@ func selectImageProvider(imgStr string, source image.Source, cfg config) (image.
 		if err != nil {
 			return nil, err
 		}
-		provider = docker.NewProviderFromDaemon(imgStr, tempDirGenerator, c, cfg.Platform)
+		provider, err = docker.NewProviderFromDaemon(imgStr, tempDirGenerator, c, cfg.Platform)
+		if err != nil {
+			return nil, err
+		}
 	case image.PodmanDaemonSource:
 		c, err := podman.GetClient()
 		if err != nil {
 			return nil, err
 		}
-		provider = docker.NewProviderFromDaemon(imgStr, tempDirGenerator, c, cfg.Platform)
+		provider, err = docker.NewProviderFromDaemon(imgStr, tempDirGenerator, c, cfg.Platform)
+		if err != nil {
+			return nil, err
+		}
 	case image.OciDirectorySource:
 		if cfg.Platform != nil {
 			return nil, platformSelectionUnsupported

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -37,13 +37,21 @@ type DaemonImageProvider struct {
 }
 
 // NewProviderFromDaemon creates a new provider instance for a specific image that will later be cached to the given directory.
-func NewProviderFromDaemon(imgStr string, tmpDirGen *file.TempDirGenerator, c client.APIClient, platform *image.Platform) *DaemonImageProvider {
+func NewProviderFromDaemon(imgStr string, tmpDirGen *file.TempDirGenerator, c client.APIClient, platform *image.Platform) (*DaemonImageProvider, error) {
+	ref, err := name.ParseReference(imgStr)
+	if err != nil {
+		return nil, err
+	}
+	tag, ok := ref.(name.Tag)
+	if ok {
+		imgStr = tag.Name()
+	}
 	return &DaemonImageProvider{
 		imageStr:  imgStr,
 		tmpDirGen: tmpDirGen,
 		client:    c,
 		platform:  platform,
-	}
+	}, nil
 }
 
 type daemonProvideProgress struct {

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -38,7 +38,7 @@ type DaemonImageProvider struct {
 
 // NewProviderFromDaemon creates a new provider instance for a specific image that will later be cached to the given directory.
 func NewProviderFromDaemon(imgStr string, tmpDirGen *file.TempDirGenerator, c client.APIClient, platform *image.Platform) (*DaemonImageProvider, error) {
-	ref, err := name.ParseReference(imgStr)
+	ref, err := name.ParseReference(imgStr, name.WithDefaultRegistry(""))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/docker/daemon_provider_test.go
+++ b/pkg/image/docker/daemon_provider_test.go
@@ -85,3 +85,50 @@ func Test_authURL(t *testing.T) {
 		})
 	}
 }
+
+func TestNewProviderFromDaemon_imageParsing(t *testing.T) {
+	tests := []struct {
+		image   string
+		want    string
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			image: "alpine:sometag",
+			want:  "alpine:sometag",
+		},
+		{
+			image: "alpine:latest",
+			want:  "alpine:latest",
+		},
+		{
+			image: "alpine",
+			want:  "alpine:latest",
+		},
+		{
+			image: "registry.place.io/thing:version",
+			want:  "registry.place.io/thing:version",
+		},
+		{
+			image: "alpine@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209",
+			want:  "alpine@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209",
+		},
+		{
+			image: "alpine:sometag@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209",
+			want:  "alpine:sometag@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.image, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+			got, err := NewProviderFromDaemon(tt.image, nil, nil, nil)
+			tt.wantErr(t, err)
+			if err != nil {
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, got.imageStr)
+		})
+	}
+}


### PR DESCRIPTION
Fix for <https://github.com/anchore/syft/issues/411>, according to [this comment](https://github.com/anchore/syft/issues/411#issuecomment-897676650), not sure that's the right spot though.

Also, this method will then resolve the container name to the fully expanded version, including the registry, I'm not sure that doesn't interfere with anything, just to mention it.

The OCI version already works, no change needed there.