### PR TITLE
chore: ungroup minor version dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
     groups:
       go:
         update-types:
-          - minor
           - patch
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Dependabot make a lot of noise, so we've tried grouping all go updates in this repo that are minor or patch. However, this makes a lot of pull requests that fail unit tests and require human investigation, which is harder than merging lots of tiny PRs that just turn green and get merged.

Therefore, try only grouping go dependencies that are patch versions; hopefully this will strike a balance between many PRs and PRs that don't require work to get merged.