### PR TITLE
fix(performance): glob search

### DIFF
--- a/pkg/filetree/index_test.go
+++ b/pkg/filetree/index_test.go
@@ -795,7 +795,7 @@ func TestFileCatalog_GetBasenames(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := fileIndex.Basenames()
+			actual := fileIndex.(*index).basenames.List()
 			assert.ElementsMatchf(t, tt.want, actual, "diff: %s", cmp.Diff(tt.want, actual))
 		})
 	}

--- a/pkg/image/file_catalog_test.go
+++ b/pkg/image/file_catalog_test.go
@@ -736,8 +736,11 @@ func TestFileCatalog_GetBasenames(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := fileCatalog.Basenames()
-			assert.ElementsMatchf(t, tt.want, actual, "diff: %s", cmp.Diff(tt.want, actual))
+			for _, name := range tt.want {
+				e, err := fileCatalog.GetByBasenameGlob(name)
+				require.NoError(t, err)
+				require.NotEmpty(t, e)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR improves a performance issue apparent in the dpkg cataloger under certain circumstances: primarily many layers with many dpkg packages that result in a basename wildcard search (e.g. `<some-path>/<file>.*`)

Mostly fixes: https://github.com/anchore/syft/issues/3683

Note: this still does not _entirely_ revert performance to what it was in the v0.95.0 release. A new feature was added, which necessarily needs to perform more searches during dpkg cataloging, and without substantial other changes, I believe it will be difficult to get back to that level of performance. Locally, with the pytorch image mentioned here on an external drive, scans actually took almost 2 hours, this change reduces them to ~15 minutes. I have some other changes in the works to further parallelize a lot of the catalogers, including dpkg, which I suspect will also substantially improve the performance. I have more ideas, but this should at least get performance in the ballpark to where it was. I ran this locally with the parallelism improvements, still reading an external spinning drive, I see this under 2 minutes locally (running with `SYFT_PARALLELISM=16 go run ./cmd/syft --scope all-layers /Volumes/Stuff/tmp/pytorch.tar -v`): 
```
[0322]  INFO task completed elapsed=1m53.680956095s task=dpkg-db-cataloger
```