### PR TITLE
DRAFT: Improve architecture selection

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package stereoscope
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/wagoodman/go-partybus"
@@ -210,6 +211,11 @@ func GetImageIndex(ctx context.Context, userStr string, options ...Option) ([]by
 	if err != nil {
 		return nil, err
 	}
+	m, err := index.IndexManifest()
+	for _, man := range m.Manifests {
+		fmt.Fprintf(os.Stderr, "manifest was: %+v", man)
+	}
+
 	return index.RawManifest()
 }
 

--- a/test/integration/oci_registry_source_test.go
+++ b/test/integration/oci_registry_source_test.go
@@ -109,6 +109,8 @@ func TestOciRegistryArchHandling(t *testing.T) {
 }
 
 func getSingleArchImageNotMatchingHostArch() string {
+	// TODO: publish test images to anchore/test_images
+	// and use those
 	if runtime.GOARCH != "amd64" {
 		return "rancher/busybox:1.31.1"
 	}
@@ -116,5 +118,10 @@ func getSingleArchImageNotMatchingHostArch() string {
 }
 
 func getMultiArchImageNotContainingHostArch() string {
-	return ""
+	// TODO: publish test images to anchore/test_images
+	// and use those
+	if runtime.GOARCH == "arm64" {
+		return "localhost:5001/learn-multi-arch:no-arm"
+	}
+	return "localhost:5001/learn-multi-arch:no-amd64"
 }


### PR DESCRIPTION
This is a draft PR to track improving architecture selection in stereoscope.

Basically, when a user of `syft` or `grype` specifies a digest, we should not validate the platform, since a digest is an unambiguous reference, but we fail on the platofrm. For example:

```
❯ grype mcr.microsoft.com/cbl-mariner/base/core:2.0.20220731-amd64@sha256:3c0f7e103ff3c39e81e7c9c042d2b321d833fb6d26d8636567f7d88a6bdde74a
 ✔ Vulnerability DB        [no update available]
 ⠹ Pulling image           2 Layers▕ █▏[28 MB] Extracting...
1 error occurred:
	* failed to catalog: could not fetch image "mcr.microsoft.com/cbl-mariner/base/core:2.0.20220731-amd64@sha256:3c0f7e103ff3c39e81e7c9c042d2b321d833fb6d26d8636567f7d88a6bdde74a": unable to use DockerDaemon source: image has unexpected architecture "amd64", which differs from the user specified architecture "arm64"
```

This was probably introduced by https://github.com/anchore/stereoscope/pull/152 in fixing https://github.com/anchore/stereoscope/issues/149.

The goal of this change is to preserve the fix to https://github.com/anchore/stereoscope/issues/149 but remove the issue, seen via `grype` above, where unambiguous requests fail at https://github.com/anchore/stereoscope/blob/e14bc4437b2eac481c5b6f101890b22df4f33596/pkg/image/docker/daemon_provider.go#L348 even when the user didn't pass `--platform`.

It's a draft pull request for now because I need to make test images at https://github.com/anchore/test-images to exercise the different scenarios in stereoscope integration tests before it can be merged.