### PR TITLE
bump bouncer to v0.4.0 and golangci-lint to v1.47.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ bootstrap: $(RESULTSDIR) ## Download and install all project dependencies (+ pre
 	go mod download
 	# install utilities
 	[ -f "$(TEMPDIR)/benchstat" ] || GO111MODULE=off GOBIN=$(shell realpath $(TEMPDIR)) go get -u golang.org/x/perf/cmd/benchstat
-	[ -f "$(TEMPDIR)/golangci" ] || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.45.0
-	[ -f "$(TEMPDIR)/bouncer" ] || curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.3.0
+	[ -f "$(TEMPDIR)/golangci" ] || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.47.2
+	[ -f "$(TEMPDIR)/bouncer" ] || curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.4.0
 
 .PHONY: static-analysis
 static-analysis: check-licenses lint


### PR DESCRIPTION
Signed-off-by: Weston Steimel <weston.steimel@anchore.com>