### PR TITLE
chore: add testutil logging

### DIFF
--- a/pkg/imagetest/fileutils.go
+++ b/pkg/imagetest/fileutils.go
@@ -30,10 +30,16 @@ func copyFile(t testing.TB, src, dst string) {
 	}
 }
 
-func fileOrDirExists(t testing.TB, filename string) bool {
+func fileExists(t testing.TB, filename string) bool {
 	t.Helper()
-	_, err := os.Stat(filename)
-	return !os.IsNotExist(err)
+	s, err := os.Stat(filename)
+	return !os.IsNotExist(err) && !s.IsDir()
+}
+
+func dirExists(t testing.TB, filename string) bool {
+	t.Helper()
+	s, err := os.Stat(filename)
+	return !os.IsNotExist(err) && s.IsDir()
 }
 
 func dirHash(t testing.TB, root string) string {


### PR DESCRIPTION
This PR adds some verbosity to the `imagetest` utilities to help diagnose issues with some flaky tests in Syft (e.g. [this one](https://github.com/anchore/syft/actions/runs/7917270348/job/21612985373#step:10:456))