### PR TITLE
chore: add ability to associate opener and layer separately

### DIFF
--- a/pkg/image/file_catalog.go
+++ b/pkg/image/file_catalog.go
@@ -41,11 +41,23 @@ func (c *FileCatalog) Add(f file.Reference, m file.Metadata, l *Layer, opener fi
 	c.addImageReferences(f.ID(), l, opener)
 }
 
+func (c *FileCatalog) AssociateOpener(f file.Reference, opener file.Opener) {
+	c.addImageReferences(f.ID(), nil, opener)
+}
+
+func (c *FileCatalog) AssociateLayer(f file.Reference, l *Layer) {
+	c.addImageReferences(f.ID(), l, nil)
+}
+
 func (c *FileCatalog) addImageReferences(id file.ID, l *Layer, opener file.Opener) {
 	c.Lock()
 	defer c.Unlock()
-	c.layerByID[id] = l
-	c.openerByID[id] = opener
+	if l != nil {
+		c.layerByID[id] = l
+	}
+	if opener != nil {
+		c.openerByID[id] = opener
+	}
 }
 
 func (c *FileCatalog) Layer(f file.Reference) *Layer {


### PR DESCRIPTION
This is useful in times when an opener is not necessarily available when indexing a filesystem, but is available later.