### PR TITLE
fix: compare dockerhub aliases during registry cred selection

### DIFF
--- a/pkg/image/registry_credentials.go
+++ b/pkg/image/registry_credentials.go
@@ -60,7 +60,8 @@ func (c RegistryCredentials) canBeUsedWithRegistry(registry string) bool {
 	// it might be that the user has configured docker.io specifically in the credentials.
 	// try again with the new host. The same can occur when asking for docker.io directly, containerd
 	// will transform this to index.docker.io.
-	if strset.New("registry-1.docker.io", "index.docker.io", "docker.io").Has(registry) {
+	dockerAliases := strset.New("registry-1.docker.io", "index.docker.io", "docker.io")
+	if dockerAliases.Has(c.Authority) && dockerAliases.Has(registry) {
 		// these are all the same in terms of auth
 		return true
 	}

--- a/pkg/image/registry_options_test.go
+++ b/pkg/image/registry_options_test.go
@@ -350,6 +350,12 @@ func TestRegistryOptions_selectMostSpecificCredentials(t *testing.T) {
 		Password:  "pass2",
 	}
 
+	dockerBasicAuth := RegistryCredentials{
+		Authority: "docker.io",
+		Username:  "user1",
+		Password:  "pass1",
+	}
+
 	tests := []struct {
 		name        string
 		credentials []RegistryCredentials
@@ -416,6 +422,27 @@ func TestRegistryOptions_selectMostSpecificCredentials(t *testing.T) {
 				otherBasicAuth1,
 			},
 			want: nil,
+		},
+		{
+			name:     "no matching credentials, docker requested",
+			registry: "docker.io",
+			credentials: []RegistryCredentials{
+				otherBasicAuth1,
+			},
+			want: nil,
+		},
+		{
+			name:     "docker requested by one alias, specified by another",
+			registry: "index.docker.io",
+			credentials: []RegistryCredentials{
+				dockerBasicAuth,
+			},
+			want: []credentialSelection{
+				{
+					credentials: dockerBasicAuth,
+					index:       0,
+				},
+			},
 		},
 		{
 			name:     "match unspecified authority and sort last (order preserved)",


### PR DESCRIPTION
Otherwise, things like docker.io and index.docker.io need to be separately specified in the config.