### PR TITLE
chore: grouped dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
     groups:
       go:
         update-types:
-          - major
           - minor
           - patch
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    groups:
+      go:
+        update-types:
+          - major
+          - minor
+          - patch
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -17,6 +23,12 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    groups:
+      workflows:
+        update-types:
+          - major
+          - minor
+          - patch
 
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/boostrap"
@@ -25,3 +37,9 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    groups:
+      workflows:
+        update-types:
+          - major
+          - minor
+          - patch


### PR DESCRIPTION
This PR enables [grouped dependabot updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)