### PR TITLE
fix: update tar traversal to respect current director entry

### DIFF
--- a/pkg/file/tarutil.go
+++ b/pkg/file/tarutil.go
@@ -148,8 +148,8 @@ func (v tarVisitor) visit(entry TarFileEntry) error {
 
 	// we should not allow for any destination path to be outside of where we are unarchiving to
 	// "." is a special case that we allow (it is the root of the unarchived content)a
-	test := v.destination + string(os.PathSeparator)
-	if !strings.HasPrefix(target, test) && entry.Header.Name != "." {
+	withinDir := v.destination + string(os.PathSeparator)
+	if !strings.HasPrefix(target, withinDir) && entry.Header.Name != "." {
 		return fmt.Errorf("potential path traversal attack with entry: %q", entry.Header.Name)
 	}
 

--- a/pkg/file/tarutil.go
+++ b/pkg/file/tarutil.go
@@ -147,7 +147,7 @@ func (v tarVisitor) visit(entry TarFileEntry) error {
 	target := filepath.Join(v.destination, entry.Header.Name)
 
 	// we should not allow for any destination path to be outside of where we are unarchiving to
-	// "." is a special case that we allow (it is the root of the unarchived content)a
+	// "." is a special case that we allow (it is the root of the unarchived content)
 	withinDir := v.destination + string(os.PathSeparator)
 	if !strings.HasPrefix(target, withinDir) && entry.Header.Name != "." {
 		return fmt.Errorf("potential path traversal attack with entry: %q", entry.Header.Name)

--- a/pkg/file/tarutil_test.go
+++ b/pkg/file/tarutil_test.go
@@ -280,6 +280,20 @@ func Test_tarVisitor_visit(t *testing.T) {
 			wantErr: require.Error,
 		},
 		{
+			name: "local . index is not a traversal error and should skip",
+			entry: TarFileEntry{
+				Sequence: 0,
+				Header: tar.Header{
+					Typeflag: tar.TypeDir,
+					Name:     ".",
+					Linkname: "",
+					Size:     2,
+				},
+				Reader: strings.NewReader("hi"),
+			},
+			assertFs: []func(t testing.TB, fs afero.Fs){},
+		},
+		{
 			name: "regular file with possible path traversal errors out (same prefix)",
 			entry: TarFileEntry{
 				Sequence: 0,


### PR DESCRIPTION
## Summary
Users of syft reported upstream that they are now seeing an error for OCI scanning when stereoscope hits a tar entry with `.` as the current directory.

This PR adds a case for making sure the destination path is not the current directory entry.

It also adds a specific skip for this type given that we don't want to `stat` `.` and perform any additional actions.

The current check will fail with a `.` entry given the following:
```
`/tmp`
`/tmp/`
```

`/tmp` does not begin with the prefix `/tmp/` so stereoscope thinks we're escaping and errors

This also prevents the error from surfacing in this case:
https://github.com/anchore/syft/issues/2678