### PR TITLE
Add more strict verifications when user provides a platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin/
 /snapshot
 /.tool
 /.task
+.mise.toml
 
 # changelog generation
 CHANGELOG.md

--- a/pkg/image/containerd/daemon_provider.go
+++ b/pkg/image/containerd/daemon_provider.go
@@ -354,27 +354,28 @@ func validatePlatform(expected *image.Platform, given *platforms.Platform) error
 	}
 
 	if given == nil {
-		return newErrFetchingImage(fmt.Errorf("image has no platform information (might be a manifest list)"))
+		return newErrPlatformMismatch(expected, fmt.Errorf("image has no platform information (might be a manifest list)"))
 	}
 
 	if given.OS != expected.OS {
-		return newErrFetchingImage(fmt.Errorf("image has unexpected OS %q, which differs from the user specified PS %q", given.OS, expected.OS))
+		return newErrPlatformMismatch(expected, fmt.Errorf("image has unexpected OS %q, which differs from the user specified PS %q", given.OS, expected.OS))
 	}
 
 	if given.Architecture != expected.Architecture {
-		return newErrFetchingImage(fmt.Errorf("image has unexpected architecture %q, which differs from the user specified architecture %q", given.Architecture, expected.Architecture))
+		return newErrPlatformMismatch(expected, fmt.Errorf("image has unexpected architecture %q, which differs from the user specified architecture %q", given.Architecture, expected.Architecture))
 	}
 
 	if given.Variant != expected.Variant {
-		return newErrFetchingImage(fmt.Errorf("image has unexpected architecture %q, which differs from the user specified architecture %q", given.Variant, expected.Variant))
+		return newErrPlatformMismatch(expected, fmt.Errorf("image has unexpected architecture %q, which differs from the user specified architecture %q", given.Variant, expected.Variant))
 	}
 
 	return nil
 }
 
-func newErrFetchingImage(err error) *image.ErrFetchingImage {
-	return &image.ErrFetchingImage{
-		Reason: err.Error(),
+func newErrPlatformMismatch(expected *image.Platform, err error) *image.ErrPlatformMismatch {
+	return &image.ErrPlatformMismatch{
+		ExpectedPlatform: expected.String(),
+		Err:              err,
 	}
 }
 

--- a/pkg/image/containerd/daemon_provider.go
+++ b/pkg/image/containerd/daemon_provider.go
@@ -341,35 +341,41 @@ func (p *daemonImageProvider) pullImageIfMissing(ctx context.Context, client *co
 		}
 	}
 
-	if err := p.validatePlatform(resolvedPlatform); err != nil {
+	if err := validatePlatform(p.platform, resolvedPlatform); err != nil {
 		return "", nil, fmt.Errorf("platform validation failed: %w", err)
 	}
 
 	return resolvedImage, resolvedPlatform, nil
 }
 
-func (p *daemonImageProvider) validatePlatform(platform *platforms.Platform) error {
-	if p.platform == nil {
+func validatePlatform(expected *image.Platform, given *platforms.Platform) error {
+	if expected == nil {
 		return nil
 	}
 
-	if platform == nil {
-		return fmt.Errorf("image has no platform information (might be a manifest list)")
+	if given == nil {
+		return newErrFetchingImage(fmt.Errorf("image has no platform information (might be a manifest list)"))
 	}
 
-	if platform.OS != p.platform.OS {
-		return fmt.Errorf("image has unexpected OS %q, which differs from the user specified PS %q", platform.OS, p.platform.OS)
+	if given.OS != expected.OS {
+		return newErrFetchingImage(fmt.Errorf("image has unexpected OS %q, which differs from the user specified PS %q", given.OS, expected.OS))
 	}
 
-	if platform.Architecture != p.platform.Architecture {
-		return fmt.Errorf("image has unexpected architecture %q, which differs from the user specified architecture %q", platform.Architecture, p.platform.Architecture)
+	if given.Architecture != expected.Architecture {
+		return newErrFetchingImage(fmt.Errorf("image has unexpected architecture %q, which differs from the user specified architecture %q", given.Architecture, expected.Architecture))
 	}
 
-	if platform.Variant != p.platform.Variant {
-		return fmt.Errorf("image has unexpected architecture %q, which differs from the user specified architecture %q", platform.Variant, p.platform.Variant)
+	if given.Variant != expected.Variant {
+		return newErrFetchingImage(fmt.Errorf("image has unexpected architecture %q, which differs from the user specified architecture %q", given.Variant, expected.Variant))
 	}
 
 	return nil
+}
+
+func newErrFetchingImage(err error) *image.ErrFetchingImage {
+	return &image.ErrFetchingImage{
+		Reason: err.Error(),
+	}
 }
 
 // save the image from the containerd daemon to a tar file

--- a/pkg/image/containerd/daemon_provider_test.go
+++ b/pkg/image/containerd/daemon_provider_test.go
@@ -97,7 +97,7 @@ func Test_exportPlatformComparer(t *testing.T) {
 
 func TestValidatePlatform(t *testing.T) {
 	isFetchError := func(t require.TestingT, err error, args ...interface{}) {
-		var pErr *image.ErrFetchingImage
+		var pErr *image.ErrPlatformMismatch
 		require.ErrorAs(t, err, &pErr)
 	}
 

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -165,7 +165,12 @@ type emitter interface {
 
 func handlePullEvent(status emitter, event *pullEvent) error {
 	if event.Error != "" {
-		return &image.ErrFetchingImage{Reason: event.Error}
+		if strings.Contains(event.Error, "does not match the specified platform") {
+			return &image.ErrPlatformMismatch{
+				Err: errors.New(event.Error),
+			}
+		}
+		return errors.New(event.Error)
 	}
 
 	// check for the last two events indicating the pull is complete

--- a/pkg/image/docker/daemon_provider.go
+++ b/pkg/image/docker/daemon_provider.go
@@ -151,14 +151,29 @@ func (p *daemonImageProvider) pull(ctx context.Context, client client.APIClient,
 
 			return fmt.Errorf("failed to pull image: %w", err)
 		}
-
-		// check for the last two events indicating the pull is complete
-		if strings.HasPrefix(thePullEvent.Status, "Digest:") || strings.HasPrefix(thePullEvent.Status, "Status:") {
-			continue
+		if err := handlePullEvent(status, thePullEvent); err != nil {
+			return err
 		}
-
-		status.onEvent(thePullEvent)
 	}
+
+	return nil
+}
+
+type emitter interface {
+	onEvent(event *pullEvent)
+}
+
+func handlePullEvent(status emitter, event *pullEvent) error {
+	if event.Error != "" {
+		return &image.ErrFetchingImage{Reason: event.Error}
+	}
+
+	// check for the last two events indicating the pull is complete
+	if strings.HasPrefix(event.Status, "Digest:") || strings.HasPrefix(event.Status, "Status:") {
+		return nil
+	}
+
+	status.onEvent(event)
 
 	return nil
 }

--- a/pkg/image/docker/daemon_provider_test.go
+++ b/pkg/image/docker/daemon_provider_test.go
@@ -8,6 +8,8 @@ import (
 	configTypes "github.com/docker/cli/cli/config/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/stereoscope/pkg/image"
 )
 
 func TestEncodeCredentials(t *testing.T) {
@@ -82,6 +84,74 @@ func Test_authURL(t *testing.T) {
 			got, err := authURL(tt.imageStr, tt.workaround)
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+type mockEmitter struct {
+	calledEvents []*pullEvent
+}
+
+func (m *mockEmitter) onEvent(event *pullEvent) {
+	m.calledEvents = append(m.calledEvents, event)
+}
+
+func TestHandlePullEventWithMockEmitter(t *testing.T) {
+	tests := []struct {
+		name          string
+		event         *pullEvent
+		expectOnEvent bool
+		assertFunc    require.ErrorAssertionFunc
+	}{
+		{
+			name: "error in event",
+			event: &pullEvent{
+				Error: "fetch failed",
+			},
+			expectOnEvent: false,
+			assertFunc: func(t require.TestingT, err error, args ...interface{}) {
+				var pErr *image.ErrFetchingImage
+				require.ErrorAs(t, err, &pErr)
+			},
+		},
+		{
+			name: "digest event",
+			event: &pullEvent{
+				Status: "Digest: abc123",
+			},
+			expectOnEvent: false,
+			assertFunc:    require.NoError,
+		},
+		{
+			name: "status event",
+			event: &pullEvent{
+				Status: "Status: Downloaded",
+			},
+			expectOnEvent: false,
+			assertFunc:    require.NoError,
+		},
+		{
+			name: "non-terminal event",
+			event: &pullEvent{
+				Status: "Downloading layer",
+			},
+			expectOnEvent: true,
+			assertFunc:    require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockEmitter{}
+			err := handlePullEvent(mock, tt.event)
+			tt.assertFunc(t, err)
+
+			if tt.expectOnEvent {
+				require.Len(t, mock.calledEvents, 1)
+				require.Equal(t, tt.event, mock.calledEvents[0])
+			} else {
+				require.Empty(t, mock.calledEvents)
+			}
 		})
 	}
 }

--- a/pkg/image/docker/daemon_provider_test.go
+++ b/pkg/image/docker/daemon_provider_test.go
@@ -110,7 +110,20 @@ func TestHandlePullEventWithMockEmitter(t *testing.T) {
 			},
 			expectOnEvent: false,
 			assertFunc: func(t require.TestingT, err error, args ...interface{}) {
-				var pErr *image.ErrFetchingImage
+				require.Error(t, err)
+				var pErr *image.ErrPlatformMismatch
+				require.NotErrorAs(t, err, &pErr)
+			},
+		},
+		{
+			name: "platform error in event",
+			event: &pullEvent{
+				Error: "image with reference anchore/test_images:golang was found but its platform (linux/amd64) does not match the specified platform (linux/arm64)",
+			},
+			expectOnEvent: false,
+			assertFunc: func(t require.TestingT, err error, args ...interface{}) {
+				require.Error(t, err)
+				var pErr *image.ErrPlatformMismatch
 				require.ErrorAs(t, err, &pErr)
 			},
 		},

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	containerregistryV1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	containerregistryV1Types "github.com/google/go-containerregistry/pkg/v1/types"
 
 	"github.com/anchore/stereoscope/internal/log"
 	"github.com/anchore/stereoscope/pkg/file"
@@ -64,9 +65,20 @@ func (p *registryImageProvider) Provide(ctx context.Context) (*image.Image, erro
 		return nil, fmt.Errorf("failed to get image descriptor from registry: %+v", err)
 	}
 
+	p.finalizePlatform(descriptor, &platform)
+
 	img, err := descriptor.Image()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image from registry: %+v", err)
+	}
+
+	c, err := img.ConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get image config from registry: %+v", err)
+	}
+
+	if err := validatePlatform(platform, c.OS, c.Architecture); err != nil {
+		return nil, err
 	}
 
 	// craft a repo digest from the registry reference and the known digest
@@ -97,6 +109,49 @@ func (p *registryImageProvider) Provide(ctx context.Context) (*image.Image, erro
 	return out, err
 }
 
+func (p *registryImageProvider) finalizePlatform(descriptor *remote.Descriptor, platform **image.Platform) {
+	if p.platform != nil {
+		return
+	}
+
+	// no platform was specified by the user. There are two cases we want to cover:
+	// 1. there is a manifest list, in which case we want to default the architecture to the host's architecture
+	// 2. there is a single platform image, in which case we want to use that architecture (specify no default)
+	switch descriptor.MediaType {
+	case containerregistryV1Types.OCIManifestSchema1, containerregistryV1Types.DockerManifestSchema1, containerregistryV1Types.DockerManifestSchema2:
+		// this is not for a multi-platform image, do not force the architecture if a platform was not specified explicitly by the user
+		*platform = nil
+		descriptor.Platform = nil
+	}
+}
+
+func validatePlatform(platform *image.Platform, givenOs, givenArch string) error {
+	if platform == nil {
+		return nil
+	}
+	if givenArch == "" || givenOs == "" {
+		return newErrFetchingImage(fmt.Errorf("missing architecture or OS from image config when user specified platform=%q", platform.String()))
+	}
+	platformStr := fmt.Sprintf("%s/%s", givenOs, givenArch)
+	actualPlatform, err := containerregistryV1.ParsePlatform(platformStr)
+	if err != nil {
+		return newErrFetchingImage(fmt.Errorf("failed to parse platform from image config: %w", err))
+	}
+	if actualPlatform == nil {
+		return newErrFetchingImage(fmt.Errorf("not platform from image config (from %q)", platformStr))
+	}
+	if !matchesPlatform(*actualPlatform, *toContainerRegistryPlatform(platform)) {
+		return newErrFetchingImage(fmt.Errorf("image platform=%q does not match user specified platform=%q", actualPlatform.String(), platform.String()))
+	}
+	return nil
+}
+
+func newErrFetchingImage(err error) *image.ErrFetchingImage {
+	return &image.ErrFetchingImage{
+		Reason: err.Error(),
+	}
+}
+
 func prepareReferenceOptions(registryOptions image.RegistryOptions) []name.Option {
 	var options []name.Option
 	if registryOptions.InsecureUseHTTP {
@@ -105,15 +160,22 @@ func prepareReferenceOptions(registryOptions image.RegistryOptions) []name.Optio
 	return options
 }
 
+func toContainerRegistryPlatform(p *image.Platform) *containerregistryV1.Platform {
+	if p == nil {
+		return nil
+	}
+	return &containerregistryV1.Platform{
+		Architecture: p.Architecture,
+		OS:           p.OS,
+		Variant:      p.Variant,
+	}
+}
+
 func prepareRemoteOptions(ctx context.Context, ref name.Reference, registryOptions image.RegistryOptions, p *image.Platform) (options []remote.Option) {
 	options = append(options, remote.WithContext(ctx))
 
 	if p != nil {
-		options = append(options, remote.WithPlatform(containerregistryV1.Platform{
-			Architecture: p.Architecture,
-			OS:           p.OS,
-			Variant:      p.Variant,
-		}))
+		options = append(options, remote.WithPlatform(*toContainerRegistryPlatform(p)))
 	}
 
 	registryName := ref.Context().RegistryStr()
@@ -165,4 +227,52 @@ func defaultPlatformIfNil(platform *image.Platform) *image.Platform {
 		}
 	}
 	return platform
+}
+
+// matchesPlatform checks if the given platform matches the required platforms.
+// The given platform matches the required platform if
+// - architecture and OS are identical.
+// - OS version and variant are identical if provided.
+// - features and OS features of the required platform are subsets of those of the given platform.
+// note: this function was copied from the GGCR repo, as it is not exported.
+func matchesPlatform(given, required containerregistryV1.Platform) bool {
+	// Required fields that must be identical.
+	if given.Architecture != required.Architecture || given.OS != required.OS {
+		return false
+	}
+
+	// Optional fields that may be empty, but must be identical if provided.
+	if required.OSVersion != "" && given.OSVersion != required.OSVersion {
+		return false
+	}
+	if required.Variant != "" && given.Variant != required.Variant {
+		return false
+	}
+
+	// Verify required platform's features are a subset of given platform's features.
+	if !isSubset(given.OSFeatures, required.OSFeatures) {
+		return false
+	}
+	if !isSubset(given.Features, required.Features) {
+		return false
+	}
+
+	return true
+}
+
+// isSubset checks if the required array of strings is a subset of the given lst.
+// note: this function was copied from the GGCR repo, as it is not exported.
+func isSubset(lst, required []string) bool {
+	set := make(map[string]bool)
+	for _, value := range lst {
+		set[value] = true
+	}
+
+	for _, value := range required {
+		if _, ok := set[value]; !ok {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -130,25 +130,26 @@ func validatePlatform(platform *image.Platform, givenOs, givenArch string) error
 		return nil
 	}
 	if givenArch == "" || givenOs == "" {
-		return newErrFetchingImage(fmt.Errorf("missing architecture or OS from image config when user specified platform=%q", platform.String()))
+		return newErrPlatformMismatch(platform, fmt.Errorf("missing architecture or OS from image config when user specified platform=%q", platform.String()))
 	}
 	platformStr := fmt.Sprintf("%s/%s", givenOs, givenArch)
 	actualPlatform, err := containerregistryV1.ParsePlatform(platformStr)
 	if err != nil {
-		return newErrFetchingImage(fmt.Errorf("failed to parse platform from image config: %w", err))
+		return newErrPlatformMismatch(platform, fmt.Errorf("failed to parse platform from image config: %w", err))
 	}
 	if actualPlatform == nil {
-		return newErrFetchingImage(fmt.Errorf("not platform from image config (from %q)", platformStr))
+		return newErrPlatformMismatch(platform, fmt.Errorf("not platform from image config (from %q)", platformStr))
 	}
 	if !matchesPlatform(*actualPlatform, *toContainerRegistryPlatform(platform)) {
-		return newErrFetchingImage(fmt.Errorf("image platform=%q does not match user specified platform=%q", actualPlatform.String(), platform.String()))
+		return newErrPlatformMismatch(platform, fmt.Errorf("image platform=%q does not match user specified platform=%q", actualPlatform.String(), platform.String()))
 	}
 	return nil
 }
 
-func newErrFetchingImage(err error) *image.ErrFetchingImage {
-	return &image.ErrFetchingImage{
-		Reason: err.Error(),
+func newErrPlatformMismatch(platform *image.Platform, err error) *image.ErrPlatformMismatch {
+	return &image.ErrPlatformMismatch{
+		ExpectedPlatform: platform.String(),
+		Err:              err,
 	}
 }
 

--- a/pkg/image/oci/registry_provider_test.go
+++ b/pkg/image/oci/registry_provider_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestValidatePlatform(t *testing.T) {
 	isFetchError := func(t require.TestingT, err error, args ...interface{}) {
-		var pErr *image.ErrFetchingImage
+		var pErr *image.ErrPlatformMismatch
 		require.ErrorAs(t, err, &pErr)
 	}
 	tests := []struct {

--- a/pkg/image/provider.go
+++ b/pkg/image/provider.go
@@ -2,7 +2,21 @@ package image
 
 import (
 	"context"
+	"fmt"
 )
+
+// ErrFetchingImage is meant to be used when a provider has positively resolved the image but, while fetching the
+// image, an error occurred. The goal is to differentiate between a provider that cannot resolve an image (thus
+// if the caller has a set of providers, it can try another provider) and a provider that can resolve an image but
+// there is an unresolvable problem (e.g. network error, mismatched architecture, etc... thus the caller should
+// not try any further providers).
+type ErrFetchingImage struct {
+	Reason string
+}
+
+func (e *ErrFetchingImage) Error() string {
+	return fmt.Sprintf("error fetching image: %s", e.Reason)
+}
 
 // Provider is an abstraction for any object that provides image objects (e.g. the docker daemon API, a tar file of
 // an OCI image, podman varlink API, etc.).

--- a/pkg/image/provider.go
+++ b/pkg/image/provider.go
@@ -5,17 +5,22 @@ import (
 	"fmt"
 )
 
-// ErrFetchingImage is meant to be used when a provider has positively resolved the image but, while fetching the
-// image, an error occurred. The goal is to differentiate between a provider that cannot resolve an image (thus
-// if the caller has a set of providers, it can try another provider) and a provider that can resolve an image but
-// there is an unresolvable problem (e.g. network error, mismatched architecture, etc... thus the caller should
-// not try any further providers).
-type ErrFetchingImage struct {
-	Reason string
+// ErrPlatformMismatch is meant to be used when a provider has positively resolved the image but the image OS or
+// architecture does not match with what was requested.
+type ErrPlatformMismatch struct {
+	ExpectedPlatform string
+	Err              error
 }
 
-func (e *ErrFetchingImage) Error() string {
-	return fmt.Sprintf("error fetching image: %s", e.Reason)
+func (e *ErrPlatformMismatch) Error() string {
+	if e.ExpectedPlatform == "" {
+		return fmt.Sprintf("mismatched platform: %v", e.Err)
+	}
+	return fmt.Sprintf("mismatched platform (expected %v): %v", e.ExpectedPlatform, e.Err)
+}
+
+func (e *ErrPlatformMismatch) Unwrap() error {
+	return e.Err
 }
 
 // Provider is an abstraction for any object that provides image objects (e.g. the docker daemon API, a tar file of

--- a/test/integration/oci_registry_source_test.go
+++ b/test/integration/oci_registry_source_test.go
@@ -32,7 +32,7 @@ func TestOciRegistrySourceMetadata(t *testing.T) {
 	imgStr := "anchore/test_images"
 	ref := fmt.Sprintf("%s@%s", imgStr, digest)
 
-	img, err := stereoscope.GetImage(context.TODO(), "registry:"+ref)
+	img, err := stereoscope.GetImage(context.TODO(), "registry:"+ref, stereoscope.WithPlatform("linux/amd64"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, img.Cleanup())


### PR DESCRIPTION
Today we allow for users to specify a platform for images being resolved. The expectation is that if the fetched/resolved image does not match the requested platform then we should error out and not continue. Bugs were found in both how the Docker daemon provider (thus Podman as well since this is shared code) as well as the OCI registry provider. Though the bugs were slightly different, at a high level they were the same: a user could provide a platform to fetch and the provider in some cases would ignore this platform and fetch the image for a different platform.

For the Docker daemon provider when monitoring the pull event status JSONL stream the `Error` field was not being considered, which is where this kind of error is raised up.

For the OCI registry provider, passing the `remote.WithPlatform` option only sets the platform field on the `v1.Descriptor` object, but does not have any effect on what is fetched in the case where there is no manifest list or index (there is a single architecture in the registry). In the case of manifest list or index the correct platform was being resolved. The change here was to explicitly pull the container config and validate against the `os` and `architecture` fields (which are required via the OCI spec).

An additional step within the OCI registry provider is checking if the manifest is a list/index or a single manifest. If the user does NOT give a platform then the current default behavior for this provider is to set one based off of `linux/<GOARCH>`. The intended behavior is to honor what the single-architecture manifest instead of overriding with a default value. This PR enforces this intended behavior by clearing the platform options after fetching the manifest and checking the MediaType for single vs multi arch support.

~The last change is to allow for providers to express errors that indicate that the image was fully resolved by the provider but there was a transient or fundamental error. This new error is intended to signal to the caller that no further providers in a set of providers should be attempted, and to raise up this single error. For instance, if we tried 7 providers with 7 "not found" errors and we reach the Docker provider and it raises up a platform mismatch error, we don't want to attempt the Registry provider since we expect a similar outcome. This fosters a fail-fast approach for cases we know the user should be paying attention to (and not get lost in a pile of errors from multiple providers).~ Instead a new specific error type has been added to allow the caller to more clearly reason about platform mismatch errors.