### PR TITLE
Fix tar path traversal issue

### DIFF
--- a/pkg/file/tarutil_test.go
+++ b/pkg/file/tarutil_test.go
@@ -4,6 +4,7 @@
 package file
 
 import (
+	"archive/tar"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -11,10 +12,16 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/go-set/strset"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -180,4 +187,218 @@ func fileExists(t testing.TB, filename string) bool {
 		t.Fatal(err)
 	}
 	return !info.IsDir()
+}
+
+func Test_tarVisitor_visit(t *testing.T) {
+	assertNoFilesInRoot := func(t testing.TB, fs afero.Fs) {
+		t.Helper()
+
+		allowableFiles := strset.New("tmp")
+
+		// list all files in root
+		files, err := afero.ReadDir(fs, "/")
+		require.NoError(t, err)
+
+		for _, f := range files {
+			assert.True(t, allowableFiles.Has(f.Name()), "unexpected file in root: %s", f.Name())
+		}
+	}
+
+	assertPaths := func(expectedFiles []string, expectedDirs []string) func(t testing.TB, fs afero.Fs) {
+		return func(t testing.TB, fs afero.Fs) {
+			t.Helper()
+
+			sort.Strings(expectedFiles)
+			haveFiles := strset.New()
+			haveDirs := strset.New()
+			err := afero.Walk(fs, "/", func(path string, info os.FileInfo, err error) error {
+				require.NoError(t, err)
+				if info.IsDir() {
+					haveDirs.Add(path)
+				} else {
+					haveFiles.Add(path)
+				}
+				return nil
+			})
+
+			haveFilesList := haveFiles.List()
+			sort.Strings(haveFilesList)
+
+			haveDirsList := haveDirs.List()
+			sort.Strings(haveDirsList)
+
+			require.NoError(t, err)
+
+			if d := cmp.Diff(expectedFiles, haveFilesList); d != "" {
+				t.Errorf("unexpected files (-want +got):\n%s", d)
+			}
+
+			if d := cmp.Diff(expectedDirs, haveDirsList); d != "" {
+				t.Errorf("unexpected dirs (-want +got):\n%s", d)
+			}
+
+		}
+	}
+
+	tests := []struct {
+		name     string
+		entry    TarFileEntry
+		wantErr  require.ErrorAssertionFunc
+		assertFs []func(t testing.TB, fs afero.Fs)
+	}{
+		{
+			name: "regular file is written",
+			entry: TarFileEntry{
+				Sequence: 0,
+				Header: tar.Header{
+					Typeflag: tar.TypeReg,
+					Name:     "file.txt",
+					Linkname: "",
+					Size:     2,
+				},
+				Reader: strings.NewReader("hi"),
+			},
+			assertFs: []func(t testing.TB, fs afero.Fs){
+				assertPaths(
+					[]string{"/tmp/file.txt"},
+					[]string{"/", "/tmp"},
+				),
+			},
+		},
+		{
+			name: "regular file with possible path traversal errors out",
+			entry: TarFileEntry{
+				Sequence: 0,
+				Header: tar.Header{
+					Typeflag: tar.TypeReg,
+					Name:     "../file.txt",
+					Linkname: "",
+					Size:     2,
+				},
+				Reader: strings.NewReader("hi"),
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "directory is created",
+			entry: TarFileEntry{
+				Sequence: 0,
+				Header: tar.Header{
+					Typeflag: tar.TypeDir,
+					Name:     "dir",
+					Linkname: "",
+				},
+			},
+			assertFs: []func(t testing.TB, fs afero.Fs){
+				assertPaths(
+					[]string{},
+					[]string{"/", "/tmp", "/tmp/dir"},
+				),
+			},
+		},
+		{
+			name: "symlink is ignored",
+			entry: TarFileEntry{
+				Sequence: 0,
+				Header: tar.Header{
+					Typeflag: tar.TypeSymlink,
+					Name:     "symlink",
+					Linkname: "./../to-location",
+				},
+			},
+			assertFs: []func(t testing.TB, fs afero.Fs){
+				assertPaths(
+					[]string{},
+					[]string{"/"},
+				),
+			},
+		},
+		{
+			name: "hardlink is ignored",
+			entry: TarFileEntry{
+				Sequence: 0,
+				Header: tar.Header{
+					Typeflag: tar.TypeLink,
+					Name:     "link",
+					Linkname: "./../to-location",
+				},
+			},
+			assertFs: []func(t testing.TB, fs afero.Fs){
+				assertPaths(
+					[]string{},
+					[]string{"/"},
+				),
+			},
+		},
+		{
+			name: "device is ignored",
+			entry: TarFileEntry{
+				Sequence: 0,
+				Header: tar.Header{
+					Typeflag: tar.TypeChar,
+					Name:     "device",
+				},
+			},
+			assertFs: []func(t testing.TB, fs afero.Fs){
+				assertPaths(
+					[]string{},
+					[]string{"/"},
+				),
+			},
+		},
+		{
+			name: "block device is ignored",
+			entry: TarFileEntry{
+				Sequence: 0,
+				Header: tar.Header{
+					Typeflag: tar.TypeBlock,
+					Name:     "device",
+				},
+			},
+			assertFs: []func(t testing.TB, fs afero.Fs){
+				assertPaths(
+					[]string{},
+					[]string{"/"},
+				),
+			},
+		},
+		{
+			name: "pipe is ignored",
+			entry: TarFileEntry{
+				Sequence: 0,
+				Header: tar.Header{
+					Typeflag: tar.TypeFifo,
+					Name:     "pipe",
+				},
+			},
+			assertFs: []func(t testing.TB, fs afero.Fs){
+				assertPaths(
+					[]string{},
+					[]string{"/"},
+				),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+			v := tarVisitor{
+				fs:          afero.NewMemMapFs(),
+				destination: "/tmp",
+			}
+			err := v.visit(tt.entry)
+			tt.wantErr(t, err)
+			if err != nil {
+				return
+			}
+			for _, fn := range tt.assertFs {
+				fn(t, v.fs)
+			}
+
+			// even if the test has no other assertions, check that the root is empty
+			assertNoFilesInRoot(t, v.fs)
+		})
+	}
 }


### PR DESCRIPTION
This modifies the `UntarToDirectory` such that if the target for a file is outside of the unarchive destination then an error is returned.