### PR TITLE
chore: Fix race in go progress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ check-go-mod-tidy:
 .PHONY: unit
 unit: $(TEMP_DIR) ## Run unit tests (with coverage)
 	$(call title,Running unit tests)
-	go test -coverprofile $(TEMP_DIR)/unit-coverage-details.txt $(shell go list ./... | grep -v anchore/stereoscope/test)
+	go test -race -coverprofile $(TEMP_DIR)/unit-coverage-details.txt $(shell go list ./... | grep -v anchore/stereoscope/test)
 	@.github/scripts/coverage.py $(COVERAGE_THRESHOLD) $(TEMP_DIR)/unit-coverage-details.txt
 
 

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/sylabs/sif/v2 v2.8.1
 	github.com/sylabs/squashfs v0.6.1
 	github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d
-	github.com/wagoodman/go-progress v0.0.0-20230301185719-21920a456ad5
+	github.com/wagoodman/go-progress v0.0.0-20230911172108-cf810b7e365c
 	golang.org/x/crypto v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlI
 github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
 github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d h1:KOxOL6qpmqwoPloNwi+CEgc1ayjHNOFNrvoOmeDOjDg=
 github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d/go.mod h1:JPirS5jde/CF5qIjcK4WX+eQmKXdPc6vcZkJ/P0hfPw=
-github.com/wagoodman/go-progress v0.0.0-20230301185719-21920a456ad5 h1:lwgTsTy18nYqASnH58qyfRW/ldj7Gt2zzBvgYPzdA4s=
-github.com/wagoodman/go-progress v0.0.0-20230301185719-21920a456ad5/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
+github.com/wagoodman/go-progress v0.0.0-20230911172108-cf810b7e365c h1:mM8T8YhiD19d2wYv3vqZn8xpe1ZFJrUJCGlK4IV05xM=
+github.com/wagoodman/go-progress v0.0.0-20230911172108-cf810b7e365c/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -283,7 +283,7 @@ func (p *DaemonImageProvider) saveImage(ctx context.Context) (string, error) {
 		}
 	}()
 
-	providerProgress.Stage.Current = "requesting image from docker"
+	providerProgress.Stage.Set("requesting image from docker")
 	readCloser, err := p.client.ImageSave(ctx, []string{p.imageStr})
 	if err != nil {
 		return "", fmt.Errorf("unable to save image tar: %w", err)
@@ -304,7 +304,7 @@ func (p *DaemonImageProvider) saveImage(ctx context.Context) (string, error) {
 
 	// save the image contents to the temp file
 	// note: this is the same image that will be used to querying image content during analysis
-	providerProgress.Stage.Current = "saving image to disk"
+	providerProgress.Stage.Set("saving image to disk")
 	nBytes, err := io.Copy(io.MultiWriter(tempTarFile, providerProgress.CopyProgress), readCloser)
 	if err != nil {
 		return "", fmt.Errorf("unable to save image to tar: %w", err)

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -62,7 +62,7 @@ func NewProviderFromDaemon(imgStr string, tmpDirGen *file.TempDirGenerator, c cl
 type daemonProvideProgress struct {
 	SaveProgress *progress.TimedProgress
 	CopyProgress *progress.Writer
-	Stage        *progress.Stage
+	Stage        *progress.AtomicStage
 }
 
 func (p *DaemonImageProvider) trackSaveProgress() (*daemonProvideProgress, error) {
@@ -86,7 +86,7 @@ func (p *DaemonImageProvider) trackSaveProgress() (*daemonProvideProgress, error
 	aggregateProgress := progress.NewAggregator(progress.NormalizeStrategy, estimateSaveProgress, copyProgress)
 
 	// let consumers know of a monitorable event (image save + copy stages)
-	stage := &progress.Stage{}
+	stage := progress.NewAtomicStage("")
 
 	bus.Publish(partybus.Event{
 		Type:   event.FetchImage,
@@ -111,7 +111,7 @@ func (p *DaemonImageProvider) trackSaveProgress() (*daemonProvideProgress, error
 func (p *DaemonImageProvider) pull(ctx context.Context) error {
 	log.Debugf("pulling docker image=%q", p.imageStr)
 
-	var status = newPullStatus()
+	status := newPullStatus()
 	defer func() {
 		status.complete = true
 	}()
@@ -156,7 +156,7 @@ func (p *DaemonImageProvider) pull(ctx context.Context) error {
 }
 
 func (p *DaemonImageProvider) pullOptions() (types.ImagePullOptions, error) {
-	var options = types.ImagePullOptions{
+	options := types.ImagePullOptions{
 		Platform: p.platform.String(),
 	}
 


### PR DESCRIPTION
Previously, setting `Current` on the stager was technically a race condition, since the reference was shared between go routines. `go-progress` added an atomic version of stager that atomically updates the current stage (https://github.com/wagoodman/go-progress/pull/2). Upgrade to use that stager implementation, and pass `-race` to the unit test step to help prevent new race conditions from being introduced.

The next step will be to merge this into syft, see comparison: https://github.com/anchore/syft/compare/fix-go-progress-race