### PR TITLE
Drop github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pelletier/go-toml v1.9.5
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	// pinned to pull in 386 arch fix: https://github.com/scylladb/go-set/commit/cc7b2070d91ebf40d233207b633e28f5bd8f03a5
 	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e
 	github.com/sergi/go-diff v1.2.0

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -2,13 +2,13 @@ package podman
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/adrg/xdg"
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 
 	"github.com/anchore/stereoscope/internal/log"

--- a/internal/podman/ssh.go
+++ b/internal/podman/ssh.go
@@ -3,6 +3,7 @@ package podman
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/homedir"
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 
@@ -74,7 +74,7 @@ func getSigners(keyPath, passphrase string) (signers []ssh.Signer, err error) {
 
 	s, err := getSignerFromPrivateKey(key, []byte(passphrase))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse identity %q", keyPath)
+		return nil, fmt.Errorf("failed to parse identity %q: %w", keyPath, err)
 	}
 
 	signers = append(signers, s)

--- a/pkg/file/tarutil.go
+++ b/pkg/file/tarutil.go
@@ -2,13 +2,13 @@ package file
 
 import (
 	"archive/tar"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 
 	"github.com/anchore/stereoscope/internal/log"

--- a/pkg/image/platform.go
+++ b/pkg/image/platform.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/errdefs"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -69,14 +68,14 @@ func (p *Platform) String() string {
 func parse(specifier string) (*Platform, error) {
 	if strings.Contains(specifier, "*") {
 		// TODO(stevvooe): need to work out exact wildcard handling
-		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, "%q: wildcards not yet supported", specifier)
+		return nil, fmt.Errorf("%q: wildcards not yet supported: %w", specifier, errdefs.ErrInvalidArgument)
 	}
 
 	parts := strings.Split(specifier, "/")
 
 	for _, part := range parts {
 		if !specifierRe.MatchString(part) {
-			return nil, errors.Wrapf(errdefs.ErrInvalidArgument, "%q is an invalid component of %q: platform specifier component must match %q", part, specifier, specifierRe.String())
+			return nil, fmt.Errorf("%q is an invalid component of %q: platform specifier component must match %q: %w", part, specifier, specifierRe.String(), errdefs.ErrInvalidArgument)
 		}
 	}
 
@@ -96,7 +95,7 @@ func parse(specifier string) (*Platform, error) {
 			return p, nil
 		}
 
-		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, "%q: unknown operating system or architecture", specifier)
+		return nil, fmt.Errorf("%q: unknown operating system or architecture: %w", specifier, errdefs.ErrInvalidArgument)
 	case 2:
 		// In this case, we treat as a regular os/arch pair or architecture/variant pair.
 		var archGuess, variantGuess string
@@ -113,7 +112,7 @@ func parse(specifier string) (*Platform, error) {
 			return p, nil
 		}
 
-		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, "%q: unknown operating system or architecture", specifier)
+		return nil, fmt.Errorf("%q: unknown operating system or architecture: %w", specifier, errdefs.ErrInvalidArgument)
 	case 3:
 		// we have a fully specified variant, this is rare
 		if osGuess := normalizeOS(parts[0]); isKnownOS(osGuess) {
@@ -128,10 +127,10 @@ func parse(specifier string) (*Platform, error) {
 			return p, nil
 		}
 
-		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, "%q: unknown operating system or architecture", specifier)
+		return nil, fmt.Errorf("%q: unknown operating system or architecture: %w", specifier, errdefs.ErrInvalidArgument)
 	}
 
-	return nil, errors.Wrapf(errdefs.ErrInvalidArgument, "%q: cannot parse platform specifier", specifier)
+	return nil, fmt.Errorf("%q: cannot parse platform specifier: %w", specifier, errdefs.ErrInvalidArgument)
 }
 
 // These function are generated from https://golang.org/src/go/build/syslist.go.


### PR DESCRIPTION
Most of these uses seem unintentional, but I've rewritten the intentional uses using fmt.Errorf.