### PR TITLE
feat: account for osx special case socket

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -2,12 +2,12 @@ package docker
 
 import (
 	"context"
-	"os/user"
-	"path/filepath"
-	"runtime"
 	"fmt"
 	"net/http"
 	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/docker/cli/cli/connhelper"
@@ -69,7 +69,7 @@ func GetClient() (*client.Client, error) {
 		}
 
 		macOSSocketPath := filepath.Join(user.HomeDir, "Library/Containers/com.docker.docker/Data/docker.raw.sock")
-		clientOpts = append(clientOpts, client.WithHost("unix://" + macOSSocketPath))
+		clientOpts = append(clientOpts, client.WithHost("unix://"+macOSSocketPath))
 		dockerClient, err = client.NewClientWithOpts(clientOpts...)
 		if err == nil {
 			_, err := dockerClient.Ping(context.Background())

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/docker/cli/cli/connhelper"
 	"github.com/docker/docker/client"
+	"github.com/mitchellh/go-homedir"
 )
 
 func GetClient() (*client.Client, error) {
@@ -78,12 +78,11 @@ func GetClient() (*client.Client, error) {
 func newClient(os string, opts ...client.Opt) (*client.Client, error) {
 	switch os {
 	case "darwin":
-		localUser, err := user.Current()
+		hDir, err := homedir.Dir()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get current user: %w", err)
+			return nil, err
 		}
-
-		macOSSocketPath := filepath.Join(localUser.HomeDir, "Library/Containers/com.docker.docker/Data/docker.raw.sock")
+		macOSSocketPath := filepath.Join(hDir, "Library/Containers/com.docker.docker/Data/docker.raw.sock")
 		opts = append(opts, client.WithHost("unix://"+macOSSocketPath))
 	default:
 	}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -55,7 +55,7 @@ func GetClient() (*client.Client, error) {
 	// This tries to create a docker client with the default options
 	dockerClient, err := client.NewClientWithOpts(clientOpts...)
 	if err == nil {
-		_, err = dockerClient.ServerVersion(context.Background())
+		_, err = dockerClient.Ping(context.Background())
 		if err == nil {
 			return dockerClient, nil // Successfully connected
 		}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -74,11 +74,6 @@ func checkConnection(dockerClient *client.Client) error {
 	return nil
 }
 
-/*
-Things I want to try
-- What is the default from the docker client library
-- What are known socket paths for a given OS
-*/
 func newClient(socket string, opts ...client.Opt) (*client.Client, error) {
 	if socket == "" {
 		return client.NewClientWithOpts(opts...)

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -77,7 +77,6 @@ func GetClient() (*client.Client, error) {
 				return dockerClient, nil // Successfully connected
 			}
 		}
-
 	}
 
 	// If both attempts failed

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -69,9 +69,10 @@ func GetClient() (*client.Client, error) {
 		}
 
 		macOSSocketPath := filepath.Join(user.HomeDir, "Library/Containers/com.docker.docker/Data/docker.raw.sock")
-		dockerClient, err = client.NewClientWithOpts(client.WithHost("unix://" + macOSSocketPath))
+		clientOpts = append(clientOpts, client.WithHost("unix://" + macOSSocketPath))
+		dockerClient, err = client.NewClientWithOpts(clientOpts...)
 		if err == nil {
-			_, err = dockerClient.ServerVersion(context.Background())
+			_, err := dockerClient.Ping(context.Background())
 			if err == nil {
 				return dockerClient, nil // Successfully connected
 			}

--- a/internal/docker/docker_client_test.go
+++ b/internal/docker/docker_client_test.go
@@ -8,14 +8,12 @@ import (
 	"github.com/docker/docker/client"
 )
 
-// Write a test that asserts that we are not overwriting the DOCKER_HOST environment variable
-
 func Test_newClient(t *testing.T) {
 	cases := []struct {
 		name           string
 		providedSocket string
 		expectedSocket string
-		setEnv         func() func()
+		setEnv         func(t *testing.T)
 	}{
 		{
 			name:           "Test newClient returns the correct default location",
@@ -25,11 +23,8 @@ func Test_newClient(t *testing.T) {
 		{
 			name:           "Test newClient with runtime specific path",
 			providedSocket: "",
-			setEnv: func() func() {
+			setEnv: func(t *testing.T) {
 				os.Setenv("DOCKER_HOST", "unix:///var/CUSTOM/docker.sock")
-				return func() {
-					os.Unsetenv("DOCKER_HOST")
-				}
 
 			},
 			expectedSocket: "unix:///var/CUSTOM/docker.sock",
@@ -44,10 +39,8 @@ func Test_newClient(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if c.setEnv != nil {
-				unset := c.setEnv()
-				defer unset()
+				c.setEnv(t)
 			}
-
 			clientOpts := []client.Opt{
 				client.FromEnv,
 				client.WithAPIVersionNegotiation(),

--- a/internal/docker/docker_client_test.go
+++ b/internal/docker/docker_client_test.go
@@ -1,43 +1,90 @@
 package docker
 
 import (
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/client"
 )
+
+// Write a test that asserts that we are not overwriting the DOCKER_HOST environment variable
 
 func Test_newClient(t *testing.T) {
 	cases := []struct {
 		name           string
-		osCase         string
+		providedSocket string
 		expectedSocket string
+		setEnv         func() func()
 	}{
 		{
-			name:           "Test newClient with default options",
-			osCase:         "",
+			name:           "Test newClient returns the correct default location",
+			providedSocket: "",
 			expectedSocket: "unix:///var/run/docker.sock",
 		},
 		{
 			name:           "Test newClient with runtime specific path",
-			osCase:         "darwin",
-			expectedSocket: "Library/Containers/com.docker.docker/Data/docker.raw.sock",
+			providedSocket: "",
+			setEnv: func() func() {
+				os.Setenv("DOCKER_HOST", "unix:///var/CUSTOM/docker.sock")
+				return func() {
+					os.Unsetenv("DOCKER_HOST")
+				}
+
+			},
+			expectedSocket: "unix:///var/CUSTOM/docker.sock",
+		},
+		{
+			name:           "Test newClient with runtime specific path",
+			providedSocket: "unix:///var/NEWCUSTOM/docker.sock",
+			expectedSocket: "unix:///var/NEWCUSTOM/docker.sock",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			dockerClient, err := newClient(c.osCase)
+			if c.setEnv != nil {
+				unset := c.setEnv()
+				defer unset()
+			}
+
+			clientOpts := []client.Opt{
+				client.FromEnv,
+				client.WithAPIVersionNegotiation(),
+			}
+
+			client, err := newClient(c.providedSocket, clientOpts...)
 			if err != nil {
-				t.Errorf("Error: %v", err)
+				t.Errorf("newClient() error = %v", err)
+				return
 			}
-			if dockerClient == nil {
-				t.Errorf("Error: dockerClient is nil")
+
+			if client.DaemonHost() != c.expectedSocket {
+				t.Errorf("newClient() = %v, want %v", client.DaemonHost(), c.expectedSocket)
 			}
-			daemonHost := dockerClient.DaemonHost()
-			if daemonHost == "" {
-				t.Errorf("Error: daemonHost is empty")
-			}
-			if strings.HasSuffix(daemonHost, c.expectedSocket) == false {
-				t.Errorf("Error: daemonHost is not  contain expectedSocket: %s:%s", daemonHost, c.expectedSocket)
+		})
+	}
+}
+
+func Test_possibleSocketPaths(t *testing.T) {
+	cases := []struct {
+		name     string
+		provided string
+		expected []string
+	}{
+		{
+			name:     "Test possibleSocketPaths returns the correct default location for darwin",
+			provided: "darwin",
+			expected: []string{"", "Library/Containers/com.docker.docker/Data/docker.raw.sock"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			for i, socketPath := range possibleSocketPaths(c.provided) {
+				if !strings.HasSuffix(socketPath, c.expected[i]) {
+					t.Errorf("possibleSocketPaths() = %v, want %v", socketPath, c.expected[i])
+				}
 			}
 		})
 	}

--- a/internal/docker/docker_client_test.go
+++ b/internal/docker/docker_client_test.go
@@ -19,7 +19,7 @@ func Test_newClient(t *testing.T) {
 		{
 			name:           "Test newClient with runtime specific path",
 			osCase:         "darwin",
-			expectedSocket: "Library/Containers/com.docker.docker/Data/docker.raw.soc",
+			expectedSocket: "Library/Containers/com.docker.docker/Data/docker.raw.sock",
 		},
 	}
 
@@ -36,7 +36,7 @@ func Test_newClient(t *testing.T) {
 			if daemonHost == "" {
 				t.Errorf("Error: daemonHost is empty")
 			}
-			if strings.Contains(daemonHost, c.expectedSocket) == false {
+			if strings.HasSuffix(daemonHost, c.expectedSocket) == false {
 				t.Errorf("Error: daemonHost is not  contain expectedSocket: %s:%s", daemonHost, c.expectedSocket)
 			}
 		})

--- a/internal/docker/docker_client_test.go
+++ b/internal/docker/docker_client_test.go
@@ -1,0 +1,44 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_newClient(t *testing.T) {
+	cases := []struct {
+		name           string
+		osCase         string
+		expectedSocket string
+	}{
+		{
+			name:           "Test newClient with default options",
+			osCase:         "",
+			expectedSocket: "unix:///var/run/docker.sock",
+		},
+		{
+			name:           "Test newClient with runtime specific path",
+			osCase:         "darwin",
+			expectedSocket: "Library/Containers/com.docker.docker/Data/docker.raw.soc",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dockerClient, err := newClient(c.osCase)
+			if err != nil {
+				t.Errorf("Error: %v", err)
+			}
+			if dockerClient == nil {
+				t.Errorf("Error: dockerClient is nil")
+			}
+			daemonHost := dockerClient.DaemonHost()
+			if daemonHost == "" {
+				t.Errorf("Error: daemonHost is empty")
+			}
+			if strings.Contains(daemonHost, c.expectedSocket) == false {
+				t.Errorf("Error: daemonHost is not  contain expectedSocket: %s:%s", daemonHost, c.expectedSocket)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Some users encounter an error when their docker desktop `DOCKER_HOST` is not at the default location of `/var/run/docker.sock`

In newer versions of docker desktop the default is for this option to be disabled and for a new location to be added for a local users docker socket. This new common path can be found at `user.HomeDir, "Library/Containers/com.docker.docker/Data/docker.raw.sock"` on `darwin` systems

## To Reproduce and assert the fix
On your local make sure the advanced settings of docker desktop is disabled for using `/var/run/docker.sock`.

The setting is called `Allow the default Docker socket to be used (requires password)` under the `Advanced` tab in settings.

Run this command where `SOME_IMAGE_ID` is an image local to your machine.
```
syft -q <SOME_IMAGE_ID>
```
You should see an output like this:
<img width="846" alt="Screenshot 2024-02-01 at 12 41 41 AM" src="https://github.com/anchore/stereoscope/assets/32073428/46bb427e-8b41-40e2-8822-6a87fac24b28">

When syft imports stereoscope with this fix you will no longer see an error as it knows how to use the correct new default socket on OSX:
<img width="461" alt="Screenshot 2024-02-01 at 12 44 26 AM" src="https://github.com/anchore/stereoscope/assets/32073428/f3217b92-b023-49bf-9f94-fd45e2b7e398">


