### PR TITLE
Ensure prefix check for path traversal has path separator

### DIFF
--- a/pkg/file/tarutil.go
+++ b/pkg/file/tarutil.go
@@ -147,7 +147,7 @@ func (v tarVisitor) visit(entry TarFileEntry) error {
 	target := filepath.Join(v.destination, entry.Header.Name)
 
 	// we should not allow for any destination path to be outside of where we are unarchiving to
-	if !strings.HasPrefix(target, v.destination) {
+	if !strings.HasPrefix(target, v.destination+string(os.PathSeparator)) {
 		return fmt.Errorf("potential path traversal attack with entry: %q", entry.Header.Name)
 	}
 

--- a/pkg/file/tarutil_test.go
+++ b/pkg/file/tarutil_test.go
@@ -280,6 +280,20 @@ func Test_tarVisitor_visit(t *testing.T) {
 			wantErr: require.Error,
 		},
 		{
+			name: "regular file with possible path traversal errors out (same prefix)",
+			entry: TarFileEntry{
+				Sequence: 0,
+				Header: tar.Header{
+					Typeflag: tar.TypeReg,
+					Name:     "../tmp-file.txt",
+					Linkname: "",
+					Size:     2,
+				},
+				Reader: strings.NewReader("hi"),
+			},
+			wantErr: require.Error,
+		},
+		{
 			name: "directory is created",
 			entry: TarFileEntry{
 				Sequence: 0,


### PR DESCRIPTION
Reported by @a1loy , it is possible to specify a tar header that matches the random destination path as a prefix, but additionally has more elements as a suffix. In these cases we will still write out to a stereoscope temp directory that is cleaned up (thus this is not a security concern), but could allow for unintentional writes within that temp directory. This addresses the bug by explicitly performing a prefix check with a path separator.