### PR TITLE
feat: add ordered preference list of image source location for DetermineDefaultImagePullSource

### DIFF
--- a/pkg/image/source_test.go
+++ b/pkg/image/source_test.go
@@ -10,8 +10,43 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 	"github.com/sylabs/sif/v2/pkg/sif"
 )
+
+func Test(t *testing.T) {
+	cases := []struct {
+		desc        string
+		image       string
+		sourceInput []Source
+		expected    Source
+	}{
+		{
+			desc:        "No input returns UnknownSource",
+			image:       "test:test",
+			sourceInput: []Source{},
+			expected:    UnknownSource,
+		},
+		{
+			desc:  "OciRegistry is returned when preferenced first",
+			image: "test:test",
+			sourceInput: []Source{
+				OciRegistrySource,
+				DockerDaemonSource,
+				PodmanDaemonSource,
+			},
+			expected: OciRegistrySource,
+		},
+		// TODO: dependency injection update to test docker/podman cases
+
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			s := DetermineDefaultImagePullSource(c.image, c.sourceInput)
+			assert.Equal(t, s, c.expected)
+		})
+	}
+}
 
 func TestDetectSource(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Enable upstream tooling more pull source configuration

Enables: https://github.com/anchore/grype/issues/1204

Currently syft (and by dependency, grype) follow a local out pattern of checking for a source for a given input:

Current state:
EX: `alpine:latest` would check the Docker Daemon, then the Podman Daemon, then default to returning `OciRegistrySource` to the caller if connectivity to the daemons could not be established.

This update allows the caller more preference in checking if they would prefer to default to just shortcutting to finding an image for a registry.


## For discussion
NOTE: this implementation previously did NOT check if the image was on the registry before returning `OCIRegistry` as the preferred source. If the caller puts registry as the 0 indexed preference, then that is the returned source. 

If there is an error upstream the caller should decide if it wants to come back and attempt local daemon sources before erroring out.

We have to go all the way to this location before the returned `Source` is used in syft to 
https://github.com/anchore/syft/blob/2fa238af7ca9e64c3553b83481a3d05a3c9cdaaf/syft/source/source.go#L160