### PR TITLE
Fix link cycles with non-existent paths

### DIFF
--- a/pkg/filetree/filetree_test.go
+++ b/pkg/filetree/filetree_test.go
@@ -3,6 +3,7 @@ package filetree
 import (
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/anchore/stereoscope/internal"
@@ -777,6 +778,23 @@ func TestFileTree_File_CycleDetection(t *testing.T) {
 
 	// the test.... do we stop when a cycle is detected?
 	exists, _, err := tr.File("/home/wagoodman", FollowBasenameLinks)
+	if err != ErrLinkCycleDetected {
+		t.Fatalf("should have gotten an error on resolving a file")
+	}
+
+	if exists {
+		t.Errorf("resolution should not exist in cycle")
+	}
+
+}
+
+func TestFileTree_File_DeadCycleDetection(t *testing.T) {
+	tr := NewFileTree()
+	_, err := tr.AddSymLink("/somewhere/acorn", "noobaa-core/../acorn/bin/acorn")
+	require.NoError(t, err)
+
+	// the test.... do we stop when a cycle is detected?
+	exists, _, err := tr.File("/somewhere/acorn", FollowBasenameLinks)
 	if err != ErrLinkCycleDetected {
 		t.Fatalf("should have gotten an error on resolving a file")
 	}


### PR DESCRIPTION
The filetree does not handle cycles with symlinks well when the file nodes do not exist:
```
$ ln -s  noobaa-core/../acorn/bin/acorn acorn
$ ls -al
total 0
drwxr-xr-x    3 wagoodman  staff    96 Nov 30 09:49 .
drwxr-xr-x  118 wagoodman  staff  3776 Nov 30 09:49 ..
lrwxr-xr-x    1 wagoodman  staff    30 Nov 30 09:49 acorn -> noobaa-core/../acorn/bin/acorn
$ syft .
⠼ Indexing .              [file: /Users/wagoodman/scratch/deadlinkloop/acorn]runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc021140420 stack=[0xc021140000, 0xc041140000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x303cf64?, 0x4529300?})
        /opt/hostedtoolcache/go/1.18.8/x64/src/runtime/panic.go:992 +0x71
runtime.newstack()
        /opt/hostedtoolcache/go/1.18.8/x64/src/runtime/stack.go:1101 +0x5cc
runtime.morestack()
        /opt/hostedtoolcache/go/1.18.8/x64/src/runtime/asm_amd64.s:547 +0x8b

goroutine 98 [running]:
runtime.heapBitsSetType(0xc00e17db80?, 0x80?, 0x80?, 0x2bf9360?)
        /opt/hostedtoolcache/go/1.18.8/x64/src/runtime/mbitmap.go:832 +0xbcc fp=0xc021140430 sp=0xc021140428 pc=0x10158ec
runtime.mallocgc(0x80, 0x2bf9360, 0x1)
        /opt/hostedtoolcache/go/1.18.8/x64/src/runtime/malloc.go:1117 +0x673 fp=0xc0211404a8 sp=0xc021140430 pc=0x100d073
runtime.makeslice(0xc00109a100?, 0x33daaa8?, 0x33daaa8?)
        /opt/hostedtoolcache/go/1.18.8/x64/src/runtime/slice.go:103 +0x52 fp=0xc0211404d0 sp=0xc0211404a8 pc=0x104c332
strings.genSplit({0xc00109a100, 0x35}, {0x33daaa8, 0x1}, 0x0, 0x11b1f798?)
        /opt/hostedtoolcache/go/1.18.8/x64/src/strings/strings.go:247 +0x6d fp=0xc021140530 sp=0xc0211404d0 pc=0x1100b8d
strings.Split(...)
        /opt/hostedtoolcache/go/1.18.8/x64/src/strings/strings.go:303
github.com/anchore/stereoscope/pkg/filetree.(*FileTree).resolveAncestorLinks(0x2e0f200?, {0xc00109a100, 0x35})
        /home/runner/go/pkg/mod/github.com/anchore/stereoscope@v0.0.0-20221006201143-d24c9d626b33/pkg/filetree/filetree.go:206 +0x85 fp=0xc0211405c0 sp=0xc021140530 pc=0x2611d85
github.com/anchore/stereoscope/pkg/filetree.(*FileTree).resolveNodeLinks(0xc0010b6020?, 0xc0010983c0, 0x1)
        /home/runner/go/pkg/mod/github.com/anchore/stereoscope@v0.0.0-20221006201143-
...
<goes on for a while...>
```

This PR fixes this behavior by providing a shared state between `resolveNodeLinks` and `resolveAncestorLinks` calls, short circuiting the link resolution when a non-existent node is provided twice in the search.

Addresses https://github.com/anchore/syft/issues/1368