### PR TITLE
Shallow clone trees to save on memory usage

### DIFF
--- a/pkg/filetree/filenode/filenode.go
+++ b/pkg/filetree/filenode/filenode.go
@@ -55,15 +55,6 @@ func (n *FileNode) ID() node.ID {
 	return IDByPath(n.RealPath)
 }
 
-func (n *FileNode) Copy() node.Node {
-	return &FileNode{
-		RealPath:  n.RealPath,
-		FileType:  n.FileType,
-		LinkPath:  n.LinkPath,
-		Reference: n.Reference,
-	}
-}
-
 func (n *FileNode) IsLink() bool {
 	return n.FileType == file.TypeHardLink || n.FileType == file.TypeSymLink
 }

--- a/pkg/filetree/filenode/filenode.go
+++ b/pkg/filetree/filenode/filenode.go
@@ -55,6 +55,15 @@ func (n *FileNode) ID() node.ID {
 	return IDByPath(n.RealPath)
 }
 
+func (n *FileNode) Copy() node.Node {
+	return &FileNode{
+		RealPath:  n.RealPath,
+		FileType:  n.FileType,
+		LinkPath:  n.LinkPath,
+		Reference: n.Reference,
+	}
+}
+
 func (n *FileNode) IsLink() bool {
 	return n.FileType == file.TypeHardLink || n.FileType == file.TypeSymLink
 }

--- a/pkg/filetree/filetree.go
+++ b/pkg/filetree/filetree.go
@@ -45,10 +45,10 @@ func New() *FileTree {
 	}
 }
 
-// Copy returns a Copy of the current FileTree.
-func (t *FileTree) Copy() (ReadWriter, error) {
+// Clone returns a shallow Copy of the current FileTree.
+func (t *FileTree) Clone() (ReadWriter, error) {
 	ct := New()
-	ct.tree = t.tree.Copy()
+	ct.tree = t.tree.Clone()
 	return ct, nil
 }
 
@@ -781,7 +781,8 @@ func (t *FileTree) Walk(fn func(path file.Path, f filenode.FileNode) error, cond
 
 // Merge takes the given Tree and combines it with the current Tree, preferring files in the other Tree if there
 // are path conflicts. This is the basis function for squashing (where the current Tree is the bottom Tree and the
-// given Tree is the top Tree).
+// given Tree is the top Tree). Note: existing nodes are not mutated during this operation, they are replaced with
+// a node from the other tree.
 //
 //nolint:gocognit,funlen
 func (t *FileTree) Merge(upper Reader) error {

--- a/pkg/filetree/filetree.go
+++ b/pkg/filetree/filetree.go
@@ -52,6 +52,13 @@ func (t *FileTree) Clone() (ReadWriter, error) {
 	return ct, nil
 }
 
+// Copy returns a deep Copy of the current FileTree.
+func (t *FileTree) Copy() (ReadWriter, error) {
+	ct := New()
+	ct.tree = t.tree.Copy()
+	return ct, nil
+}
+
 // AllFiles returns all files within the FileTree (defaults to regular files only, but you can provide one or more allow types).
 func (t *FileTree) AllFiles(types ...file.Type) []file.Reference {
 	if len(types) == 0 {

--- a/pkg/filetree/interfaces.go
+++ b/pkg/filetree/interfaces.go
@@ -28,7 +28,7 @@ type PathReader interface {
 }
 
 type Copier interface {
-	Copy() (ReadWriter, error)
+	Clone() (ReadWriter, error)
 }
 
 type Walker interface {

--- a/pkg/filetree/interfaces.go
+++ b/pkg/filetree/interfaces.go
@@ -28,6 +28,7 @@ type PathReader interface {
 }
 
 type Copier interface {
+	Copy() (ReadWriter, error)
 	Clone() (ReadWriter, error)
 }
 

--- a/pkg/filetree/union_filetree.go
+++ b/pkg/filetree/union_filetree.go
@@ -21,14 +21,14 @@ func (u *UnionFileTree) Squash() (ReadWriter, error) {
 	case 0:
 		return New(), nil
 	case 1:
-		return u.trees[0].Copy()
+		return u.trees[0].Clone()
 	}
 
 	var squashedTree ReadWriter
 	var err error
 	for layerIdx, refTree := range u.trees {
 		if layerIdx == 0 {
-			squashedTree, err = refTree.Copy()
+			squashedTree, err = refTree.Clone()
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/filetree/union_filetree.go
+++ b/pkg/filetree/union_filetree.go
@@ -21,6 +21,8 @@ func (u *UnionFileTree) Squash() (ReadWriter, error) {
 	case 0:
 		return New(), nil
 	case 1:
+		// important: use clone over copy to reduce memory footprint. If callers need a distinct tree they can call
+		// copy after the fact.
 		return u.trees[0].Clone()
 	}
 
@@ -28,6 +30,8 @@ func (u *UnionFileTree) Squash() (ReadWriter, error) {
 	var err error
 	for layerIdx, refTree := range u.trees {
 		if layerIdx == 0 {
+			// important: use clone over copy to reduce memory footprint. If callers need a distinct tree they can call
+			// copy after the fact.
 			squashedTree, err = refTree.Clone()
 			if err != nil {
 				return nil, err

--- a/pkg/tree/node/node.go
+++ b/pkg/tree/node/node.go
@@ -2,4 +2,5 @@ package node
 
 type Node interface {
 	ID() ID
+	Copy() Node
 }

--- a/pkg/tree/node/node.go
+++ b/pkg/tree/node/node.go
@@ -2,5 +2,4 @@ package node
 
 type Node interface {
 	ID() ID
-	Copy() Node
 }

--- a/pkg/tree/tree.go
+++ b/pkg/tree/tree.go
@@ -32,6 +32,38 @@ func (t *Tree) Clone() *Tree {
 	return ct
 }
 
+// Copy returns a deep copy of the Tree.
+func (t *Tree) Copy() *Tree {
+	ct := NewTree()
+	for k, v := range t.nodes {
+		if v == nil {
+			ct.nodes[k] = nil
+			continue
+		}
+		ct.nodes[k] = v.Copy()
+	}
+	for k, v := range t.parent {
+		if v == nil {
+			ct.parent[k] = nil
+			continue
+		}
+		ct.parent[k] = v.Copy()
+	}
+	for from, lookup := range t.children {
+		if _, exists := ct.children[from]; !exists {
+			ct.children[from] = make(map[node.ID]node.Node)
+		}
+		for to, v := range lookup {
+			if v == nil {
+				ct.children[from][to] = nil
+				continue
+			}
+			ct.children[from][to] = v.Copy()
+		}
+	}
+	return ct
+}
+
 // Roots is all of the nodes with no parents.
 func (t *Tree) Roots() node.Nodes {
 	var nodes = make([]node.Node, 0)

--- a/pkg/tree/tree.go
+++ b/pkg/tree/tree.go
@@ -2,6 +2,7 @@ package tree
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/anchore/stereoscope/pkg/tree/node"
 )
@@ -22,34 +23,12 @@ func NewTree() *Tree {
 	}
 }
 
-func (t *Tree) Copy() *Tree {
+// Clone returns a shallow copy of the Tree.
+func (t *Tree) Clone() *Tree {
 	ct := NewTree()
-	for k, v := range t.nodes {
-		if v == nil {
-			ct.nodes[k] = nil
-			continue
-		}
-		ct.nodes[k] = v.Copy()
-	}
-	for k, v := range t.parent {
-		if v == nil {
-			ct.parent[k] = nil
-			continue
-		}
-		ct.parent[k] = v.Copy()
-	}
-	for from, lookup := range t.children {
-		if _, exists := ct.children[from]; !exists {
-			ct.children[from] = make(map[node.ID]node.Node)
-		}
-		for to, v := range lookup {
-			if v == nil {
-				ct.children[from][to] = nil
-				continue
-			}
-			ct.children[from][to] = v.Copy()
-		}
-	}
+	ct.nodes = maps.Clone(t.nodes)
+	ct.parent = maps.Clone(t.parent)
+	ct.children = maps.Clone(t.children)
 	return ct
 }
 

--- a/pkg/tree/tree_test.go
+++ b/pkg/tree/tree_test.go
@@ -338,7 +338,7 @@ func TestTree(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.fields, tt.fields.Clone())
+			assert.Equal(t, tt.fields, tt.fields.Copy())
 			assert.Equal(t, tt.roots, tt.fields.Roots())
 
 			if tt.id != "" {

--- a/pkg/tree/tree_test.go
+++ b/pkg/tree/tree_test.go
@@ -338,7 +338,7 @@ func TestTree(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.fields, tt.fields.Copy())
+			assert.Equal(t, tt.fields, tt.fields.Clone())
 			assert.Equal(t, tt.roots, tt.fields.Roots())
 
 			if tt.id != "" {

--- a/test/integration/path_type_change_test.go
+++ b/test/integration/path_type_change_test.go
@@ -1,0 +1,62 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree/filenode"
+	"github.com/anchore/stereoscope/pkg/imagetest"
+)
+
+func TestPathTypeChangeImage(t *testing.T) {
+	image := imagetest.GetFixtureImage(t, "docker-archive", "image-path-type-change")
+
+	layerAssertions := []map[string]file.Type{
+		make(map[string]file.Type),
+		{
+			"/chimera/a.txt": file.TypeRegular,
+			"/chimera/b.txt": file.TypeRegular,
+			"/chimera":       file.TypeDirectory,
+		},
+		{
+			"/chimera": file.TypeDirectory,
+		},
+		make(map[string]file.Type),
+		{
+			"/chimera": file.TypeRegular,
+		},
+		make(map[string]file.Type),
+		{
+			"/chimera": file.TypeSymLink,
+		},
+		make(map[string]file.Type),
+		{
+			"/chimera": file.TypeDirectory,
+		},
+	}
+
+	for idx, layer := range image.Layers {
+		assertions := layerAssertions[idx]
+		err := layer.SquashedTree.Walk(func(path file.Path, f filenode.FileNode) error {
+			expect, ok := assertions[string(path)]
+			if !ok {
+				return nil
+			}
+			if f.FileType != expect {
+				t.Errorf("at %v got %v want %v", path, f.FileType, expect)
+			}
+			delete(assertions, string(path))
+			return nil
+		}, nil)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	for i, a := range layerAssertions {
+		if len(a) > 0 {
+			for k, v := range a {
+				t.Errorf("for layer %v, never saw %v of type %v", i, k, v)
+			}
+		}
+	}
+}

--- a/test/integration/test-fixtures/image-path-type-change/Dockerfile
+++ b/test/integration/test-fixtures/image-path-type-change/Dockerfile
@@ -1,0 +1,20 @@
+FROM busybox:1.37.0@sha256:db142d433cdde11f10ae479dbf92f3b13d693fd1c91053da9979728cceb1dc68
+
+# makes /chimera/a.txt /chimera/b.txt
+COPY . /
+
+# make a layer where the dir is empty
+RUN rm /chimera/a.txt /chimera/b.txt
+
+RUN rmdir /chimera
+
+RUN touch /chimera
+
+RUN rm /chimera
+
+RUN ln -s /etc/hostname /chimera
+
+RUN unlink /chimera
+
+RUN mkdir /chimera
+


### PR DESCRIPTION
Based off of the inuse memory in stereoscope we spend of lot of memory on copying the filetree for squashing. An observation here is that all tree mutation operations always create or replace nodes, but never mutate existing nodes. This means that we can share references across the multiple trees created for the squashfs functionality for each layer.

Here is a snapshot of inuse memory today for image read for a sample image:
<img width="1101" alt="Screenshot 2024-07-10 at 1 48 13 PM" src="https://github.com/anchore/stereoscope/assets/590471/5cf9952f-de98-4ea0-a73b-aa9d39108147">

Here is a snapshot of inuse memory after using `map.Clone` to shallow clone existing trees:
<img width="1101" alt="Screenshot 2024-07-10 at 1 48 22 PM" src="https://github.com/anchore/stereoscope/assets/590471/65e6a318-4610-4913-8396-d854ab9ba9b1">

Partially fixes #233 in terms of inuse memory