### PR TITLE
chore: add logging to get timing info

### DIFF
--- a/pkg/image/docker/tarball_provider.go
+++ b/pkg/image/docker/tarball_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -39,6 +40,8 @@ func (p *tarballImageProvider) Name() string {
 
 // Provide an image object that represents the docker image tar at the configured location on disk.
 func (p *tarballImageProvider) Provide(_ context.Context) (*image.Image, error) {
+	startTime := time.Now()
+
 	img, err := tarball.ImageFromPath(p.path, nil)
 	if err != nil {
 		// raise a more controlled error for when there are multiple images within the given tar (from https://github.com/anchore/grype/issues/215)
@@ -47,6 +50,8 @@ func (p *tarballImageProvider) Provide(_ context.Context) (*image.Image, error) 
 		}
 		return nil, fmt.Errorf("unable to provide image from tarball: %w", err)
 	}
+
+	log.WithFields("image", p.path, "time", time.Since(startTime)).Debug("got uncompressed image tarball")
 
 	// make a best-effort to generate an OCI manifest and gets tags, but ultimately this should be considered optional
 	var rawOCIManifest []byte

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -207,10 +208,10 @@ func (i *Image) Read() error {
 		return err
 	}
 
-	log.Debugf("image metadata: digest=%+v mediaType=%+v tags=%+v",
-		i.Metadata.ID,
-		i.Metadata.MediaType,
-		i.Metadata.Tags)
+	log.WithFields("digest", i.Metadata.ID, "mediaType", i.Metadata.MediaType, "tags", i.Metadata.Tags).Debug("reading image")
+
+	startTime := time.Now()
+	lapTime := startTime
 
 	v1Layers, err := i.image.Layers()
 	if err != nil {
@@ -236,11 +237,20 @@ func (i *Image) Read() error {
 
 	i.Layers = layers
 
+	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image layer copy")
+	lapTime = time.Now()
+
 	// in order to resolve symlinks all squashed trees must be available
 	err = i.squash(readProg)
 
+	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image squash")
+	lapTime = time.Now()
+
 	i.FileCatalog = fileCatalog
 	i.SquashedSearchContext = filetree.NewSearchContext(i.SquashedTree(), i.FileCatalog)
+
+	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image search context")
+	log.WithFields("digest", i.Metadata.ID, "mediaType", i.Metadata.MediaType, "tags", i.Metadata.Tags, "time", time.Since(startTime)).Info("completed image read")
 
 	return err
 }

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -47,6 +48,7 @@ func (p *registryImageProvider) Name() string {
 func (p *registryImageProvider) Provide(ctx context.Context) (*image.Image, error) {
 	log.Debugf("pulling image info directly from registry image=%q", p.imageStr)
 
+	startTime := time.Now()
 	imageTempDir, err := p.tmpDirGen.NewDirectory("oci-registry-image")
 	if err != nil {
 		return nil, err
@@ -81,6 +83,8 @@ func (p *registryImageProvider) Provide(ctx context.Context) (*image.Image, erro
 	if err := validatePlatform(platform, c.OS, c.Architecture); err != nil {
 		return nil, err
 	}
+
+	log.WithFields("image", p.imageStr, "time", time.Since(startTime)).Info("completed downloading image")
 
 	// craft a repo digest from the registry reference and the known digest
 	// note: the descriptor is fetched from the registry, and the descriptor digest is the same as the repo digest

--- a/pkg/image/oci/tarball_provider.go
+++ b/pkg/image/oci/tarball_provider.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/anchore/stereoscope/internal/log"
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
 )
@@ -43,9 +45,14 @@ func (p *tarballImageProvider) Provide(ctx context.Context) (*image.Image, error
 		return nil, err
 	}
 
+	log.WithFields("file", p.path, "tempDir", tempDir).Trace("extracting OCI tar file to tempdir")
+	startTime := time.Now()
+
 	if err = file.UntarToDirectory(f, tempDir); err != nil {
 		return nil, err
 	}
+
+	log.WithFields("file", p.path, "tempDir", tempDir, "time", time.Since(startTime)).Debug("extracted OCI tar file to tempdir")
 
 	return NewDirectoryProvider(p.tmpDirGen, tempDir).Provide(ctx)
 }


### PR DESCRIPTION
This PR adds some timing info during stereoscope image processing to better understand where time is being spent: downloading, saving, indexing, etc..

I've tried to make the logging levels appropriately noisy. In other words, info has some approximation of these messages added:
```
[0000]  INFO docker pulling image image=golang:latest
[0000]  INFO docker pulled image image=golang:latest time=11.192994ms
[0013]  INFO docker saved image image=golang:latest path=/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/stereoscope-67844120/docker-daemon-image-2765683229/image.tar time=13.219155363s
[0017]  INFO completed image read digest=sha256:ec829c45babe26254b2b8aa569b45d60af9f2a8c3cc8d94f3240a4ca34ecfeac mediaType=application/vnd.docker.distribution.manifest.v2+json tags=[golang:latest] time=3.961071492s
```
Debug:
```
[0000]  INFO docker pulling image image=golang:latest
[0000]  INFO docker pulled image image=golang:latest time=8.318835ms
[0012]  INFO docker saved image image=golang:latest path=/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/stereoscope-651095740/docker-daemon-image-2341072489/image.tar time=12.185550926s
[0012] DEBUG got uncompressed image tarball image=/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/stereoscope-651095740/docker-daemon-image-2341072489/image.tar time=1.945874ms
[0012] DEBUG reading image digest=sha256:ec829c45babe26254b2b8aa569b45d60af9f2a8c3cc8d94f3240a4ca34ecfeac mediaType=application/vnd.docker.distribution.manifest.v2+json tags=[golang:latest]
[0016]  INFO completed image read digest=sha256:ec829c45babe26254b2b8aa569b45d60af9f2a8c3cc8d94f3240a4ca34ecfeac mediaType=application/vnd.docker.distribution.manifest.v2+json tags=[golang:latest] time=4.111925849s
```
Trace:
```
[0000]  INFO docker pulling image image=golang:latest
[0000]  INFO docker pulled image image=golang:latest time=11.332431ms
[0000] TRACE docker validated image image=golang:latest time=2.731703ms
[0012]  INFO docker saved image image=golang:latest path=/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/stereoscope-191422219/docker-daemon-image-357755956/image.tar time=12.054025775s
[0012] DEBUG got uncompressed image tarball image=/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/stereoscope-191422219/docker-daemon-image-357755956/image.tar time=756.562µs
[0012] DEBUG reading image digest=sha256:ec829c45babe26254b2b8aa569b45d60af9f2a8c3cc8d94f3240a4ca34ecfeac mediaType=application/vnd.docker.distribution.manifest.v2+json tags=[golang:latest]
[0012] TRACE reading uncompressed image layer digest=sha256:f7f2b929d8a55112a2db1bc16fb8731045c9572b84d6dfbbdbd5dc6dd2bd9fe4 index=0 mediaType=application/vnd.docker.image.rootfs.diff.tar.gzip
[0012] TRACE start uncompressed layer cache index=0 path=/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/stereoscope-191422219/docker-tarball-image-2061478161/sha256:f7f2b929d8a55112a2db1bc16fb8731045c9572b84d6dfbbdbd5dc6dd2bd9fe4
[0012] TRACE completed uncompressed layer cache index=0 path=/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/stereoscope-191422219/docker-tarball-image-2061478161/sha256:f7f2b929d8a55112a2db1bc16fb8731045c9572b84d6dfbbdbd5dc6dd2bd9fe4 time=185.777462ms
[0012] TRACE completed indexing image layer digest=sha256:f7f2b929d8a55112a2db1bc16fb8731045c9572b84d6dfbbdbd5dc6dd2bd9fe4 index=0 mediaType=application/vnd.docker.image.rootfs.diff.tar.gzip time=405.760535ms
[0012] TRACE completed layer search context index=0 time=2.334897ms
[0012] TRACE reading uncompressed image layer digest=sha256:7f0053786e6e2411ce577e795ef6c278601de3faa0817c071801b11a3f83fd0d index=1 mediaType=application/vnd.docker.image.rootfs.diff.tar.gzip
[0012] TRACE start uncompressed layer cache index=1 path=/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/stereoscope-191422219/docker-tarball-image-2061478161/sha256:7f0053786e6e2411ce577e795ef6c278601de3faa0817c071801b11a3f83fd0d
[0012] TRACE completed uncompressed layer cache index=1 path=/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/stereoscope-191422219/docker-tarball-image-2061478161/sha256:7f0053786e6e2411ce577e795ef6c278601de3faa0817c071801b11a3f83fd0d time=55.98348ms
[0012] TRACE completed indexing image layer digest=sha256:7f0053786e6e2411ce577e795ef6c278601de3faa0817c071801b11a3f83fd0d index=1 mediaType=application/vnd.docker.image.rootfs.diff.tar.gzip time=121.487649ms
[0012] TRACE completed layer search context index=1 time=1.39849ms
[0012] TRACE reading uncompressed image layer digest=sha256:b2bcbd8ebb2be9869ca3198b4c521f18b612b4287ee4b705678d7b85383b71af index=2 mediaType=application/vnd.docker.image.rootfs.diff.tar.gzip
...
[0015] TRACE reading uncompressed image layer digest=sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef index=6 mediaType=application/vnd.docker.image.rootfs.diff.tar.gzip
[0015] TRACE start uncompressed layer cache index=6 path=/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/stereoscope-191422219/docker-tarball-image-2061478161/sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef
[0015] TRACE completed uncompressed layer cache index=6 path=/var/folders/jc/fxkytj5j5sj8rwxsv7k5x1b80000gn/T/stereoscope-191422219/docker-tarball-image-2061478161/sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef time=282.378µs
[0015] TRACE completed indexing image layer digest=sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef index=6 mediaType=application/vnd.docker.image.rootfs.diff.tar.gzip time=55.364µs
[0015] TRACE completed layer search context index=6 time=1.337937ms
[0015] TRACE completed image layer copy digest=sha256:ec829c45babe26254b2b8aa569b45d60af9f2a8c3cc8d94f3240a4ca34ecfeac time=3.573271382s
[0016] TRACE completed image squash digest=sha256:ec829c45babe26254b2b8aa569b45d60af9f2a8c3cc8d94f3240a4ca34ecfeac time=367.027552ms
[0016] TRACE completed image search context digest=sha256:ec829c45babe26254b2b8aa569b45d60af9f2a8c3cc8d94f3240a4ca34ecfeac time=2.583331ms
[0016]  INFO completed image read digest=sha256:ec829c45babe26254b2b8aa569b45d60af9f2a8c3cc8d94f3240a4ca34ecfeac mediaType=application/vnd.docker.distribution.manifest.v2+json tags=[golang:latest] time=3.943010198s
```