### PR TITLE
Read docker host/socket location from the current docker context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 require (
 	cloud.google.com/go/compute v1.19.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
 	golang.org/x/mod v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
+github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQmYw=
+github.com/fvbommel/sortorder v1.1.0/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/gabriel-vasile/mimetype v1.4.0 h1:Cn9dkdYsMIu56tGho+fqzh7XmvY2YyGU0FnbhiOsEro=
 github.com/gabriel-vasile/mimetype v1.4.0/go.mod h1:fA8fi6KUiG7MgQQ+mEWotXoEOvmxRtOJlERCzSmRvr8=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=

--- a/internal/docker/config.go
+++ b/internal/docker/config.go
@@ -1,0 +1,76 @@
+package docker
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/context/store"
+	"github.com/docker/docker/pkg/homedir"
+)
+
+const (
+	defaultContextName = "default"
+	dockerEndpoint     = "docker"
+
+	envOverrideContext = "DOCKER_CONTEXT"
+)
+
+var (
+	configFileDir  = filepath.Join(homedir.Get(), ".docker")
+	contextsDir    = filepath.Join(configFileDir, "contexts")
+	configFileName = filepath.Join(configFileDir, "config.json")
+)
+
+func resolveContextName(config *configfile.ConfigFile) string {
+	if ctxName := os.Getenv(envOverrideContext); ctxName != "" {
+		return ctxName
+	}
+	if config != nil && config.CurrentContext != "" {
+		return config.CurrentContext
+	}
+	return defaultContextName
+}
+
+func loadConfig(filename string) (*configfile.ConfigFile, error) {
+	cfg := configfile.New(filename)
+
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cfg.LoadFromReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("cant parse docker config: %w", err)
+	}
+
+	return cfg, err
+}
+
+func endpointFromConfig(cfg *configfile.ConfigFile) (string, error) {
+	ctx := resolveContextName(cfg)
+
+	st := store.New(config.ContextStoreDir(), store.Config{})
+
+	meta, err := st.GetMetadata(ctx)
+	if err != nil {
+		return "", fmt.Errorf("cant get docker config metadata: %w", err)
+	}
+
+	// retrieving endpoint
+	ep, ok := meta.Endpoints[dockerEndpoint].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("cant get docker endpoint from metadata: %w", err)
+	}
+
+	host, ok := ep["Host"].(string)
+	if !ok {
+		return "", fmt.Errorf("cant get docker host from metadata: %w", err)
+	}
+
+	return host, nil
+}

--- a/internal/docker/config.go
+++ b/internal/docker/config.go
@@ -51,9 +51,7 @@ func loadConfig(filename string) (*configfile.ConfigFile, error) {
 	return cfg, err
 }
 
-func endpointFromConfig(cfg *configfile.ConfigFile) (string, error) {
-	ctx := resolveContextName(cfg)
-
+func endpointFromContext(ctx string) (string, error) {
 	st := store.New(config.ContextStoreDir(), store.Config{})
 
 	meta, err := st.GetMetadata(ctx)

--- a/internal/docker/config_test.go
+++ b/internal/docker/config_test.go
@@ -1,0 +1,208 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_loadConfig(t *testing.T) {
+	root := "test-fixtures"
+
+	prepareConfig := func(t *testing.T, context, fname string) *configfile.ConfigFile {
+		t.Helper()
+		cfg := configfile.New(fname)
+		cfg.CurrentContext = context
+
+		return cfg
+	}
+
+	tests := []struct {
+		name     string
+		filename string
+		want     *configfile.ConfigFile
+		err      error
+		wantErr  bool
+	}{
+		{
+			name:     "config file not found",
+			filename: "some-nonexisting-file",
+			wantErr:  true,
+		},
+		{
+			name:     "config file parsed normally",
+			filename: filepath.Join(root, "config0.json"),
+			wantErr:  false,
+			want:     prepareConfig(t, "colima", filepath.Join(root, "config0.json")),
+		},
+		{
+			name:     "config file cannot be parsed",
+			filename: filepath.Join(root, "config1.json"),
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := loadConfig(tt.filename)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_resolveContextName(t *testing.T) {
+	type args struct {
+		contextOverride string
+		config          *configfile.ConfigFile
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "respect contextOverride",
+			args: args{
+				contextOverride: "contextFromEnvironment",
+			},
+			want: "contextFromEnvironment",
+		},
+		{
+			name: "returns default context name if config is nil",
+			args: args{},
+			want: "default",
+		},
+		{
+			name: "returns context from the config",
+			args: args{
+				config: &configfile.ConfigFile{
+					CurrentContext: "colima",
+				},
+			},
+			want: "colima",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveContextName(tt.args.contextOverride, tt.args.config)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_endpointFromContext(t *testing.T) {
+	root := "test-fixtures"
+
+	tmpCtxDir := func(t *testing.T) string {
+		t.Helper()
+		d, err := os.MkdirTemp("", "tests")
+		if err != nil {
+			t.Fatalf("cant setup test: %v", err)
+		}
+
+		ctxDir := filepath.Join(d, "contexts")
+		err = os.MkdirAll(ctxDir, 0o755)
+		if err != nil {
+			t.Fatalf("cant setup test: %v", err)
+		}
+
+		return ctxDir
+	}
+
+	readFixture := func(t *testing.T, name string) []byte {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			t.Fatalf("cant setup test: %v", err)
+		}
+
+		return data
+	}
+
+	// meta files stored under ~/.docker with names like
+	// ~/.docker/contexts/meta/f24fd3749c1368328e2b149bec149cb6795619f244c5b584e844961215dadd16/meta.json
+	writeTestMeta := func(t *testing.T, fixture, dir, contextName string) {
+		t.Helper()
+		data := readFixture(t, fixture)
+		dd := digest.FromString(contextName)
+
+		base := filepath.Join(dir, "meta", dd.Encoded())
+
+		err := os.MkdirAll(base, 0o755)
+		if err != nil {
+			t.Fatalf("cant setup test: %v", err)
+		}
+
+		outFname := filepath.Join(base, "meta.json")
+
+		err = os.WriteFile(outFname, data, 0o600)
+		if err != nil {
+			t.Fatalf("cant setup test: %v", err)
+		}
+
+		t.Logf("fixture %s written to: %s", fixture, outFname)
+	}
+
+	tests := []struct {
+		name    string
+		ctxName string
+		want    string
+		fixture string
+		wantErr bool
+	}{
+		{
+			name:    "reads docker host from the meta data",
+			want:    "unix:///some_weird_location/.colima/docker.sock",
+			ctxName: "colima",
+			fixture: "meta0.json",
+		},
+		{
+			name:    "cant read docker host from the meta data",
+			want:    "",
+			ctxName: "colima",
+			fixture: "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid endpoint name",
+			want:    "",
+			ctxName: "colima",
+			fixture: "meta1.json",
+			wantErr: true,
+		},
+		{
+			name:    "no host defined",
+			want:    "",
+			ctxName: "colima",
+			fixture: "meta2.json",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tmpCtxDir(t)
+			if tt.fixture != "" {
+				writeTestMeta(t, tt.fixture, dir, tt.ctxName)
+			}
+
+			got, err := endpointFromContext(dir, tt.ctxName)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/docker/test-fixtures/config0.json
+++ b/internal/docker/test-fixtures/config0.json
@@ -1,0 +1,4 @@
+{
+    "auths": {},
+    "currentContext": "colima"
+}

--- a/internal/docker/test-fixtures/config1.json
+++ b/internal/docker/test-fixtures/config1.json
@@ -1,0 +1,5 @@
+BROKEN_JSON_FILE
+{
+    "auths": {},
+    "currentContext": "colima"
+}

--- a/internal/docker/test-fixtures/meta0.json
+++ b/internal/docker/test-fixtures/meta0.json
@@ -1,0 +1,1 @@
+{"Name":"colima","Metadata":{"Description":"colima"},"Endpoints":{"docker":{"Host":"unix:///some_weird_location/.colima/docker.sock","SkipTLSVerify":false}}}

--- a/internal/docker/test-fixtures/meta1.json
+++ b/internal/docker/test-fixtures/meta1.json
@@ -1,0 +1,1 @@
+{"Name":"colima","Metadata":{"Description":"colima"},"Endpoints":{"INVALID-NONDOCKER-ENDPOINT":{"Host":"unix:///some_weird_location/.colima/docker.sock","SkipTLSVerify":false}}}

--- a/internal/docker/test-fixtures/meta2.json
+++ b/internal/docker/test-fixtures/meta2.json
@@ -1,0 +1,1 @@
+{"Name":"colima","Metadata":{"Description":"colima"},"Endpoints":{"docker":{"NO-HOSTNAME-DEFINED":"unix:///some_weird_location/.colima/docker.sock","SkipTLSVerify":false}}}


### PR DESCRIPTION
Reading dockerd socket/host location from the current docker context
It resolves the issues with lima/colima/docker desktop set ups.

This PR probably needs more work (tests, style, etc), I will appreciate the comments.
Parts of the code are coming from https://github.com/docker/cli repo.
Changes were tested with syft and local lima setup on MacOS.