### PR TITLE
fix: goroutine leak with docker daemon 

### DIFF
--- a/client.go
+++ b/client.go
@@ -81,7 +81,10 @@ func GetImageFromSource(ctx context.Context, imgStr string, source image.Source,
 		}
 	}
 
-	provider, err := selectImageProvider(imgStr, source, cfg)
+	provider, cleanup, err := selectImageProvider(imgStr, source, cfg)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -99,44 +102,60 @@ func GetImageFromSource(ctx context.Context, imgStr string, source image.Source,
 	return img, nil
 }
 
-func selectImageProvider(imgStr string, source image.Source, cfg config) (image.Provider, error) {
+func selectImageProvider(imgStr string, source image.Source, cfg config) (image.Provider, func(), error) {
 	var provider image.Provider
 	tempDirGenerator := rootTempDirGenerator.NewGenerator()
 	platformSelectionUnsupported := fmt.Errorf("specified platform=%q however image source=%q does not support selecting platform", cfg.Platform.String(), source.String())
 
+	cleanup := func() {}
+
 	switch source {
 	case image.DockerTarballSource:
 		if cfg.Platform != nil {
-			return nil, platformSelectionUnsupported
+			return nil, cleanup, platformSelectionUnsupported
 		}
 		// note: the imgStr is the path on disk to the tar file
 		provider = docker.NewProviderFromTarball(imgStr, tempDirGenerator)
 	case image.DockerDaemonSource:
 		c, err := dockerClient.GetClient()
 		if err != nil {
-			return nil, err
+			return nil, cleanup, err
 		}
+
+		cleanup = func() {
+			if err := c.Close(); err != nil {
+				log.Errorf("unable to close docker client: %+v", err)
+			}
+		}
+
 		provider, err = docker.NewProviderFromDaemon(imgStr, tempDirGenerator, c, cfg.Platform)
 		if err != nil {
-			return nil, err
+			return nil, cleanup, err
 		}
 	case image.PodmanDaemonSource:
 		c, err := podman.GetClient()
 		if err != nil {
-			return nil, err
+			return nil, cleanup, err
 		}
+
+		cleanup = func() {
+			if err := c.Close(); err != nil {
+				log.Errorf("unable to close docker client: %+v", err)
+			}
+		}
+
 		provider, err = docker.NewProviderFromDaemon(imgStr, tempDirGenerator, c, cfg.Platform)
 		if err != nil {
-			return nil, err
+			return nil, cleanup, err
 		}
 	case image.OciDirectorySource:
 		if cfg.Platform != nil {
-			return nil, platformSelectionUnsupported
+			return nil, cleanup, platformSelectionUnsupported
 		}
 		provider = oci.NewProviderFromPath(imgStr, tempDirGenerator)
 	case image.OciTarballSource:
 		if cfg.Platform != nil {
-			return nil, platformSelectionUnsupported
+			return nil, cleanup, platformSelectionUnsupported
 		}
 		provider = oci.NewProviderFromTarball(imgStr, tempDirGenerator)
 	case image.OciRegistrySource:
@@ -144,13 +163,13 @@ func selectImageProvider(imgStr string, source image.Source, cfg config) (image.
 		provider = oci.NewProviderFromRegistry(imgStr, tempDirGenerator, cfg.Registry, cfg.Platform)
 	case image.SingularitySource:
 		if cfg.Platform != nil {
-			return nil, platformSelectionUnsupported
+			return nil, cleanup, platformSelectionUnsupported
 		}
 		provider = sif.NewProviderFromPath(imgStr, tempDirGenerator)
 	default:
-		return nil, fmt.Errorf("unable to determine image source")
+		return nil, cleanup, fmt.Errorf("unable to determine image source")
 	}
-	return provider, nil
+	return provider, cleanup, nil
 }
 
 // defaultPlatformIfNil sets the platform to use the host's architecture

--- a/client.go
+++ b/client.go
@@ -102,6 +102,7 @@ func GetImageFromSource(ctx context.Context, imgStr string, source image.Source,
 	return img, nil
 }
 
+// nolint:funlen
 func selectImageProvider(imgStr string, source image.Source, cfg config) (image.Provider, func(), error) {
 	var provider image.Provider
 	tempDirGenerator := rootTempDirGenerator.NewGenerator()

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -1,13 +1,10 @@
 package docker
 
 import (
-	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/docker/cli/cli/connhelper"
 	"github.com/docker/docker/client"
@@ -50,20 +47,6 @@ func GetClient() (*client.Client, error) {
 			return nil, fmt.Errorf("failed create docker client: %w", err)
 		}
 	}
-
-	clientOpts = append(clientOpts, func(c *client.Client) error {
-		httpClient := &http.Client{
-			Transport: &http.Transport{
-				DisableKeepAlives: true,
-				IdleConnTimeout:   10 * time.Second,
-			},
-		}
-		return client.WithHTTPClient(httpClient)(c)
-	})
-
-	clientOpts = append(clientOpts, client.WithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return net.Dial("unix", "/var/run/docker.sock") // In some cases, the path of unix socket is not /var/run/docker.sock
-	}))
 
 	dockerClient, err := client.NewClientWithOpts(clientOpts...)
 	if err != nil {


### PR DESCRIPTION
This commit addresses a goroutine leak that occurs when continuously communicating with the Docker daemon via the Unix socket. Previously, these connections were not being properly released, leading to a growing number of goroutines over time.

The first solution with https://github.com/anchore/stereoscope/pull/183/commits/4cf42ace9aa21cc44fc18bab7721618fdf13bb73 involved modifying the http.Transport of the Docker client to disable keep-alives and set an idle connection timeout. This effectively closes idle connections, thereby preventing the goroutine leak.

Based off of [comments on the issue](https://github.com/anchore/stereoscope/issues/182#issuecomment-1634919267) this was pivoted to close the client after the provider is used for the first time.

Resolves: #182