### PR TITLE
Add format make target

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -12,7 +12,7 @@ After cloning the following step can help you get setup:
 1. run `make bootstrap` to download go mod dependencies, create the `/.tmp` dir, and download helper utilities.
 2. run `make help` to view the selection of developer commands in the Makefile
 
-The main make tasks for common static analysis and testing are `lint`, `lint-fix`, `unit`, and `integration`.
+The main make tasks for common static analysis and testing are `lint`, `format`, `lint-fix`, `unit`, and `integration`.
 
 See `make help` for all the current make tasks.
 

--- a/client.go
+++ b/client.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/anchore/go-logger"
+	"github.com/wagoodman/go-partybus"
 
+	"github.com/anchore/go-logger"
 	"github.com/anchore/stereoscope/internal/bus"
 	dockerClient "github.com/anchore/stereoscope/internal/docker"
 	"github.com/anchore/stereoscope/internal/log"
@@ -16,7 +17,6 @@ import (
 	"github.com/anchore/stereoscope/pkg/image/docker"
 	"github.com/anchore/stereoscope/pkg/image/oci"
 	"github.com/anchore/stereoscope/pkg/image/sif"
-	"github.com/wagoodman/go-partybus"
 )
 
 var rootTempDirGenerator = file.NewTempDirGenerator("stereoscope")

--- a/client_test.go
+++ b/client_test.go
@@ -1,11 +1,13 @@
 package stereoscope
 
 import (
-	"github.com/anchore/stereoscope/pkg/image"
+	"testing"
+
 	"github.com/scylladb/go-set/i8set"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/anchore/stereoscope/pkg/image"
 )
 
 func Test_setPlatform(t *testing.T) {

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/anchore/go-logger"
 	"github.com/anchore/go-logger/adapter/logrus"
-
-	"os"
-
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree/filenode"

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/anchore/stereoscope/internal/log"
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
+
+	"github.com/anchore/stereoscope/internal/log"
 )
 
 var (

--- a/internal/podman/ssh.go
+++ b/internal/podman/ssh.go
@@ -12,11 +12,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/anchore/stereoscope/internal/log"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
+
+	"github.com/anchore/stereoscope/internal/log"
 )
 
 type sshClientConfig struct {

--- a/internal/string_set_test.go
+++ b/internal/string_set_test.go
@@ -2,8 +2,9 @@ package internal
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStringSet_Size(t *testing.T) {

--- a/pkg/event/parsers/parsers.go
+++ b/pkg/event/parsers/parsers.go
@@ -3,12 +3,12 @@ package parsers
 import (
 	"fmt"
 
-	"github.com/anchore/stereoscope/pkg/image/docker"
+	"github.com/wagoodman/go-partybus"
+	"github.com/wagoodman/go-progress"
 
 	"github.com/anchore/stereoscope/pkg/event"
 	"github.com/anchore/stereoscope/pkg/image"
-	"github.com/wagoodman/go-partybus"
-	"github.com/wagoodman/go-progress"
+	"github.com/anchore/stereoscope/pkg/image/docker"
 )
 
 type ErrBadPayload struct {

--- a/pkg/file/id_set_test.go
+++ b/pkg/file/id_set_test.go
@@ -2,8 +2,9 @@ package file
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIDSet_Size(t *testing.T) {

--- a/pkg/file/metadata.go
+++ b/pkg/file/metadata.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/anchore/stereoscope/internal/log"
-
 	"github.com/sylabs/squashfs"
+
+	"github.com/anchore/stereoscope/internal/log"
 )
 
 // Metadata represents all file metadata of interest (used today for in-tar file resolution).

--- a/pkg/file/metadata_test.go
+++ b/pkg/file/metadata_test.go
@@ -10,10 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/go-test/deep"
 )
 
 func TestFileMetadataFromTar(t *testing.T) {

--- a/pkg/file/mime_type_test.go
+++ b/pkg/file/mime_type_test.go
@@ -1,12 +1,13 @@
 package file
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_MIMEType(t *testing.T) {

--- a/pkg/file/path_set_test.go
+++ b/pkg/file/path_set_test.go
@@ -2,8 +2,9 @@ package file
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPathSet_Size(t *testing.T) {

--- a/pkg/file/resolution_test.go
+++ b/pkg/file/resolution_test.go
@@ -1,9 +1,10 @@
 package file
 
 import (
-	"github.com/stretchr/testify/assert"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestResolution_Less(t *testing.T) {

--- a/pkg/file/tarutil.go
+++ b/pkg/file/tarutil.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/anchore/stereoscope/internal/log"
 	"github.com/pkg/errors"
+
+	"github.com/anchore/stereoscope/internal/log"
 )
 
 const perFileReadLimit = 2 * GB

--- a/pkg/filetree/depth_first_path_walker_test.go
+++ b/pkg/filetree/depth_first_path_walker_test.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-test/deep"
+
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree/filenode"
-	"github.com/go-test/deep"
 )
 
 func dfsTestTree(t *testing.T) (*FileTree, map[string]*file.Reference) {

--- a/pkg/filetree/filetree.go
+++ b/pkg/filetree/filetree.go
@@ -7,15 +7,14 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/scylladb/go-set/strset"
-
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/scylladb/go-set/iset"
+	"github.com/scylladb/go-set/strset"
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree/filenode"
 	"github.com/anchore/stereoscope/pkg/tree"
 	"github.com/anchore/stereoscope/pkg/tree/node"
-	"github.com/bmatcuk/doublestar/v4"
 )
 
 var ErrRemovingRoot = errors.New("cannot remove the root path (`/`) from the FileTree")

--- a/pkg/filetree/filetree_test.go
+++ b/pkg/filetree/filetree_test.go
@@ -5,15 +5,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/scylladb/go-set/strset"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/scylladb/go-set/strset"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree/filenode"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFileTree_AddPath(t *testing.T) {

--- a/pkg/filetree/glob.go
+++ b/pkg/filetree/glob.go
@@ -7,9 +7,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/anchore/stereoscope/pkg/filetree/filenode"
-
 	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree/filenode"
 )
 
 // basic interface assertion

--- a/pkg/filetree/glob_parser_test.go
+++ b/pkg/filetree/glob_parser_test.go
@@ -1,8 +1,9 @@
 package filetree
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_parseGlob(t *testing.T) {

--- a/pkg/filetree/glob_test.go
+++ b/pkg/filetree/glob_test.go
@@ -4,9 +4,10 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/go-test/deep"
+
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree/filenode"
-	"github.com/go-test/deep"
 )
 
 func TestFileInfoAdapter(t *testing.T) {

--- a/pkg/filetree/index.go
+++ b/pkg/filetree/index.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/anchore/stereoscope/internal/log"
-
-	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/becheran/wildmatch-go"
 	"github.com/scylladb/go-set/strset"
+
+	"github.com/anchore/stereoscope/internal/log"
+	"github.com/anchore/stereoscope/pkg/file"
 )
 
 type Index interface {

--- a/pkg/filetree/index_test.go
+++ b/pkg/filetree/index_test.go
@@ -4,11 +4,12 @@
 package filetree
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 
 	"github.com/anchore/stereoscope/pkg/file"
 )

--- a/pkg/filetree/search.go
+++ b/pkg/filetree/search.go
@@ -5,12 +5,12 @@ import (
 	"path"
 	"sort"
 
+	"github.com/bmatcuk/doublestar/v4"
+
 	"github.com/anchore/stereoscope/internal/log"
+	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree/filenode"
 	"github.com/anchore/stereoscope/pkg/tree/node"
-
-	"github.com/anchore/stereoscope/pkg/file"
-	"github.com/bmatcuk/doublestar/v4"
 )
 
 // Searcher is a facade for searching a file tree with optional indexing support.

--- a/pkg/filetree/search_test.go
+++ b/pkg/filetree/search_test.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/anchore/stereoscope/pkg/file"
-	"github.com/anchore/stereoscope/pkg/filetree/filenode"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree/filenode"
 )
 
 func Test_searchContext_SearchByPath(t *testing.T) {

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -14,11 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/anchore/stereoscope/internal/bus"
-	"github.com/anchore/stereoscope/internal/log"
-	"github.com/anchore/stereoscope/pkg/event"
-	"github.com/anchore/stereoscope/pkg/file"
-	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/docker/cli/cli/config"
 	configTypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/api/types"
@@ -26,6 +21,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
+
+	"github.com/anchore/stereoscope/internal/bus"
+	"github.com/anchore/stereoscope/internal/log"
+	"github.com/anchore/stereoscope/pkg/event"
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/image"
 )
 
 // DaemonImageProvider is a image.Provider capable of fetching and representing a docker image from the docker daemon API.

--- a/pkg/image/docker/daemon_provider_test.go
+++ b/pkg/image/docker/daemon_provider_test.go
@@ -3,11 +3,11 @@ package docker
 import (
 	"encoding/base64"
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	configTypes "github.com/docker/cli/cli/config/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncodeCredentials(t *testing.T) {

--- a/pkg/image/docker/manifest.go
+++ b/pkg/image/docker/manifest.go
@@ -7,11 +7,12 @@ import (
 	"io"
 	"os"
 
-	"github.com/anchore/stereoscope/internal/log"
-	"github.com/anchore/stereoscope/pkg/file"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"github.com/anchore/stereoscope/internal/log"
+	"github.com/anchore/stereoscope/pkg/file"
 )
 
 type dockerManifest struct {

--- a/pkg/image/docker/manifest_test.go
+++ b/pkg/image/docker/manifest_test.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/go-test/deep"
 	"github.com/sergi/go-diff/diffmatchpatch"
 
 	"github.com/anchore/go-testutils"
-	"github.com/go-test/deep"
 )
 
 var update = flag.Bool("update", false, "update the *.golden files for the oci manifest assembly test")

--- a/pkg/image/docker/tarball_provider.go
+++ b/pkg/image/docker/tarball_provider.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+
 	"github.com/anchore/stereoscope/internal/log"
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
 var ErrMultipleManifests = fmt.Errorf("cannot process multiple docker manifests")

--- a/pkg/image/file_catalog_test.go
+++ b/pkg/image/file_catalog_test.go
@@ -14,17 +14,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/anchore/stereoscope/pkg/filetree"
+	"github.com/go-test/deep"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/go-test/deep"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/types"
-
 	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree"
 )
 
 const (

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -6,18 +6,18 @@ import (
 	"io"
 	"os"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/hashicorp/go-multierror"
 	"github.com/scylladb/go-set/strset"
+	"github.com/wagoodman/go-partybus"
+	"github.com/wagoodman/go-progress"
 
 	"github.com/anchore/stereoscope/internal/bus"
 	"github.com/anchore/stereoscope/internal/log"
 	"github.com/anchore/stereoscope/pkg/event"
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree"
-	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/wagoodman/go-partybus"
-	"github.com/wagoodman/go-progress"
 )
 
 // Image represents a container image.

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-
 	"github.com/google/go-containerregistry/pkg/name"
 )
 

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -9,16 +9,17 @@ import (
 	"os"
 	"path"
 
-	"github.com/anchore/stereoscope/internal/bus"
-	"github.com/anchore/stereoscope/internal/log"
-	"github.com/anchore/stereoscope/pkg/event"
-	"github.com/anchore/stereoscope/pkg/file"
-	"github.com/anchore/stereoscope/pkg/filetree"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/sylabs/squashfs"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
+
+	"github.com/anchore/stereoscope/internal/bus"
+	"github.com/anchore/stereoscope/internal/log"
+	"github.com/anchore/stereoscope/pkg/event"
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree"
 )
 
 const SingularitySquashFSLayer = "application/vnd.sylabs.sif.layer.v1.squashfs"

--- a/pkg/image/oci/credhelpers/ecr_helper.go
+++ b/pkg/image/oci/credhelpers/ecr_helper.go
@@ -1,8 +1,9 @@
 package credhelpers
 
 import (
-	"github.com/anchore/stereoscope/pkg/image"
 	ecr "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
+
+	"github.com/anchore/stereoscope/pkg/image"
 )
 
 type ECRHelper struct {

--- a/pkg/image/oci/credhelpers/gcr_helper.go
+++ b/pkg/image/oci/credhelpers/gcr_helper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/credhelper"
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/store"
+
 	"github.com/anchore/stereoscope/pkg/image"
 )
 

--- a/pkg/image/oci/directory_provider.go
+++ b/pkg/image/oci/directory_provider.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
-	"github.com/google/go-containerregistry/pkg/v1/layout"
 )
 
 // DirectoryImageProvider is an image.Provider for an OCI image (V1) for an existing tar on disk (from a buildah push <img> oci:<img> command).

--- a/pkg/image/oci/directory_provider_test.go
+++ b/pkg/image/oci/directory_provider_test.go
@@ -3,8 +3,9 @@ package oci
 import (
 	"testing"
 
-	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/stereoscope/pkg/file"
 )
 
 func Test_NewProviderFromPath(t *testing.T) {

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/anchore/stereoscope/internal/log"
-	"github.com/anchore/stereoscope/pkg/file"
-	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	containerregistryV1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+
+	"github.com/anchore/stereoscope/internal/log"
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/image"
 )
 
 // RegistryImageProvider is an image.Provider capable of fetching and representing a container image fetched from a remote registry (described by the OCI distribution spec).

--- a/pkg/image/oci/registry_provider_test.go
+++ b/pkg/image/oci/registry_provider_test.go
@@ -5,10 +5,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/anchore/stereoscope/pkg/file"
-	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/image"
 )
 
 func Test_NewProviderFromRegistry(t *testing.T) {

--- a/pkg/image/oci/tarball_provider_test.go
+++ b/pkg/image/oci/tarball_provider_test.go
@@ -3,8 +3,9 @@ package oci
 import (
 	"testing"
 
-	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/stereoscope/pkg/file"
 )
 
 func Test_NewProviderFromTarball(t *testing.T) {

--- a/pkg/image/platform_test.go
+++ b/pkg/image/platform_test.go
@@ -2,8 +2,9 @@ package image
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewPlatform(t *testing.T) {

--- a/pkg/image/registry_credentials.go
+++ b/pkg/image/registry_credentials.go
@@ -1,8 +1,9 @@
 package image
 
 import (
-	"github.com/anchore/stereoscope/internal/log"
 	"github.com/google/go-containerregistry/pkg/authn"
+
+	"github.com/anchore/stereoscope/internal/log"
 )
 
 // RegistryCredentials contains any information necessary to authenticate against an OCI-distribution-compliant

--- a/pkg/image/registry_credentials_test.go
+++ b/pkg/image/registry_credentials_test.go
@@ -3,9 +3,8 @@ package image
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRegistryCredentials_Authenticator(t *testing.T) {

--- a/pkg/image/registry_options.go
+++ b/pkg/image/registry_options.go
@@ -1,8 +1,9 @@
 package image
 
 import (
-	"github.com/anchore/stereoscope/internal/log"
 	"github.com/google/go-containerregistry/pkg/authn"
+
+	"github.com/anchore/stereoscope/internal/log"
 )
 
 // RegistryOptions for the OCI registry provider.

--- a/pkg/image/sif/image.go
+++ b/pkg/image/sif/image.go
@@ -7,11 +7,12 @@ import (
 	"io"
 	"os"
 
-	"github.com/anchore/stereoscope/pkg/image"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/sylabs/sif/v2/pkg/sif"
+
+	"github.com/anchore/stereoscope/pkg/image"
 )
 
 const SingularityMediaType = "application/vnd.sylabs.sif.layer.v1.sif"

--- a/pkg/image/sif/provider.go
+++ b/pkg/image/sif/provider.go
@@ -3,9 +3,10 @@ package sif
 import (
 	"context"
 
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
-	"github.com/google/go-containerregistry/pkg/v1/partial"
 )
 
 // SingularityImageProvider is an image.Provider for a Singularity Image Format (SIF) image.
@@ -24,7 +25,7 @@ func NewProviderFromPath(path string, tmpDirGen *file.TempDirGenerator) *Singula
 }
 
 // Provide returns an Image that represents a Singularity Image Format (SIF) image.
-func (p *SingularityImageProvider) Provide(ctx context.Context, userMetadata ...image.AdditionalMetadata) (*image.Image, error) {
+func (p *SingularityImageProvider) Provide(_ context.Context, userMetadata ...image.AdditionalMetadata) (*image.Image, error) {
 	// We need to map the SIF to a GGCR v1.Image. Start with an implementation of the GGCR
 	// partial.UncompressedImageCore interface.
 	si, err := newSIFImage(p.path)

--- a/pkg/image/sif/provider_test.go
+++ b/pkg/image/sif/provider_test.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sylabs/sif/v2/pkg/sif"
+
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
-	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 func TestSingularityImageProvider_Provide(t *testing.T) {

--- a/pkg/image/source.go
+++ b/pkg/image/source.go
@@ -10,13 +10,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/anchore/stereoscope/internal/docker"
-	"github.com/anchore/stereoscope/internal/podman"
-	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/afero"
 	"github.com/sylabs/sif/v2/pkg/sif"
+
+	"github.com/anchore/stereoscope/internal/docker"
+	"github.com/anchore/stereoscope/internal/podman"
+	"github.com/anchore/stereoscope/pkg/file"
 )
 
 const (

--- a/pkg/imagetest/image_fixtures.go
+++ b/pkg/imagetest/image_fixtures.go
@@ -9,11 +9,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/logrusorgru/aurora"
+	"github.com/stretchr/testify/require"
+
 	"github.com/anchore/go-testutils"
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/stereoscope/pkg/image"
-	"github.com/logrusorgru/aurora"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/pkg/tree/node/id_test.go
+++ b/pkg/tree/node/id_test.go
@@ -2,8 +2,9 @@ package node
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIDSet_Size(t *testing.T) {

--- a/pkg/tree/tree_test.go
+++ b/pkg/tree/tree_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/anchore/stereoscope/pkg/tree/node"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/stereoscope/pkg/tree/node"
 )
 
 type testNode struct {

--- a/test/integration/fixture_image_opaque_directory_test.go
+++ b/test/integration/fixture_image_opaque_directory_test.go
@@ -1,10 +1,11 @@
 package integration
 
 import (
+	"testing"
+
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree"
 	"github.com/anchore/stereoscope/pkg/imagetest"
-	"testing"
 )
 
 func TestImage_SquashedTree_OpaqueDirectoryExistsInFileCatalog(t *testing.T) {

--- a/test/integration/fixture_image_simple_test.go
+++ b/test/integration/fixture_image_simple_test.go
@@ -10,15 +10,16 @@ import (
 	"strings"
 	"testing"
 
+	v1Types "github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/scylladb/go-set"
+	"github.com/stretchr/testify/require"
+
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/stereoscope/pkg/image/sif"
 	"github.com/anchore/stereoscope/pkg/imagetest"
-	v1Types "github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/scylladb/go-set"
-	"github.com/stretchr/testify/require"
 )
 
 // Common layer metadata for OCI / Docker / Podman. MediaType will be filled in during test.

--- a/test/integration/fixture_image_symlinks_test.go
+++ b/test/integration/fixture_image_symlinks_test.go
@@ -5,15 +5,16 @@ package integration
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io"
 	"testing"
+
+	"github.com/scylladb/go-set"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/stereoscope/pkg/imagetest"
-	"github.com/scylladb/go-set"
 )
 
 type linkFetchConfig struct {

--- a/test/integration/mime_type_detection_test.go
+++ b/test/integration/mime_type_detection_test.go
@@ -2,11 +2,13 @@ package integration
 
 import (
 	"context"
-	"github.com/anchore/stereoscope"
-	"github.com/anchore/stereoscope/pkg/imagetest"
+	"testing"
+
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/assert"
-	"testing"
+
+	"github.com/anchore/stereoscope"
+	"github.com/anchore/stereoscope/pkg/imagetest"
 )
 
 func TestContentMIMETypeDetection(t *testing.T) {

--- a/test/integration/oci_registry_source_test.go
+++ b/test/integration/oci_registry_source_test.go
@@ -3,11 +3,12 @@ package integration
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
 
-	"github.com/anchore/stereoscope"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/stereoscope"
 )
 
 func TestOciRegistrySourceMetadata(t *testing.T) {

--- a/test/integration/platform_test.go
+++ b/test/integration/platform_test.go
@@ -3,12 +3,14 @@ package integration
 import (
 	"context"
 	"fmt"
-	"github.com/anchore/stereoscope"
-	"github.com/anchore/stereoscope/pkg/image"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/stereoscope"
+	"github.com/anchore/stereoscope/pkg/image"
 )
 
 func TestPlatformSelection(t *testing.T) {

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -1,11 +1,11 @@
 package integration
 
 import (
-	"github.com/anchore/stereoscope/pkg/filetree"
-	"github.com/anchore/stereoscope/pkg/filetree/filenode"
 	"testing"
 
 	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree"
+	"github.com/anchore/stereoscope/pkg/filetree/filenode"
 	"github.com/anchore/stereoscope/pkg/image"
 )
 


### PR DESCRIPTION
Splits the format-related tasks in the `lint-fix` target into a new `format` target (which `lint-fix` depends on).

Additionally updates the linter, lint targets, and thus there are code changes due to new linting behaviors. (The `Makefile` is the main file for review)