### PR TITLE
Use default http transport settings to honor proxy settings

### DIFF
--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -126,9 +126,10 @@ func prepareRemoteOptions(ctx context.Context, ref name.Reference, registryOptio
 	if err != nil {
 		log.Warn("unable to configure TLS transport: %w", err)
 	} else if tlsConfig != nil {
-		options = append(options, remote.WithTransport(&http.Transport{
-			TLSClientConfig: tlsConfig,
-		}))
+		// use the default transport to inherit existing default options (such as proxy configuration)
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = tlsConfig
+		options = append(options, remote.WithTransport(transport))
 	}
 
 	return options

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 
@@ -126,11 +127,15 @@ func prepareRemoteOptions(ctx context.Context, ref name.Reference, registryOptio
 	if err != nil {
 		log.Warn("unable to configure TLS transport: %w", err)
 	} else if tlsConfig != nil {
-		// use the default transport to inherit existing default options (such as proxy configuration)
-		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport.TLSClientConfig = tlsConfig
-		options = append(options, remote.WithTransport(transport))
+		options = append(options, remote.WithTransport(getTransport(tlsConfig)))
 	}
 
 	return options
+}
+
+func getTransport(tlsConfig *tls.Config) *http.Transport {
+	// use the default transport to inherit existing default options (including proxy options)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	return transport
 }

--- a/pkg/image/oci/registry_provider_test.go
+++ b/pkg/image/oci/registry_provider_test.go
@@ -2,9 +2,12 @@ package oci
 
 import (
 	"context"
+	"net/http"
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/stretchr/testify/assert"
 
@@ -128,5 +131,19 @@ func Test_prepareReferenceOptions(t *testing.T) {
 				assert.Equal(t, e1, e2)
 			}
 		})
+	}
+}
+
+func Test_getTransport_haxProxyCfg(t *testing.T) {
+	defTransport := http.DefaultTransport.(*http.Transport)
+	transport := getTransport(nil)
+
+	assert.NotNil(t, transport.Proxy)
+	assert.NotNil(t, transport.DialContext)
+
+	if d := cmp.Diff(defTransport, transport,
+		cmpopts.IgnoreFields(http.Transport{}, "TLSClientConfig", "Proxy", "DialContext", "TLSNextProto"),
+		cmpopts.IgnoreUnexported(http.Transport{})); d != "" {
+		t.Errorf("unexpected proxy config (-want +got):\n%s", d)
 	}
 }

--- a/test/integration/oci_registry_source_test.go
+++ b/test/integration/oci_registry_source_test.go
@@ -44,21 +44,3 @@ func TestOciRegistrySourceMetadata(t *testing.T) {
 	assert.Equal(t, "index.docker.io/"+ref, img.Metadata.RepoDigests[0])
 	assert.Equal(t, []byte(rawManifest), img.Metadata.RawManifest)
 }
-
-func TestOciRegistry_Proxy(t *testing.T) {
-	// note: invalid proxy configuration
-	t.Setenv("https_proxy", "http://0.0.0.0:1234")
-
-	// a valid image...
-	digest := "sha256:a15790640a6690aa1730c38cf0a440e2aa44aaca9b0e8931a9f2b0d7cc90fd65"
-	imgStr := "anchore/test_images"
-	ref := fmt.Sprintf("%s@%s", imgStr, digest)
-
-	// note: this should FAIL!
-	img, err := stereoscope.GetImage(context.TODO(), "registry:"+ref)
-	require.ErrorContains(t, err, "proxyconnect tcp: dial tcp 0.0.0.0:1234: connect: connection refused")
-
-	t.Cleanup(func() {
-		require.NoError(t, img.Cleanup())
-	})
-}


### PR DESCRIPTION
Before #174 the `http.Transport` was only overridden in certain circumstances. When the transport was overridden no proxy configuration would be honored. With the containerd PR, the transport is always overridden, causing proxy configurations to fail by default. This fixes the overridden proxy to always inherit all options (except for the TLS config) from the default prototype to fix the existing proxy issues reported in https://github.com/anchore/syft/issues/2203 .