### PR TITLE
chore(ci): fix composite GitHub action path in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
           - patch
 
   - package-ecosystem: "github-actions"
-    directory: "/.github/actions/boostrap"
+    directory: "/.github/actions/bootstrap"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Fixes a typo in the dependabot config which was preventing automated updates to the composite bootstrap action definition.