### PR TITLE
fix: avoid data race in NewFileReference

### DIFF
--- a/pkg/file/id.go
+++ b/pkg/file/id.go
@@ -1,6 +1,8 @@
 package file
 
-var nextID = 0 // note: this is governed by the reference constructor
+import "sync/atomic"
+
+var nextID atomic.Uint64 // note: this is governed by the reference constructor
 
 // ID is used for file tree manipulation to uniquely identify tree nodes.
 type ID uint64

--- a/pkg/file/reference.go
+++ b/pkg/file/reference.go
@@ -10,10 +10,9 @@ type Reference struct {
 
 // NewFileReference creates a new unique file reference for the given path.
 func NewFileReference(path Path) *Reference {
-	nextID++
 	return &Reference{
 		RealPath: path,
-		id:       ID(nextID),
+		id:       ID(nextID.Add(1)),
 	}
 }
 


### PR DESCRIPTION
Use `atomic.Uint64` to safely generate IDs when run in parallel.

Closes #184 