### PR TITLE
Specify platform in integ test images

### DIFF
--- a/test/integration/test-fixtures/image-opaque-directory/Dockerfile
+++ b/test/integration/test-fixtures/image-opaque-directory/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM --platform=linux/amd64 centos:7
 
 RUN curl -sLO https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.rpm
 RUN rpm -i amazon-corretto-11-x64-linux-jdk.rpm

--- a/test/integration/tools/singularity/Dockerfile
+++ b/test/integration/tools/singularity/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:20.04
+# force platform since https://github.com/sylabs/singularity/releases
+# has no arm64 releases.
 RUN  apt-get update && apt-get install curl -y && \
      curl -sLO https://github.com/sylabs/singularity/releases/download/v3.10.0/singularity-ce_3.10.0-focal_amd64.deb && \
      apt-get install -f ./singularity-ce_3.10.0-focal_amd64.deb -y


### PR DESCRIPTION
Otherwise, "make integration" will fail on M1 Macs. Note that this is a workaround which assumes that, if "make integration" is run on an arm64 host, that host is able to run containers from amd64 images. This change enables development on stereoscope on M1 Macs, but may not enable it on other arm64 machines.