### PR TITLE
fix directory leak leading to out of disk

### DIFF
--- a/client.go
+++ b/client.go
@@ -170,5 +170,5 @@ func SetBus(b *partybus.Bus) {
 // Cleanup deletes all directories created by stereoscope calls. Note: please use image.Image.Cleanup() over this
 // function when possible.
 func Cleanup() {
-	log.Warn("cleanup is deprecated - no need to call. please use image.Image.Cleanup()")
+	log.Debug("cleanup is deprecated - no need to call. please use image.Image.Cleanup()")
 }

--- a/client.go
+++ b/client.go
@@ -18,8 +18,6 @@ import (
 	"github.com/wagoodman/go-partybus"
 )
 
-var rootTempDirGenerator = file.NewTempDirGenerator("stereoscope")
-
 func WithRegistryOptions(options image.RegistryOptions) Option {
 	return func(c *config) error {
 		c.Registry = options
@@ -100,7 +98,7 @@ func GetImageFromSource(ctx context.Context, imgStr string, source image.Source,
 
 func selectImageProvider(imgStr string, source image.Source, cfg config) (image.Provider, error) {
 	var provider image.Provider
-	tempDirGenerator := rootTempDirGenerator.NewGenerator()
+	tempDirGenerator := file.NewTempDirGenerator("stereoscope")
 	platformSelectionUnsupported := fmt.Errorf("specified platform=%q however image source=%q does not support selecting platform", cfg.Platform.String(), source.String())
 
 	switch source {
@@ -172,7 +170,5 @@ func SetBus(b *partybus.Bus) {
 // Cleanup deletes all directories created by stereoscope calls. Note: please use image.Image.Cleanup() over this
 // function when possible.
 func Cleanup() {
-	if err := rootTempDirGenerator.Cleanup(); err != nil {
-		log.Errorf("failed to cleanup tempdir root: %w", err)
-	}
+	log.Warn("cleanup is deprecated - no need to call. please use image.Image.Cleanup()")
 }

--- a/pkg/image/docker/tarball_provider.go
+++ b/pkg/image/docker/tarball_provider.go
@@ -82,5 +82,5 @@ func (p *TarballImageProvider) Provide(_ context.Context, userMetadata ...image.
 		return nil, err
 	}
 
-	return image.New(img, contentTempDir, metadata...), nil
+	return image.New(img, p.tmpDirGen, contentTempDir, metadata...), nil
 }

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -3,10 +3,11 @@ package image
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"os"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/google/go-containerregistry/pkg/name"
 )
@@ -98,7 +99,7 @@ func TestImageAdditionalMetadata(t *testing.T) {
 				os.Remove(tempFile.Name())
 			})
 
-			img := New(nil, tempFile.Name(), test.options...)
+			img := New(nil, nil, tempFile.Name(), test.options...)
 
 			err = img.applyOverrideMetadata()
 			if err != nil {

--- a/pkg/image/oci/directory_provider.go
+++ b/pkg/image/oci/directory_provider.go
@@ -69,5 +69,5 @@ func (p *DirectoryImageProvider) Provide(_ context.Context, userMetadata ...imag
 		return nil, err
 	}
 
-	return image.New(img, contentTempDir, metadata...), nil
+	return image.New(img, p.tmpDirGen, contentTempDir, metadata...), nil
 }

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -80,7 +80,7 @@ func (p *RegistryImageProvider) Provide(ctx context.Context, userMetadata ...ima
 	// apply user-supplied metadata last to override any default behavior
 	metadata = append(metadata, userMetadata...)
 
-	return image.New(img, imageTempDir, metadata...), nil
+	return image.New(img, p.tmpDirGen, imageTempDir, metadata...), nil
 }
 
 func prepareReferenceOptions(registryOptions image.RegistryOptions) []name.Option {

--- a/pkg/image/sif/provider.go
+++ b/pkg/image/sif/provider.go
@@ -51,5 +51,5 @@ func (p *SingularityImageProvider) Provide(ctx context.Context, userMetadata ...
 	}
 	metadata = append(metadata, userMetadata...)
 
-	return image.New(ui, contentCacheDir, metadata...), nil
+	return image.New(ui, p.tmpDirGen, contentCacheDir, metadata...), nil
 }


### PR DESCRIPTION
### [Issue 132](https://github.com/anchore/stereoscope/issues/132)

# Why
When using stereoscope as a library, for long running processes, the relationship between the providers may cause files in temp to not get cleaned up after `image.Image.Cleanup` is called. 

# What
* enable `image.Image.Cleanup` to own `tmpDirGenerator` and perform cleanup any directories related to the image.

# How Tested
* per guide
```
make bootstrap
make unit
make integration
```

* using the basic example
```
$ docker pull ruby:2.6-alpine3.11
$ ls -l /tmp/ | grep stereo
$ go run basic.go docker:ruby:2.6-alpine3.11 &>/dev/null
$ ls -l /tmp/ | grep stereo
```
