### PR TITLE
Fix link cycle detection

### DIFF
--- a/pkg/file/path_set.go
+++ b/pkg/file/path_set.go
@@ -90,7 +90,7 @@ func (s PathCountSet) Add(ids ...Path) {
 			s[i] = 1
 			continue
 		}
-		s[i] += 1
+		s[i]++
 	}
 }
 

--- a/pkg/file/path_set.go
+++ b/pkg/file/path_set.go
@@ -75,3 +75,39 @@ func (s PathSet) ContainsAny(ids ...Path) bool {
 	}
 	return false
 }
+
+type PathCountSet map[Path]int
+
+func NewPathCountSet(is ...Path) PathCountSet {
+	s := make(PathCountSet)
+	s.Add(is...)
+	return s
+}
+
+func (s PathCountSet) Add(ids ...Path) {
+	for _, i := range ids {
+		if _, ok := s[i]; !ok {
+			s[i] = 1
+			continue
+		}
+		s[i] += 1
+	}
+}
+
+func (s PathCountSet) Remove(ids ...Path) {
+	for _, i := range ids {
+		if _, ok := s[i]; !ok {
+			continue
+		}
+
+		s[i]--
+		if s[i] <= 0 {
+			delete(s, i)
+		}
+	}
+}
+
+func (s PathCountSet) Contains(i Path) bool {
+	count, ok := s[i]
+	return ok && count > 0
+}

--- a/pkg/file/path_set_test.go
+++ b/pkg/file/path_set_test.go
@@ -224,3 +224,45 @@ func TestPathSet_ContainsAny(t *testing.T) {
 		})
 	}
 }
+
+func TestPathCountSet(t *testing.T) {
+	s := NewPathCountSet()
+
+	s.Add("a", "b") // {a: 1, b: 1}
+	assert.True(t, s.Contains("a"))
+	assert.True(t, s.Contains("b"))
+	assert.False(t, s.Contains("c"))
+
+	s.Add("a", "c") // {a: 2, b: 1, c: 1}
+	assert.True(t, s.Contains("a"))
+	assert.True(t, s.Contains("b"))
+	assert.True(t, s.Contains("c"))
+
+	s.Remove("a") // {a: 1, b: 1, c: 1}
+	assert.True(t, s.Contains("a"))
+	assert.True(t, s.Contains("b"))
+	assert.True(t, s.Contains("c"))
+
+	s.Remove("a", "b") // {c: 1}
+	assert.False(t, s.Contains("a"))
+	assert.False(t, s.Contains("b"))
+	assert.True(t, s.Contains("c"))
+
+	s.Remove("a", "b", "v", "c") // {}
+	assert.False(t, s.Contains("a"))
+	assert.False(t, s.Contains("b"))
+	assert.False(t, s.Contains("c"))
+
+	s.Add("a", "a", "a", "a") // {a: 4}
+	assert.True(t, s.Contains("a"))
+	assert.Equal(t, 4, s["a"])
+
+	s.Remove("a", "a", "a") // {a: 1}
+	assert.True(t, s.Contains("a"))
+
+	s.Remove("a", "a", "a", "a") // {}
+	assert.False(t, s.Contains("a"))
+
+	s.Remove("a", "a", "a", "a", "a", "a", "a", "a") // {}
+	assert.False(t, s.Contains("a"))
+}

--- a/pkg/filetree/filenode/filenode.go
+++ b/pkg/filetree/filenode/filenode.go
@@ -77,7 +77,6 @@ func (n *FileNode) RenderLinkDestination() file.Path {
 		return ""
 	}
 
-	// TODO: do we want to assert on if a destination exists or not here?
 	if n.LinkPath.IsAbsolutePath() {
 		// use links with absolute paths blindly
 		return n.LinkPath

--- a/pkg/filetree/filenode/filenode.go
+++ b/pkg/filetree/filenode/filenode.go
@@ -77,6 +77,7 @@ func (n *FileNode) RenderLinkDestination() file.Path {
 		return ""
 	}
 
+	// TODO: do we want to assert on if a destination exists or not here?
 	if n.LinkPath.IsAbsolutePath() {
 		// use links with absolute paths blindly
 		return n.LinkPath

--- a/pkg/filetree/filetree.go
+++ b/pkg/filetree/filetree.go
@@ -250,7 +250,7 @@ func (t *FileTree) node(p file.Path, strategy linkResolutionStrategy) (*nodeAcce
 
 // return FileNode of the basename in the given path (no resolution is done at or past the basename). Note: it is
 // assumed that the given path has already been normalized.
-func (t *FileTree) resolveAncestorLinks(path file.Path, currentlyResolvingLinkPaths file.PathSet) (*nodeAccess, error) {
+func (t *FileTree) resolveAncestorLinks(path file.Path, currentlyResolvingLinkPaths file.PathCountSet) (*nodeAccess, error) {
 	// performance optimization... see if there is a node at the path (as if it is a real path). If so,
 	// use it, otherwise, continue with ancestor resolution
 	currentNodeAccess, err := t.node(path, linkResolutionStrategy{})
@@ -325,7 +325,7 @@ func (t *FileTree) resolveAncestorLinks(path file.Path, currentlyResolvingLinkPa
 // resolveNodeLinks takes the given FileNode and resolves all links at the base of the real path for the node (this implies
 // that NO ancestors are considered).
 // nolint: funlen
-func (t *FileTree) resolveNodeLinks(n *nodeAccess, followDeadBasenameLinks bool, currentlyResolvingLinkPaths file.PathSet) (*nodeAccess, error) {
+func (t *FileTree) resolveNodeLinks(n *nodeAccess, followDeadBasenameLinks bool, currentlyResolvingLinkPaths file.PathCountSet) (*nodeAccess, error) {
 	if n == nil {
 		return nil, fmt.Errorf("cannot resolve links with nil Node given")
 	}
@@ -334,7 +334,7 @@ func (t *FileTree) resolveNodeLinks(n *nodeAccess, followDeadBasenameLinks bool,
 	// this represents current link resolution requests that are in progress. This set is pruned once the resolution
 	// has been completed.
 	if currentlyResolvingLinkPaths == nil {
-		currentlyResolvingLinkPaths = file.NewPathSet()
+		currentlyResolvingLinkPaths = file.NewPathCountSet()
 	}
 
 	// note: this assumes that callers are passing paths in which the constituent parts are NOT symlinks

--- a/pkg/filetree/filetree_test.go
+++ b/pkg/filetree/filetree_test.go
@@ -1079,6 +1079,7 @@ func TestFileTree_File_DeadCycleDetection(t *testing.T) {
 
 	// the test.... do we stop when a cycle is detected?
 	exists, _, err := tr.File("/somewhere/acorn", FollowBasenameLinks)
+	require.Error(t, err, "should have gotten an error on resolution of a dead cycle")
 	// TODO: check this case
 	if err != ErrLinkCycleDetected {
 		t.Fatalf("should have gotten an error on resolving a file")
@@ -1094,13 +1095,17 @@ func TestFileTree_File_DeadCycleDetection_BAD(t *testing.T) {
 	tr := New()
 	_, err := tr.AddFile("/usr/bin/ksh93")
 	require.NoError(t, err)
+
+	_, err = tr.AddSymLink("/usr/local/bin/ksh", "/bin/ksh")
+	require.NoError(t, err)
+
 	_, err = tr.AddSymLink("/bin", "/usr/bin")
 	require.NoError(t, err)
-	_, err = tr.AddSymLink("/usr/bin/ksh", "/etc/alternatives/ksh")
-	require.NoError(t, err)
+
 	_, err = tr.AddSymLink("/etc/alternatives/ksh", "/bin/ksh93")
 	require.NoError(t, err)
-	_, err = tr.AddSymLink("/usr/local/bin/ksh", "/bin/ksh")
+
+	_, err = tr.AddSymLink("/usr/bin/ksh", "/etc/alternatives/ksh")
 	require.NoError(t, err)
 
 	/*
@@ -1109,6 +1114,8 @@ func TestFileTree_File_DeadCycleDetection_BAD(t *testing.T) {
 		/usr/bin/ksh -> /etc/alternatives/ksh
 		/etc/alternatives/ksh -> /bin/ksh93
 	*/
+
+	//
 
 	// ls -al /usr/local/bin/ksh
 	// /usr/local/bin/ksh -> /bin/ksh

--- a/pkg/filetree/filetree_test.go
+++ b/pkg/filetree/filetree_test.go
@@ -1079,6 +1079,7 @@ func TestFileTree_File_DeadCycleDetection(t *testing.T) {
 
 	// the test.... do we stop when a cycle is detected?
 	exists, _, err := tr.File("/somewhere/acorn", FollowBasenameLinks)
+	// TODO: check this case
 	if err != ErrLinkCycleDetected {
 		t.Fatalf("should have gotten an error on resolving a file")
 	}
@@ -1087,6 +1088,39 @@ func TestFileTree_File_DeadCycleDetection(t *testing.T) {
 		t.Errorf("resolution should not exist in cycle")
 	}
 
+}
+
+func TestFileTree_File_DeadCycleDetection_BAD(t *testing.T) {
+	tr := New()
+	_, err := tr.AddFile("/usr/bin/ksh93")
+	require.NoError(t, err)
+	_, err = tr.AddSymLink("/bin", "/usr/bin")
+	require.NoError(t, err)
+	_, err = tr.AddSymLink("/usr/bin/ksh", "/etc/alternatives/ksh")
+	require.NoError(t, err)
+	_, err = tr.AddSymLink("/etc/alternatives/ksh", "/bin/ksh93")
+	require.NoError(t, err)
+	_, err = tr.AddSymLink("/usr/local/bin/ksh", "/bin/ksh")
+	require.NoError(t, err)
+
+	/*
+		/usr/bin/ksh93 <-- Real file
+		/bin -> /usr/bin
+		/usr/bin/ksh -> /etc/alternatives/ksh
+		/etc/alternatives/ksh -> /bin/ksh93
+	*/
+
+	// ls -al /usr/local/bin/ksh
+	// /usr/local/bin/ksh -> /bin/ksh
+	// ls -al /bin/ksh
+	// /bin/ksh -> /etc/alternatives/ksh
+	// /etc/alternatives/ksh
+	// /etc/alternatives/ksh -> /bin/ksh93
+	// /bin/ksh93
+
+	// the test.... do we stop when a cycle is detected?
+	_, _, err = tr.File("/usr/local/bin/ksh", FollowBasenameLinks)
+	require.NoError(t, err)
 }
 
 func TestFileTree_AllFiles(t *testing.T) {


### PR DESCRIPTION
PR https://github.com/anchore/stereoscope/pull/154 added a regression where link resolution may result in falsely claiming that there is a link cycle for links that reference the same path twice while resolving links for a single path.

For example:
```
# links:
   /usr/local/bin/ksh -> /bin/ksh
   /bin -> /usr/bin
   /etc/alternatives/ksh -> /bin/ksh93

# real file: 
   /usr/bin/ksh93
```

In this case while resolving links in the `/usr/local/bin/ksh` path, the `/usr/bin` path is resolved twice, which under the current (buggy) implementation will falsely claim that there is a cycle relating to `/usr/bin`.

Relates to https://github.com/anchore/syft/issues/1586