### PR TITLE
Bump actions cache

### DIFF
--- a/.github/workflows/benchmark-testing.yaml
+++ b/.github/workflows/benchmark-testing.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/bootstrap
 
       - name: Restore base benchmark result
-        uses: actions/cache@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
         with:
           path: test/results/benchmark-main.txt
           # use base sha for PR or new commit hash for main push in benchmark result key

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -109,14 +109,14 @@ jobs:
           limit-access-to-actor: true
 
       - name: Restore integration test-fixture cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
         with:
           path: ${{ github.workspace }}/test/integration/test-fixtures/cache
           key: ${{ runner.os }}-integration-test-cache-${{ hashFiles('test/integration/test-fixtures/cache.fingerprint') }}
 
       - name: Restore integration tool cache
         id: integration-tool-cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
         with:
           path: ${{ github.workspace }}/test/integration/tools/cache
           key: ${{ runner.os }}-integration-tools-cache-${{ hashFiles('test/integration/tools/cache.fingerprint') }}


### PR DESCRIPTION
Not certain why [dependabot will not update this](https://github.com/anchore/stereoscope/actions/runs/13272971601/job/37056485524), [but we now need to](https://github.com/actions/cache/discussions/1510) (v4.0.2 is deprecated too):
```
updater | 2025/02/11 21:35:41 INFO <job_962732186> Checking if actions/cache 4 needs updating
  proxy | 2025/02/11 21:35:41 [052] GET [https://github.com:443/actions/cache.git/info/refs?service=git-upload-pack](https://github.com/actions/cache.git/info/refs?service=git-upload-pack)
2025/02/11 21:35:41 [052] 200 [https://github.com:443/actions/cache.git/info/refs?service=git-upload-pack](https://github.com/actions/cache.git/info/refs?service=git-upload-pack)
updater | 2025/02/11 21:35:41 INFO <job_962732186> Latest version is 4
2025/02/11 21:35:41 INFO <job_962732186> No update needed for actions/cache 4
```