### PR TITLE
Fix Podman client address resolution

### DIFF
--- a/examples/basic.go
+++ b/examples/basic.go
@@ -21,7 +21,7 @@ func main() {
 
 	lctx, err := logrus.New(logrus.Config{
 		EnableConsole: true,
-		Level:         logger.DebugLevel,
+		Level:         logger.TraceLevel,
 	})
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible
+	github.com/adrg/xdg v0.4.0
 	github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220517224237-e6f29200ae04
@@ -34,6 +35,8 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute v1.19.0 // indirect
+	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.7.1 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.5.0 // indirect
@@ -54,11 +57,13 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.16.4 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
@@ -71,24 +76,17 @@ require (
 	github.com/therootcompany/xz v1.0.1 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
+	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.6.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
+	golang.org/x/tools v0.8.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230403163135-c38d8f061ccd // indirect
 	google.golang.org/grpc v1.54.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
-
-require (
-	cloud.google.com/go/compute v1.19.0 // indirect
-	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	github.com/golang/mock v1.6.0 // indirect
-	github.com/kr/pretty v0.2.1 // indirect
-	golang.org/x/mod v0.10.0 // indirect
-	golang.org/x/tools v0.8.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible h1:juIa
 github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible/go.mod h1:BB1eHdMLYEFuFdBlRMb0N7YGVdM5s6Pt0njxgvfbGGs=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8 h1:imgMA0gN0TZx7PSa/pdWqXadBvrz8WsN6zySzCe4XX0=
 github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8/go.mod h1:+gPap4jha079qzRTUaehv+UZ6sSdaNwkH0D3b6zhTuk=
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0vW0nnNKJfJieyH/TZ9UYAnTZs5/gHTdAe8=
@@ -221,6 +223,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/adrg/xdg"
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 
@@ -16,6 +17,8 @@ var (
 	ErrNoSocketAddress = errors.New("no socket address")
 	ErrNoHostAddress   = errors.New("no host address")
 )
+
+const defaultSocketPath = "/run/podman/podman.sock"
 
 func ClientOverSSH() (*client.Client, error) {
 	var clientOpts = []client.Opt{
@@ -70,29 +73,16 @@ func ClientOverUnixSocket() (*client.Client, error) {
 		client.WithAPIVersionNegotiation(),
 	}
 
-	addr := getUnixSocketAddress(configPaths)
-	if v, found := os.LookupEnv("CONTAINER_HOST"); found && v != "" {
-		addr = v
-	}
-
-	if addr == "" { // in some cases there might not be any config file
-		// we can try guessing; podman CLI does that
-		socketPath := fmt.Sprintf("/run/user/%d/podman/podman.sock", os.Getuid())
-		log.Debugf("no socket address was found. Trying default address: %s", socketPath)
-		_, err := os.Stat(socketPath)
-		if err != nil {
-			log.Debugf("looking for socket file: %v", err)
-			return nil, ErrNoSocketAddress
-		}
-
-		addr = fmt.Sprintf("unix://%s", socketPath)
+	addr, err := getContainerHostAddress(configPaths, xdg.RuntimeDir, defaultSocketPath)
+	if err != nil {
+		return nil, err
 	}
 
 	clientOpts = append(clientOpts, client.WithHost(addr))
 
 	c, err := client.NewClientWithOpts(clientOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("creating local client for podman: %w", err)
+		return nil, fmt.Errorf("failed to create podman client: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*3)
@@ -102,11 +92,49 @@ func ClientOverUnixSocket() (*client.Client, error) {
 	return c, err
 }
 
+func getContainerHostAddress(configPaths []string, xdgRuntimeDir, defaultSocketPath string) (string, error) {
+	var addr string
+	if v, found := os.LookupEnv("CONTAINER_HOST"); found && v != "" {
+		addr = v
+	} else {
+		addr = getUnixSocketAddressFromConfig(configPaths)
+	}
+
+	if addr != "" {
+		return addr, nil
+	}
+
+	// in some cases there might not be any config file, in which case we can try guessing (the same way the podman CLI does)
+	candidateAddresses := []string{
+		// default rootless address for the podman-system-service
+		fmt.Sprintf("%s/podman/podman.sock", xdgRuntimeDir),
+
+		// typically accessible to only root, but last ditch effort
+		defaultSocketPath,
+	}
+
+	for _, candidate := range candidateAddresses {
+		log.WithFields("path", candidate).Trace("trying podman socket")
+		_, err := os.Stat(candidate)
+		if err == nil {
+			addr = fmt.Sprintf("unix://%s", candidate)
+			break
+		}
+	}
+
+	if addr == "" {
+		return "", ErrNoSocketAddress
+	}
+
+	return addr, nil
+}
+
 func GetClient() (*client.Client, error) {
 	c, err := ClientOverUnixSocket()
 	if err == nil {
 		return c, nil
 	}
+	log.WithFields("error", err).Trace("unable to connect to podman via unix socket")
 
 	return ClientOverSSH()
 }

--- a/internal/podman/client_test.go
+++ b/internal/podman/client_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,10 +26,10 @@ func Test_getContainerHostAddress(t *testing.T) {
 			args: args{
 				containerHostEnvVar: "unix:///somewhere/podman.sock",
 				configPaths: []string{
-					"test-fixtures/containers.conf",
+					"containers.conf",
 				},
-				xdgRuntimeDir:     "test-fixtures/xdg-runtime",
-				defaultSocketPath: "test-fixtures/default/podman.sock",
+				xdgRuntimeDir:     "/xdg-runtime",
+				defaultSocketPath: "/default/podman.sock",
 			},
 			want:    "unix:///somewhere/podman.sock",
 			wantErr: assert.NoError,
@@ -38,12 +39,12 @@ func Test_getContainerHostAddress(t *testing.T) {
 			args: args{
 				containerHostEnvVar: "",
 				configPaths: []string{
-					"test-fixtures/containers-relative.conf",
+					"containers-relative.conf",
 				},
-				xdgRuntimeDir:     "test-fixtures/xdg-runtime",
-				defaultSocketPath: "test-fixtures/default/podman.sock",
+				xdgRuntimeDir:     "/xdg-runtime",
+				defaultSocketPath: "/default/podman.sock",
 			},
-			want:    "unix://user/podman.sock",
+			want:    "unix:///user/podman.sock",
 			wantErr: assert.NoError,
 		},
 		{
@@ -51,10 +52,10 @@ func Test_getContainerHostAddress(t *testing.T) {
 			args: args{
 				containerHostEnvVar: "",
 				configPaths:         []string{},
-				xdgRuntimeDir:       "test-fixtures/xdg-runtime",
-				defaultSocketPath:   "test-fixtures/default/podman.sock",
+				xdgRuntimeDir:       "/xdg-runtime",
+				defaultSocketPath:   "/default/podman.sock",
 			},
-			want:    "unix://test-fixtures/xdg-runtime/podman/podman.sock",
+			want:    "unix:///xdg-runtime/podman/podman.sock",
 			wantErr: assert.NoError,
 		},
 		{
@@ -63,9 +64,9 @@ func Test_getContainerHostAddress(t *testing.T) {
 				containerHostEnvVar: "",
 				configPaths:         []string{},
 				xdgRuntimeDir:       "does-not-exist",
-				defaultSocketPath:   "test-fixtures/default/podman.sock",
+				defaultSocketPath:   "/default/podman.sock",
 			},
-			want:    "unix://test-fixtures/default/podman.sock",
+			want:    "unix:///default/podman.sock",
 			wantErr: assert.NoError,
 		},
 		{
@@ -82,7 +83,8 @@ func Test_getContainerHostAddress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("CONTAINER_HOST", tt.args.containerHostEnvVar)
-			got, err := getContainerHostAddress(tt.args.configPaths, tt.args.xdgRuntimeDir, tt.args.defaultSocketPath)
+			fs := afero.NewBasePathFs(afero.NewOsFs(), "test-fixtures")
+			got, err := getContainerHostAddress(fs, tt.args.configPaths, tt.args.xdgRuntimeDir, tt.args.defaultSocketPath)
 			if !tt.wantErr(t, err, fmt.Sprintf("getContainerHostAddress(%v, %v)", tt.args.configPaths, tt.args.xdgRuntimeDir)) {
 				return
 			}

--- a/internal/podman/client_test.go
+++ b/internal/podman/client_test.go
@@ -1,0 +1,92 @@
+package podman
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getContainerHostAddress(t *testing.T) {
+	type args struct {
+		containerHostEnvVar string
+		configPaths         []string
+		xdgRuntimeDir       string
+		defaultSocketPath   string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "env vars > config",
+			args: args{
+				containerHostEnvVar: "unix:///somewhere/podman.sock",
+				configPaths: []string{
+					"test-fixtures/containers.conf",
+				},
+				xdgRuntimeDir:     "test-fixtures/xdg-runtime",
+				defaultSocketPath: "test-fixtures/default/podman.sock",
+			},
+			want:    "unix:///somewhere/podman.sock",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "config > candidates",
+			args: args{
+				containerHostEnvVar: "",
+				configPaths: []string{
+					"test-fixtures/containers-relative.conf",
+				},
+				xdgRuntimeDir:     "test-fixtures/xdg-runtime",
+				defaultSocketPath: "test-fixtures/default/podman.sock",
+			},
+			want:    "unix://user/podman.sock",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "attempt candidate socket from xdg runtime dir",
+			args: args{
+				containerHostEnvVar: "",
+				configPaths:         []string{},
+				xdgRuntimeDir:       "test-fixtures/xdg-runtime",
+				defaultSocketPath:   "test-fixtures/default/podman.sock",
+			},
+			want:    "unix://test-fixtures/xdg-runtime/podman/podman.sock",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "use default socket candidate last",
+			args: args{
+				containerHostEnvVar: "",
+				configPaths:         []string{},
+				xdgRuntimeDir:       "does-not-exist",
+				defaultSocketPath:   "test-fixtures/default/podman.sock",
+			},
+			want:    "unix://test-fixtures/default/podman.sock",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "error when there are no candidates",
+			args: args{
+				containerHostEnvVar: "",
+				configPaths:         []string{},
+				xdgRuntimeDir:       "does-not-exist",
+				defaultSocketPath:   "does-not-exist",
+			},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CONTAINER_HOST", tt.args.containerHostEnvVar)
+			got, err := getContainerHostAddress(tt.args.configPaths, tt.args.xdgRuntimeDir, tt.args.defaultSocketPath)
+			if !tt.wantErr(t, err, fmt.Sprintf("getContainerHostAddress(%v, %v)", tt.args.configPaths, tt.args.xdgRuntimeDir)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "getContainerHostAddress(%v, %v)", tt.args.configPaths, tt.args.xdgRuntimeDir)
+		})
+	}
+}

--- a/internal/podman/config_test.go
+++ b/internal/podman/config_test.go
@@ -184,7 +184,7 @@ func Test_configPrecedence(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.wantUnixAddress, getUnixSocketAddress(tt.args.paths), "getUnixSocketAddress(%v)", tt.args.paths)
+			assert.Equalf(t, tt.wantUnixAddress, getUnixSocketAddressFromConfig(tt.args.paths), "getUnixSocketAddressFromConfig(%v)", tt.args.paths)
 		})
 	}
 }

--- a/internal/podman/ssh_test.go
+++ b/internal/podman/ssh_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/testdata"
@@ -16,8 +17,8 @@ import (
 
 func TestNewSSHConfig(t *testing.T) {
 	paths := []string{
-		"./test-fixtures/containers.conf",
-		"./test-fixtures/empty.conf",
+		"containers.conf",
+		"empty.conf",
 	}
 
 	const (
@@ -25,7 +26,8 @@ func TestNewSSHConfig(t *testing.T) {
 		sshKeyPath = "/home/jonas/.ssh/podman-machine-default"
 	)
 
-	address, identity := getSSHAddress(paths)
+	fs := afero.NewBasePathFs(afero.NewOsFs(), "test-fixtures")
+	address, identity := getSSHAddress(fs, paths)
 	assert.Equal(t, sshAddress, address)
 	assert.Equal(t, sshKeyPath, identity)
 
@@ -44,10 +46,11 @@ func TestNewSSHConfig(t *testing.T) {
 
 func TestEmptySSHConfig(t *testing.T) {
 	paths := []string{
-		"./test-fixtures/empty.conf",
+		"empty.conf",
 	}
 
-	address, identity := getSSHAddress(paths)
+	fs := afero.NewBasePathFs(afero.NewOsFs(), "test-fixtures")
+	address, identity := getSSHAddress(fs, paths)
 	conf, err := newSSHConf(address, identity, "")
 	assert.Error(t, err)
 	assert.Nil(t, conf)

--- a/internal/podman/test-fixtures/containers-relative.conf
+++ b/internal/podman/test-fixtures/containers-relative.conf
@@ -10,6 +10,6 @@
   stop_timeout = 10
   [engine.service_destinations]
     [engine.service_destinations.default]
-      uri = "unix://user/podman.sock"
+      uri = "unix:///user/podman.sock"
 
 [network]

--- a/internal/podman/test-fixtures/containers-relative.conf
+++ b/internal/podman/test-fixtures/containers-relative.conf
@@ -1,0 +1,15 @@
+[containers]
+  log_size_max = -1
+  pids_limit = 2048
+  userns_size = 65536
+
+[engine]
+  image_parallel_copies = 0
+  num_locks = 2048
+  active_service = "podman-machine-default"
+  stop_timeout = 10
+  [engine.service_destinations]
+    [engine.service_destinations.default]
+      uri = "unix://user/podman.sock"
+
+[network]

--- a/internal/podman/test-fixtures/default/podman.sock
+++ b/internal/podman/test-fixtures/default/podman.sock
@@ -1,0 +1,1 @@
+fake socket file

--- a/internal/podman/test-fixtures/user/podman.sock
+++ b/internal/podman/test-fixtures/user/podman.sock
@@ -1,0 +1,1 @@
+fake socket file

--- a/internal/podman/test-fixtures/xdg-runtime/podman/podman.sock
+++ b/internal/podman/test-fixtures/xdg-runtime/podman/podman.sock
@@ -1,0 +1,1 @@
+fake socket file

--- a/test/integration/test-fixtures/podman/Makefile
+++ b/test/integration/test-fixtures/podman/Makefile
@@ -1,8 +1,10 @@
+IMAGE = localhost/podman-ssh:latest
+
 all: build start
 
 .PHONY: build
 build:
-	docker build -t podman-ssh:latest .
+	docker build -t $(IMAGE) .
 
 .PHONY: ssh
 ssh:
@@ -16,13 +18,17 @@ stop:
 exec:
 	docker exec -it podman bash
 
+.PHONY: status
+status:
+	docker exec -t podman systemctl status sshd podman.socket
+
 .PHONY: start
 start:
 	docker run --rm \
 				-d \
 				--name podman \
-				-it \
+				-t \
 				--privileged \
 				-p 2222:22 \
 				-v $(shell pwd)/ssh:/root/.ssh/ \
-					podman-ssh:latest
+					$(IMAGE)

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -17,6 +17,13 @@ import (
 func runAndShow(t *testing.T, cmd *exec.Cmd) {
 	t.Helper()
 
+	err := runAndShowPassive(t, cmd)
+	require.NoErrorf(t, err, "cmd failed: %+v", err)
+}
+
+func runAndShowPassive(t *testing.T, cmd *exec.Cmd) error {
+	t.Helper()
+
 	stderr, err := cmd.StderrPipe()
 	require.NoErrorf(t, err, "could not get stderr: +v", err)
 
@@ -37,8 +44,7 @@ func runAndShow(t *testing.T, cmd *exec.Cmd) {
 	show("out", stdout)
 	show("err", stderr)
 
-	err = cmd.Wait()
-	require.NoErrorf(t, err, "cmd failed: %+v", err)
+	return cmd.Wait()
 }
 
 func compareLayerSquashTrees(t *testing.T, expected map[uint]filetree.Reader, i *image.Image, ignorePaths []file.Path) {


### PR DESCRIPTION
This refactors some of the podman client address resolution logic such that:

- podman env vars override config files
- rootless socket is attempted first before trying the default socket
- uncomments and fixes the podman integration tests
- refactors the podman os actions to use the afero FS abstraction (makes testing easier for the new client tests)
