### PR TITLE
refactor: embed fs.FileInfo within file.Metadata

### DIFF
--- a/pkg/file/tarutil_test.go
+++ b/pkg/file/tarutil_test.go
@@ -57,38 +57,42 @@ func TestMetadataFromTar(t *testing.T) {
 	tests := []struct {
 		name     string
 		fixture  string
-		expected expected
+		expected Metadata
 	}{
 		{
 			name:    "path/branch/two/file-2.txt",
 			fixture: "fixture-1",
-			expected: expected{
+			expected: Metadata{
 				Path:            "/path/branch/two/file-2.txt",
 				LinkDestination: "",
-				Size:            12,
 				UserID:          1337,
 				GroupID:         5432,
 				Type:            TypeRegular,
-				IsDir:           false,
-				Mode:            0x1ed,
 				MIMEType:        "application/octet-stream",
-				ModTime:         time.Date(2019, time.September, 16, 0, 0, 0, 0, time.Local),
+				FileInfo: ManualInfo{
+					NameValue:    "file-2.txt",
+					SizeValue:    12,
+					ModeValue:    0x1ed,
+					ModTimeValue: time.Date(2019, time.September, 16, 0, 0, 0, 0, time.UTC),
+				},
 			},
 		},
 		{
 			name:    "path/branch/two/",
 			fixture: "fixture-1",
-			expected: expected{
+			expected: Metadata{
 				Path:            "/path/branch/two",
 				LinkDestination: "",
-				Size:            0,
 				UserID:          1337,
 				GroupID:         5432,
 				Type:            TypeDirectory,
-				IsDir:           true,
-				Mode:            0x800001ed,
 				MIMEType:        "",
-				ModTime:         time.Date(2019, time.September, 16, 0, 0, 0, 0, time.Local),
+				FileInfo: ManualInfo{
+					NameValue:    "two",
+					SizeValue:    0,
+					ModeValue:    0x800001ed,
+					ModTimeValue: time.Date(2019, time.September, 16, 0, 0, 0, 0, time.UTC),
+				},
 			},
 		},
 	}
@@ -97,7 +101,7 @@ func TestMetadataFromTar(t *testing.T) {
 			f := getTarFixture(t, test.fixture)
 			metadata, err := MetadataFromTar(f, test.name)
 			assert.NoError(t, err)
-			test.expected.assertEqual(t, metadata)
+			assertMetadataEqual(t, test.expected, metadata)
 		})
 	}
 }

--- a/pkg/file/tarutil_test.go
+++ b/pkg/file/tarutil_test.go
@@ -57,12 +57,12 @@ func TestMetadataFromTar(t *testing.T) {
 	tests := []struct {
 		name     string
 		fixture  string
-		expected Metadata
+		expected expected
 	}{
 		{
 			name:    "path/branch/two/file-2.txt",
 			fixture: "fixture-1",
-			expected: Metadata{
+			expected: expected{
 				Path:            "/path/branch/two/file-2.txt",
 				LinkDestination: "",
 				Size:            12,
@@ -72,15 +72,13 @@ func TestMetadataFromTar(t *testing.T) {
 				IsDir:           false,
 				Mode:            0x1ed,
 				MIMEType:        "application/octet-stream",
-				ModTime:         time.Date(2019, time.September, 16, 0, 0, 0, 0, time.UTC),
-				AccessTime:      time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
-				ChangeTime:      time.Time{},
+				ModTime:         time.Date(2019, time.September, 16, 0, 0, 0, 0, time.Local),
 			},
 		},
 		{
 			name:    "path/branch/two/",
 			fixture: "fixture-1",
-			expected: Metadata{
+			expected: expected{
 				Path:            "/path/branch/two",
 				LinkDestination: "",
 				Size:            0,
@@ -90,9 +88,7 @@ func TestMetadataFromTar(t *testing.T) {
 				IsDir:           true,
 				Mode:            0x800001ed,
 				MIMEType:        "",
-				ModTime:         time.Date(2019, time.September, 16, 0, 0, 0, 0, time.UTC),
-				AccessTime:      time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
-				ChangeTime:      time.Time{},
+				ModTime:         time.Date(2019, time.September, 16, 0, 0, 0, 0, time.Local),
 			},
 		},
 	}
@@ -101,7 +97,7 @@ func TestMetadataFromTar(t *testing.T) {
 			f := getTarFixture(t, test.fixture)
 			metadata, err := MetadataFromTar(f, test.name)
 			assert.NoError(t, err)
-			assert.Equal(t, test.expected, metadata)
+			test.expected.assertEqual(t, metadata)
 		})
 	}
 }

--- a/pkg/image/docker/manifest.go
+++ b/pkg/image/docker/manifest.go
@@ -107,7 +107,7 @@ func generateOCIManifest(tarPath string, manifest *dockerManifest) (*v1.Manifest
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to find layer tar: %w", err)
 		}
-		layerSizes[idx] = layerMetadata.Size
+		layerSizes[idx] = layerMetadata.Size()
 	}
 
 	theManifest, err := assembleOCIManifest(configContents, layerSizes)

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -236,7 +236,7 @@ func layerTarIndexer(ft filetree.Writer, fileCatalog *FileCatalog, size *int64, 
 		}
 
 		if size != nil {
-			*(size) += metadata.Size
+			*(size) += metadata.Size()
 		}
 		fileCatalog.addImageReferences(ref.ID(), layerRef, index.Open)
 
@@ -273,7 +273,7 @@ func squashfsVisitor(ft filetree.Writer, fileCatalog *FileCatalog, size *int64, 
 		}
 
 		if size != nil {
-			*(size) += metadata.Size
+			*(size) += metadata.Size()
 		}
 		fileCatalog.addImageReferences(fileReference.ID(), layerRef, func() io.ReadCloser {
 			r, err := fsys.Open(path)


### PR DESCRIPTION
As discussed in today's community call... here is a proposal to go with #171. Thanks in advance for takin the time to discuss it, and for any feedback on this change.

Embed the original `fs.FileInfo` directly within the `file.Metadata struct`, replacing the previous `Size`, `IsDir`, `Mode`, and `ModTime` fields.

I'm also proposing the removal of the recently added `AccessTime` and `ChangeTime` fields from the `file.Metadata` struct, with the argument that they're currently unset except when the `Metadata` refers to a TAR layer, and the layer uses a format other than the relatively common `USTAR` ([ref](https://pkg.go.dev/archive/tar#Format)). Technically, a `fs.FileInfo` still exposes these via `fs.FileInfo.Sys()` if the returned value is of type `*tar.Header`. I believe this approach discourages use of fields which won't be set very often, while still making them available to those willing to dig. All that being said, I'm not strongly opinionated here!

Closes  #171 