### PR TITLE
feat: treat manifests with equal digest as single image

### DIFF
--- a/pkg/image/oci/directory_provider_test.go
+++ b/pkg/image/oci/directory_provider_test.go
@@ -32,6 +32,7 @@ func Test_Directory_Provide(t *testing.T) {
 		{"reads invalid oci manifest", "test-fixtures/invalid_file", true},
 		{"reads valid oci manifest with no images", "test-fixtures/no_manifests", true},
 		{"reads a fully correct manifest", "test-fixtures/valid_manifest", false},
+		{"reads a fully correct manifest with equal digests", "test-fixtures/valid_manifest", false},
 	}
 
 	for _, tc := range tests {

--- a/pkg/image/oci/test-fixtures/valid_manifest_equal_digests/index.json
+++ b/pkg/image/oci/test-fixtures/valid_manifest_equal_digests/index.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 2,
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:27280e6c2e98b6ec460a9c1a5f354d894037dac6a649535bcc4063eb1f555c15",
+      "size": 480,
+      "annotations": {
+        "io.containerd.image.name": "docker.io/anchore/app:latest",
+        "org.opencontainers.image.created": "2023-09-19T15:16:47Z",
+        "org.opencontainers.image.ref.name": "latest"
+      },
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:27280e6c2e98b6ec460a9c1a5f354d894037dac6a649535bcc4063eb1f555c15",
+      "size": 480,
+      "annotations": {
+        "io.containerd.image.name": "docker.io/anchore/app:1.0.0",
+        "org.opencontainers.image.created": "2023-09-19T15:16:47Z",
+        "org.opencontainers.image.ref.name": "1.0.0"
+      },
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Support for https://github.com/anchore/syft/issues/1544

When considering the manifests in the oci directory provider we now check to see if all of the digests are equivalent. If we find that all manifests are the same digest with just different tags then it makes sense to process the tar as a single image for analysis.

Note - this change only affects the directory and tarball provider - we have no such manifest check for the OCI registry provider.

To validate these changes you can go over to syft and use a replace directive using this branch

To generate a local tar with the above conditions simply follow these instructions:

1. If you don't have one already use the `docker-container` driver with buildx

```
docker buildx create --use --name oci --driver docker-container
```

2. Using a simple dockerfile generate the oci tar:
```
FROM alpine:latest
```

```

docker buildx build . --platform=linux/amd64 --tag app:latest --tag app:1.0.0 --output type=oci,dest=app.tar
```

3. Use syft (with the replace directive consuming this branch) to scan `app.tar`
```
syft app.tar
```


Without the branch you should see:
```
syft app.tar
2023/09/19 12:22:21 error during command execution: 1 error occurred:
	* failed to construct source from user input "app.tar": unable to load image: unable to use OciTarball source: unexpected number of OCI directory manifests (found 2)
```

Consuming this branch as the stereoscope dependency you should see:
```
syft app.tar
 ✔ Parsed image                                                                                                                                          sha256:af663469120203843a0803c642a53d39e0db2aba02fc0e092320b05b1b7b767f
 ✔ Cataloged packages              [16 packages]
NAME                    VERSION      TYPE
alpine-baselayout       3.4.3-r1     apk
alpine-baselayout-data  3.4.3-r1     apk
alpine-keys             2.4-r1       apk
apk-tools               2.14.0-r2    apk
busybox                 1.36.1-r2    apk
busybox-binsh           1.36.1-r2    apk
ca-certificates-bundle  20230506-r0  apk
libc-utils              0.7.2-r5     apk
libcrypto3              3.1.2-r0     apk
libssl3                 3.1.2-r0     apk
musl                    1.2.4-r1     apk
musl-utils              1.2.4-r1     apk
scanelf                 1.3.7-r1     apk
ssl_client              1.36.1-r2    apk
zlib                    1.2.13-r1    apk
```