### PR TITLE
fix: complex symlink performance issue

### DIFF
--- a/pkg/filetree/glob_parser.go
+++ b/pkg/filetree/glob_parser.go
@@ -47,14 +47,14 @@ func (s searchBasis) String() string {
 
 type searchRequest struct {
 	searchBasis
-	value       string
-	requirement string
+	indexLookup string
+	glob        string
 }
 
 func (s searchRequest) String() string {
-	value := s.searchBasis.String() + ": " + s.value
-	if s.requirement != "" {
-		value += " (requirement: " + s.requirement + ")"
+	value := s.searchBasis.String() + ": " + s.indexLookup
+	if s.glob != "" {
+		value += " (requirement: " + s.glob + ")"
 	}
 	return value
 }
@@ -62,11 +62,12 @@ func (s searchRequest) String() string {
 func parseGlob(glob string) []searchRequest {
 	glob = cleanGlob(glob)
 
-	if !strings.ContainsAny(glob, "*?[]{}") {
+	if exactMatch(glob) {
 		return []searchRequest{
 			{
 				searchBasis: searchByFullPath,
-				value:       glob,
+				indexLookup: glob,
+				glob:        glob,
 			},
 		}
 	}
@@ -80,20 +81,20 @@ func parseGlob(glob string) []searchRequest {
 			requests := []searchRequest{
 				{
 					searchBasis: searchBySubDirectory,
-					value:       nestedBasename,
-					requirement: beforeBasename,
+					indexLookup: nestedBasename,
+					glob:        glob,
 				},
 			}
 			return requests
 		}
 	}
 
-	requests := parseGlobBasename(basename)
-	for i := range requests {
-		applyRequirement(&requests[i], beforeBasename, glob)
-	}
+	return parseGlobBasename(basename, glob)
+}
 
-	return requests
+// exactMatch indicates the string does not contain an expression that may result in multiple results such as * or {}
+func exactMatch(glob string) bool {
+	return !strings.ContainsAny(glob, "*?[]{}")
 }
 
 func splitAtBasename(glob string) (string, string) {
@@ -118,34 +119,9 @@ func splitAtBasename(glob string) (string, string) {
 	return beforeBasename, basename
 }
 
-func applyRequirement(request *searchRequest, beforeBasename, glob string) {
-	var requirement string
-
-	if beforeBasename != "" {
-		requirement = glob
-		switch beforeBasename {
-		case "**", request.requirement:
-			if request.searchBasis != searchByExtension {
-				requirement = ""
-			}
-		}
-	} else {
-		requirement = ""
-	}
-
-	request.requirement = requirement
-
-	if request.searchBasis == searchByGlob {
-		request.value = glob
-		if glob == request.requirement {
-			request.requirement = ""
-		}
-	}
-}
-
-func parseGlobBasename(basenameInput string) []searchRequest {
+func parseGlobBasename(basenameInput, glob string) []searchRequest {
 	if strings.ContainsAny(basenameInput, "[]{}") {
-		return parseBasenameAltAndClassGlobSections(basenameInput)
+		return parseBasenameAltAndClassGlobSections(basenameInput, glob)
 	}
 
 	extensionFields := strings.Split(basenameInput, "*.")
@@ -156,7 +132,8 @@ func parseGlobBasename(basenameInput string) []searchRequest {
 			return []searchRequest{
 				{
 					searchBasis: searchByExtension,
-					value:       "." + possibleExtension,
+					indexLookup: "." + possibleExtension,
+					glob:        glob,
 				},
 			}
 		}
@@ -167,7 +144,8 @@ func parseGlobBasename(basenameInput string) []searchRequest {
 		return []searchRequest{
 			{
 				searchBasis: searchByBasename,
-				value:       basenameInput,
+				indexLookup: basenameInput,
+				glob:        glob,
 			},
 		}
 	}
@@ -177,7 +155,7 @@ func parseGlobBasename(basenameInput string) []searchRequest {
 		return []searchRequest{
 			{
 				searchBasis: searchByGlob,
-				// note: we let the parent caller attach the full glob value
+				glob:        glob,
 			},
 		}
 	}
@@ -185,12 +163,13 @@ func parseGlobBasename(basenameInput string) []searchRequest {
 	return []searchRequest{
 		{
 			searchBasis: searchByBasenameGlob,
-			value:       basenameInput,
+			indexLookup: basenameInput,
+			glob:        glob,
 		},
 	}
 }
 
-func parseBasenameAltAndClassGlobSections(basenameInput string) []searchRequest {
+func parseBasenameAltAndClassGlobSections(basenameInput, glob string) []searchRequest {
 	// TODO: process escape sequences
 
 	altStartCount := strings.Count(basenameInput, "{")
@@ -203,7 +182,7 @@ func parseBasenameAltAndClassGlobSections(basenameInput string) []searchRequest 
 		return []searchRequest{
 			{
 				searchBasis: searchByGlob,
-				// note: we let the parent caller attach the full glob value
+				glob:        glob,
 			},
 		}
 	}
@@ -213,7 +192,8 @@ func parseBasenameAltAndClassGlobSections(basenameInput string) []searchRequest 
 		return []searchRequest{
 			{
 				searchBasis: searchByBasenameGlob,
-				value:       basenameInput,
+				indexLookup: basenameInput,
+				glob:        glob,
 			},
 		}
 	}
@@ -236,7 +216,8 @@ func parseBasenameAltAndClassGlobSections(basenameInput string) []searchRequest 
 
 					requests = append(requests, searchRequest{
 						searchBasis: basis,
-						value:       altSection,
+						indexLookup: altSection,
+						glob:        glob,
 					})
 				}
 				return requests
@@ -248,7 +229,8 @@ func parseBasenameAltAndClassGlobSections(basenameInput string) []searchRequest 
 	return []searchRequest{
 		{
 			searchBasis: searchByBasenameGlob,
-			value:       basenameInput,
+			indexLookup: basenameInput,
+			glob:        glob,
 		},
 	}
 }

--- a/pkg/filetree/glob_parser_test.go
+++ b/pkg/filetree/glob_parser_test.go
@@ -19,7 +19,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByFullPath,
-					value:       "foo/bar/basename.txt",
+					indexLookup: "foo/bar/basename.txt",
+					glob:        "foo/bar/basename.txt",
 				},
 			},
 		},
@@ -29,7 +30,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByFullPath,
-					value:       "/foo/bar/basename.txt",
+					indexLookup: "/foo/bar/basename.txt",
+					glob:        "/foo/bar/basename.txt",
 				},
 			},
 		},
@@ -39,7 +41,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByExtension,
-					value:       ".txt",
+					indexLookup: ".txt",
+					glob:        "*.txt",
 				},
 			},
 		},
@@ -49,8 +52,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByExtension,
-					value:       ".txt",
-					requirement: "**/*.txt",
+					indexLookup: ".txt",
+					glob:        "**/*.txt",
 				},
 			},
 		},
@@ -60,7 +63,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "bas*nam?.txt",
+					indexLookup: "bas*nam?.txt",
+					glob:        "bas*nam?.txt",
 				},
 			},
 		},
@@ -70,8 +74,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByExtension,
-					value:       ".txt",
-					requirement: "foo/bar/**/*.txt",
+					indexLookup: ".txt",
+					glob:        "foo/bar/**/*.txt",
 				},
 			},
 		},
@@ -81,7 +85,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByFullPath,
-					value:       "basename.txt",
+					indexLookup: "basename.txt",
+					glob:        "basename.txt",
 				},
 			},
 		},
@@ -91,7 +96,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasename,
-					value:       "basename.txt",
+					indexLookup: "basename.txt",
+					glob:        "**/basename.txt",
 				},
 			},
 		},
@@ -101,8 +107,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasename,
-					value:       "basename.txt",
-					requirement: "foo/b*/basename.txt",
+					indexLookup: "basename.txt",
+					glob:        "foo/b*/basename.txt",
 				},
 			},
 		},
@@ -112,7 +118,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "basename.*",
+					indexLookup: "basename.*",
+					glob:        "basename.*",
 				},
 			},
 		},
@@ -122,8 +129,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "basename.*",
-					requirement: "**/foo/bar/basename.*",
+					indexLookup: "basename.*",
+					glob:        "**/foo/bar/basename.*",
 				},
 			},
 		},
@@ -133,8 +140,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "basenam?.txt",
-					requirement: "**/foo/bar/basenam?.txt",
+					indexLookup: "basenam?.txt",
+					glob:        "**/foo/bar/basenam?.txt",
 				},
 			},
 		},
@@ -144,8 +151,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "basena[me][me].txt",
-					requirement: "**/foo/bar/basena[me][me].txt",
+					indexLookup: "basena[me][me].txt",
+					glob:        "**/foo/bar/basena[me][me].txt",
 				},
 			},
 		},
@@ -155,8 +162,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "basena[me][me].txt",
-					requirement: "**/foo/[bB]ar/basena[me][me].txt",
+					indexLookup: "basena[me][me].txt",
+					glob:        "**/foo/[bB]ar/basena[me][me].txt",
 				},
 			},
 		},
@@ -166,7 +173,7 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByGlob,
-					value:       "**/foo/bar/{nested/basena[me][me].txt,another.txt}",
+					glob:        "**/foo/bar/{nested/basena[me][me].txt,another.txt}",
 				},
 			},
 		},
@@ -176,7 +183,7 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByGlob,
-					value:       "**/foo/bar/[me][m/e].txt,another.txt",
+					glob:        "**/foo/bar/[me][m/e].txt,another.txt",
 				},
 			},
 		},
@@ -186,18 +193,18 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasename,
-					value:       "Packages",
-					requirement: "**/var/lib/rpm/{Packages,Packages.db,rpmdb.sqlite}",
+					indexLookup: "Packages",
+					glob:        "**/var/lib/rpm/{Packages,Packages.db,rpmdb.sqlite}",
 				},
 				{
 					searchBasis: searchByBasename,
-					value:       "Packages.db",
-					requirement: "**/var/lib/rpm/{Packages,Packages.db,rpmdb.sqlite}",
+					indexLookup: "Packages.db",
+					glob:        "**/var/lib/rpm/{Packages,Packages.db,rpmdb.sqlite}",
 				},
 				{
 					searchBasis: searchByBasename,
-					value:       "rpmdb.sqlite",
-					requirement: "**/var/lib/rpm/{Packages,Packages.db,rpmdb.sqlite}",
+					indexLookup: "rpmdb.sqlite",
+					glob:        "**/var/lib/rpm/{Packages,Packages.db,rpmdb.sqlite}",
 				},
 			},
 		},
@@ -207,8 +214,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "{Packa{ges}{GES},Packages.db,rpmdb.sqlite}",
-					requirement: "**/var/lib/rpm/{Packa{ges}{GES},Packages.db,rpmdb.sqlite}",
+					indexLookup: "{Packa{ges}{GES},Packages.db,rpmdb.sqlite}",
+					glob:        "**/var/lib/rpm/{Packa{ges}{GES},Packages.db,rpmdb.sqlite}",
 				},
 			},
 		},
@@ -218,18 +225,18 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "Pack???s",
-					requirement: "**/var/lib/rpm/{Pack???s,Packages.db,rpm*.sqlite}",
+					indexLookup: "Pack???s",
+					glob:        "**/var/lib/rpm/{Pack???s,Packages.db,rpm*.sqlite}",
 				},
 				{
 					searchBasis: searchByBasename,
-					value:       "Packages.db",
-					requirement: "**/var/lib/rpm/{Pack???s,Packages.db,rpm*.sqlite}",
+					indexLookup: "Packages.db",
+					glob:        "**/var/lib/rpm/{Pack???s,Packages.db,rpm*.sqlite}",
 				},
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "rpm*.sqlite",
-					requirement: "**/var/lib/rpm/{Pack???s,Packages.db,rpm*.sqlite}",
+					indexLookup: "rpm*.sqlite",
+					glob:        "**/var/lib/rpm/{Pack???s,Packages.db,rpm*.sqlite}",
 				},
 			},
 		},
@@ -239,7 +246,7 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByGlob,
-					value:       "**/foo/bar/*?/**",
+					glob:        "**/foo/bar/*?/**",
 				},
 			},
 		},
@@ -249,8 +256,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchBySubDirectory,
-					value:       "bar",
-					requirement: "**/foo/bar",
+					indexLookup: "bar",
+					glob:        "**/foo/bar/*",
 				},
 			},
 		},
@@ -270,7 +277,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByFullPath,
-					value:       "/",
+					indexLookup: "/",
+					glob:        "/",
 				},
 			},
 		},
@@ -280,7 +288,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByFullPath,
-					value:       "/",
+					indexLookup: "/",
+					glob:        "/",
 				},
 			},
 		},
@@ -290,8 +299,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "b*r",
-					requirement: "/foo/b*r", // note that the slash is removed since this should be a clean path
+					indexLookup: "b*r",
+					glob:        "/foo/b*r", // note that the slash is removed since this should be a clean path
 				},
 			},
 		},
@@ -301,7 +310,7 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByGlob,
-					value:       "**/foo/b*r/*",
+					glob:        "**/foo/b*r/*",
 				},
 			},
 		},
@@ -311,7 +320,7 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByGlob,
-					value:       "**/foo/b*r/**",
+					glob:        "**/foo/b*r/**",
 				},
 			},
 		},
@@ -321,8 +330,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasename,
-					value:       " .txt",          // note the space
-					requirement: "/foo/b*r/ .txt", // note the space in the middle, but otherwise clean on the front and back
+					indexLookup: " .txt",          // note the space
+					glob:        "/foo/b*r/ .txt", // note the space in the middle, but otherwise clean on the front and back
 				},
 			},
 		},
@@ -332,8 +341,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "*.*.*",            // note that the basename glob is cleaned up
-					requirement: "**/foo/bar/*.*.*", // note that the glob is cleaned up
+					indexLookup: "*.*.*",            // note that the basename glob is cleaned up
+					glob:        "**/foo/bar/*.*.*", // note that the glob is cleaned up
 				},
 			},
 		},
@@ -343,8 +352,8 @@ func Test_parseGlob(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "*thin*.txt",                 // note that the basename glob is cleaned up
-					requirement: "**/foo/*.*.*bar/*thin*.txt", // note that the glob is cleaned up
+					indexLookup: "*thin*.txt",                 // note that the basename glob is cleaned up
+					glob:        "**/foo/*.*.*bar/*thin*.txt", // note that the glob is cleaned up
 				},
 			},
 		},
@@ -395,7 +404,7 @@ func Test_parseGlobBasename(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasename,
-					value:       "basename.txt",
+					indexLookup: "basename.txt",
 				},
 			},
 		},
@@ -405,7 +414,7 @@ func Test_parseGlobBasename(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "*basename.txt",
+					indexLookup: "*basename.txt",
 				},
 			},
 		},
@@ -415,7 +424,7 @@ func Test_parseGlobBasename(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "bas*nam?.txt",
+					indexLookup: "bas*nam?.txt",
 				},
 			},
 		},
@@ -425,7 +434,7 @@ func Test_parseGlobBasename(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByExtension,
-					value:       ".txt",
+					indexLookup: ".txt",
 				},
 			},
 		},
@@ -435,7 +444,7 @@ func Test_parseGlobBasename(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "*.*.txt",
+					indexLookup: "*.*.txt",
 				},
 			},
 		},
@@ -445,7 +454,7 @@ func Test_parseGlobBasename(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasename,
-					value:       ".txt",
+					indexLookup: ".txt",
 				},
 			},
 		},
@@ -455,7 +464,7 @@ func Test_parseGlobBasename(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasenameGlob,
-					value:       "*thin*.txt",
+					indexLookup: "*thin*.txt",
 				},
 			},
 		},
@@ -465,22 +474,22 @@ func Test_parseGlobBasename(t *testing.T) {
 			want: []searchRequest{
 				{
 					searchBasis: searchByBasename,
-					value:       "Packages",
+					indexLookup: "Packages",
 				},
 				{
 					searchBasis: searchByBasename,
-					value:       "Packages.db",
+					indexLookup: "Packages.db",
 				},
 				{
 					searchBasis: searchByBasename,
-					value:       "rpmdb.sqlite",
+					indexLookup: "rpmdb.sqlite",
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, parseGlobBasename(tt.input), "parseGlobBasename(%v)", tt.input)
+			assert.Equalf(t, tt.want, parseGlobBasename(tt.input, ""), "parseGlobBasename(%v)", tt.input)
 		})
 	}
 }

--- a/pkg/filetree/search.go
+++ b/pkg/filetree/search.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 
@@ -98,9 +99,13 @@ func (sc searchContext) SearchByMIMEType(mimeTypes ...string) ([]file.Resolution
 		fileEntries = append(fileEntries, entries...)
 	}
 
-	refs, err := sc.referencesInTree(fileEntries)
-	if err != nil {
-		return nil, err
+	// this is not a path-based request, so resolving all link resolutions is not necessary, since all real paths satisfy the request
+	var refs []file.Resolution
+	for _, entry := range fileEntries {
+		refs = append(refs, file.Resolution{
+			RequestPath: entry.RealPath,
+			Reference:   &entry.Reference,
+		})
 	}
 
 	sort.Sort(file.Resolutions(refs))
@@ -139,7 +144,7 @@ func (sc searchContext) searchByRequest(request searchRequest, options ...LinkRe
 	switch request.searchBasis {
 	case searchByFullPath:
 		options = append(options, FollowBasenameLinks)
-		ref, err := sc.SearchByPath(request.value, options...)
+		ref, err := sc.SearchByPath(request.indexLookup, options...)
 		if err != nil {
 			return nil, err
 		}
@@ -148,118 +153,96 @@ func (sc searchContext) searchByRequest(request searchRequest, options ...LinkRe
 		}
 		return []file.Resolution{*ref}, nil
 	case searchByBasename:
-		indexes, err := sc.index.GetByBasename(request.value)
+		indexes, err := sc.index.GetByBasename(request.indexLookup)
 		if err != nil {
-			return nil, fmt.Errorf("unable to search by basename=%q: %w", request.value, err)
+			return nil, fmt.Errorf("unable to search by basename=%q: %w", request.indexLookup, err)
 		}
-		refs, err := sc.referencesWithRequirement(request.requirement, indexes)
+		resolutions, err := sc.firstMatchingReferences(request.glob, indexes)
 		if err != nil {
 			return nil, err
 		}
-		return refs, nil
+		return resolutions, nil
 	case searchByBasenameGlob:
-		indexes, err := sc.index.GetByBasenameGlob(request.value)
+		indexes, err := sc.index.GetByBasenameGlob(request.indexLookup)
 		if err != nil {
-			return nil, fmt.Errorf("unable to search by basename-glob=%q: %w", request.value, err)
+			return nil, fmt.Errorf("unable to search by basename-glob=%q: %w", request.indexLookup, err)
 		}
-		refs, err := sc.referencesWithRequirement(request.requirement, indexes)
+		resolutions, err := sc.firstMatchingReferences(request.glob, indexes)
 		if err != nil {
 			return nil, err
 		}
-		return refs, nil
+		return resolutions, nil
 	case searchByExtension:
-		indexes, err := sc.index.GetByExtension(request.value)
+		indexes, err := sc.index.GetByExtension(request.indexLookup)
 		if err != nil {
-			return nil, fmt.Errorf("unable to search by extension=%q: %w", request.value, err)
+			return nil, fmt.Errorf("unable to search by extension=%q: %w", request.indexLookup, err)
 		}
-		refs, err := sc.referencesWithRequirement(request.requirement, indexes)
+		resolutions, err := sc.firstMatchingReferences(request.glob, indexes)
 		if err != nil {
 			return nil, err
 		}
-		return refs, nil
+		return resolutions, nil
 	case searchBySubDirectory:
 		return sc.searchByParentBasename(request)
 
 	case searchByGlob:
-		log.WithFields("glob", request.value).Trace("glob provided is an expensive search, consider using a more specific indexed search")
+		log.WithFields("glob", request.glob).Trace("glob provided is an expensive search, consider using a more specific indexed search")
 
 		options = append(options, FollowBasenameLinks)
-		return sc.tree.FilesByGlob(request.value, options...)
+		return sc.tree.FilesByGlob(request.glob, options...)
 	}
 
 	return nil, fmt.Errorf("invalid search request: %+v", request.searchBasis)
 }
 
 func (sc searchContext) searchByParentBasename(request searchRequest) ([]file.Resolution, error) {
-	indexes, err := sc.index.GetByBasename(request.value)
+	indexes, err := sc.index.GetByBasename(request.indexLookup)
 	if err != nil {
-		return nil, fmt.Errorf("unable to search by extension=%q: %w", request.value, err)
-	}
-	refs, err := sc.referencesWithRequirement(request.requirement, indexes)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to search by extension=%q: %w", request.indexLookup, err)
 	}
 
 	var results []file.Resolution
-	for _, ref := range refs {
-		paths, err := sc.tree.ListPaths(ref.RequestPath)
+	for _, i := range indexes {
+		paths, err := sc.tree.ListPaths(i.RealPath)
 		if err != nil {
 			// this may not be a directory, that's alright, just continue...
 			continue
 		}
 		for _, p := range paths {
-			_, nestedRef, err := sc.tree.File(p, FollowBasenameLinks)
+			nestedRef, err := sc.firstMatchingReference(request.glob, string(p))
 			if err != nil {
-				return nil, fmt.Errorf("unable to fetch file reference from parent path %q for path=%q: %w", ref.RequestPath, p, err)
+				return nil, fmt.Errorf("unable to fetch file reference from parent path %q for path=%q: %w", i.RealPath, p, err)
 			}
 			if !nestedRef.HasReference() {
 				continue
 			}
-			// note: the requirement was written for the parent, so we need to consider the new
-			// child path by adding /* to match all children
-			matches, err := matchesRequirement(*nestedRef, request.requirement+"/*")
-			if err != nil {
-				return nil, err
-			}
-			if matches {
-				results = append(results, *nestedRef)
-			}
+			results = append(results, *nestedRef)
 		}
 	}
 
 	return results, nil
 }
 
-func (sc searchContext) referencesWithRequirement(requirement string, entries []IndexEntry) ([]file.Resolution, error) {
-	refs, err := sc.referencesInTree(entries)
-	if err != nil {
-		return nil, err
-	}
-
-	if requirement == "" {
-		return refs, nil
-	}
-
-	var results []file.Resolution
-	for _, ref := range refs {
-		matches, err := matchesRequirement(ref, requirement)
+func (sc searchContext) firstMatchingReferences(glob string, entries []IndexEntry) ([]file.Resolution, error) {
+	var references []file.Resolution
+	for _, entry := range entries {
+		ref, err := sc.firstMatchingReference(glob, string(entry.Reference.RealPath))
 		if err != nil {
 			return nil, err
 		}
-		if matches {
-			results = append(results, ref)
+		if ref != nil {
+			references = append(references, *ref)
 		}
 	}
-
-	return results, nil
+	return references, nil
 }
 
-func matchesRequirement(ref file.Resolution, requirement string) (bool, error) {
+func matchesGlob(ref file.Resolution, glob string) (bool, error) {
 	allRefPaths := ref.AllRequestPaths()
 	for _, p := range allRefPaths {
-		matched, err := doublestar.Match(requirement, string(p))
+		matched, err := doublestar.Match(glob, string(p))
 		if err != nil {
-			return false, fmt.Errorf("unable to match glob pattern=%q to path=%q: %w", requirement, p, err)
+			return false, fmt.Errorf("unable to match glob pattern=%q to path=%q: %w", glob, p, err)
 		}
 		if matched {
 			return true, nil
@@ -268,135 +251,79 @@ func matchesRequirement(ref file.Resolution, requirement string) (bool, error) {
 	return false, nil
 }
 
-type cacheRequest struct {
-	RealPath file.Path
-}
+// firstPathToNode returns the first path matching the given glob, this is done by:
+// * testing the provided path, returning the path if matching
+// * expanding parent paths, replacing paths that are symlinks
+func (sc searchContext) firstPathToNode(observedPaths file.PathSet, glob string, pathSegments ...string) (*file.Resolution, error) {
+	fullPath := file.Path(path.Join(pathSegments...))
 
-type cacheResult struct {
-	Paths file.PathSet
-	Error error
-}
-
-func (sc searchContext) allPathsToNode(fn *filenode.FileNode) ([]file.Path, error) {
-	if fn == nil {
+	if observedPaths.Contains(fullPath) {
+		// we've already observed this path, so we can stop here
 		return nil, nil
 	}
+	observedPaths.Add(fullPath)
 
-	observedPaths := file.NewPathSet()
-
-	cache := map[cacheRequest]cacheResult{}
-
-	paths, err := sc.pathsToNode(fn, observedPaths, cache)
+	// first, test the path against the glob and return it if matches
+	// _, ref, err := sc.tree.File(fullPath, FollowBasenameLinks, followAncestorLinks)
+	_, ref, err := sc.tree.File(fullPath, FollowBasenameLinks)
 	if err != nil {
 		return nil, err
 	}
-
-	pathsList := paths.List()
-	sort.Sort(file.Paths(pathsList))
-
-	// TODO: filter to only paths that exist in the tree
-
-	return pathsList, nil
-}
-
-func (sc searchContext) pathsToNode(fn *filenode.FileNode, observedPaths file.PathSet, cache map[cacheRequest]cacheResult) (file.PathSet, error) {
-	req := cacheRequest{
-		RealPath: fn.RealPath,
-	}
-
-	if result, ok := cache[req]; ok {
-		return result.Paths, result.Error
-	}
-
-	paths, err := sc._pathsToNode(fn, observedPaths, cache)
-
-	cache[req] = cacheResult{
-		Paths: paths,
-		Error: err,
-	}
-
-	return paths, err
-}
-
-// nolint: funlen
-func (sc searchContext) _pathsToNode(fn *filenode.FileNode, observedPaths file.PathSet, cache map[cacheRequest]cacheResult) (file.PathSet, error) {
-	if fn == nil {
-		return nil, nil
-	}
-
-	paths := file.NewPathSet()
-	paths.Add(fn.RealPath)
-
-	if observedPaths != nil {
-		if observedPaths.Contains(fn.RealPath) {
-			// we've already observed this path, so we can stop here
-			return nil, nil
-		}
-		observedPaths.Add(fn.RealPath)
-	}
-
-	nodeID := fn.ID()
-
-	addPath := func(suffix string, ps ...file.Path) {
-		for _, p := range ps {
-			if suffix != "" {
-				p = file.Path(path.Join(string(p), suffix))
-			}
-			paths.Add(p)
-		}
-	}
-
-	// add all paths to the node that are linked to it
-	for _, linkSrcID := range sc.linkBackwardRefs[nodeID].List() {
-		pfn := sc.tree.tree.Node(linkSrcID)
-		if pfn == nil {
-			log.WithFields("id", nodeID, "parent", linkSrcID).Warn("found non-existent parent link")
-			continue
-		}
-		linkSrcPaths, err := sc.pathsToNode(pfn.(*filenode.FileNode), observedPaths, cache)
+	if ref != nil {
+		matches, err := matchesGlob(*ref, glob)
 		if err != nil {
 			return nil, err
 		}
-
-		addPath("", linkSrcPaths.List()...)
+		// path matches, don't need to check for more symlink path references
+		if matches {
+			return ref, nil
+		}
 	}
 
-	// crawl up the tree to find all paths to our parent and repeat
-	for _, p := range paths.List() {
-		nextNestedSuffix := p.Basename()
-		allParentPaths := p.ConstituentPaths()
-		sort.Sort(sort.Reverse(file.Paths(allParentPaths)))
+	parts := strings.Split(strings.TrimLeft(pathSegments[0], "/"), "/")
+	for i := 0; i <= len(parts); i++ {
+		joinedPath := path.Join(parts[0:i]...)
+		if !strings.HasPrefix(joinedPath, "/") {
+			joinedPath = "/" + joinedPath
+		}
+		dir := file.Path(joinedPath)
 
-		for _, pp := range allParentPaths {
-			if pp == "/" {
-				break
-			}
+		if observedPaths.Contains(dir) {
+			// we've already observed this path, don't get in a loop, e.g. /usr/bin/X11 -> /usr/bin
+			continue
+		}
+		observedPaths.Add(dir)
 
-			nestedSuffix := nextNestedSuffix
-			nextNestedSuffix = path.Join(pp.Basename(), nestedSuffix)
+		na, err := sc.tree.file(dir) // do not follow symlinks here; this call is effectively following symlinks manually
+		if err != nil {
+			return nil, fmt.Errorf("unable to get ref for path=%q: %w", fullPath, err)
+		}
 
-			pna, err := sc.tree.node(pp, linkResolutionStrategy{
-				FollowAncestorLinks: true,
-				FollowBasenameLinks: false,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("unable to get parent node for path=%q: %w", pp, err)
-			}
+		// this filters out any index entries that do not exist in the tree
+		// if !na.HasFileNode() {
+		//	return nil, nil
+		//}
 
-			if !pna.HasFileNode() {
+		nodeID := na.FileNode.ID()
+
+		// check all paths to the node that are linked to any parent dir
+		for _, linkSrcID := range sc.linkBackwardRefs[nodeID].List() {
+			pfn := sc.tree.tree.Node(linkSrcID)
+			if pfn == nil {
+				log.WithFields("id", nodeID, "parent", linkSrcID).Trace("found non-existent parent link")
 				continue
 			}
 
-			parentLinkPaths, err := sc.pathsToNode(pna.FileNode, observedPaths, cache)
-			if err != nil {
-				return nil, err
+			linkPath := string(pfn.(*filenode.FileNode).RealPath)
+			linkReplacedPath := append(append([]string{linkPath}, parts[i:]...), pathSegments[1:]...)
+			ref, err = sc.firstPathToNode(observedPaths, glob, linkReplacedPath...)
+			if ref != nil || err != nil {
+				return ref, err
 			}
-			addPath(nestedSuffix, parentLinkPaths.List()...)
 		}
 	}
-	observedPaths.Remove(fn.RealPath)
 
-	return paths, nil
+	return nil, nil
 }
 
 func (sc searchContext) fileNodesInTree(fileEntries []IndexEntry) ([]*filenode.FileNode, error) {
@@ -424,48 +351,7 @@ allFileEntries:
 	return nodes, nil
 }
 
-// referencesInTree does two things relative to the index entries given:
-// 1) it expands the index entries to include all possible access paths to the file node (by considering all possible link resolutions)
-// 2) it filters the index entries to only include those that exist in the tree
-func (sc searchContext) referencesInTree(fileEntries []IndexEntry) ([]file.Resolution, error) {
-	var refs []file.Resolution
-
-	for _, entry := range fileEntries {
-		na, err := sc.tree.file(entry.Reference.RealPath, FollowBasenameLinks)
-		if err != nil {
-			return nil, fmt.Errorf("unable to get ref for path=%q: %w", entry.Reference.RealPath, err)
-		}
-
-		// this filters out any index entries that do not exist in the tree
-		if !na.HasFileNode() {
-			continue
-		}
-
-		// expand the index results with more possible access paths from the link resolution cache
-		var expandedRefs []file.Resolution
-		allPathsToNode, err := sc.allPathsToNode(na.FileNode)
-		if err != nil {
-			return nil, fmt.Errorf("unable to get all paths to node for path=%q: %w", entry.Reference.RealPath, err)
-		}
-		for _, p := range allPathsToNode {
-			_, ref, err := sc.tree.File(p, FollowBasenameLinks)
-			if err != nil {
-				return nil, fmt.Errorf("unable to get ref for path=%q: %w", p, err)
-			}
-			if !ref.HasReference() {
-				continue
-			}
-			expandedRefs = append(expandedRefs, *ref)
-		}
-
-		for _, ref := range expandedRefs {
-			for _, accessRef := range ref.References() {
-				if accessRef.ID() == entry.Reference.ID() {
-					// we know this entry exists in the tree, keep track of the reference for this file
-					refs = append(refs, ref)
-				}
-			}
-		}
-	}
-	return refs, nil
+// firstMatchingReference returns the first file reference matching the glob
+func (sc searchContext) firstMatchingReference(glob string, pathSegments ...string) (*file.Resolution, error) {
+	return sc.firstPathToNode(file.PathSet{}, glob, pathSegments...)
 }

--- a/pkg/filetree/search_test.go
+++ b/pkg/filetree/search_test.go
@@ -6,11 +6,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/stereoscope/pkg/file"
-	"github.com/anchore/stereoscope/pkg/filetree/filenode"
 )
 
 func Test_searchContext_SearchByPath(t *testing.T) {
@@ -157,20 +155,6 @@ func Test_searchContext_SearchByGlob(t *testing.T) {
 						RealPath: "/path/to/file.txt",
 					},
 				},
-				{
-
-					RequestPath: "/double-link-to-path/to/file.txt",
-					Reference: &file.Reference{
-						RealPath: "/path/to/file.txt",
-					},
-				},
-				{
-
-					RequestPath: "/link-to-path/to/file.txt",
-					Reference: &file.Reference{
-						RealPath: "/path/to/file.txt",
-					},
-				},
 			},
 		},
 		{
@@ -309,33 +293,6 @@ func Test_searchContext_SearchByGlob(t *testing.T) {
 					RequestPath: "/path/to/file.txt",
 					Reference:   &file.Reference{RealPath: "/path/to/file.txt"},
 				},
-				{
-					RequestPath: "/double-link-to-path/to/file.txt",
-					Reference: &file.Reference{
-						RealPath: "/path/to/file.txt",
-					},
-				},
-				// note: this is NOT expected since the input glob does not match against the request path
-				//{
-				//	Resolution: file.Resolution{
-				//		RequestPath: "/link-to-file",
-				//		Reference: &file.Reference{
-				//			RealPath: "/path/to/file.txt",
-				//		},
-				//	},
-				//	LinkResolutions: []file.Resolution{
-				//		{
-				//			RequestPath: "/link-to-file",
-				//			Reference:   &file.Reference{RealPath: "/link-to-file"},
-				//		},
-				//	},
-				//},
-				{
-					RequestPath: "/link-to-path/to/file.txt",
-					Reference: &file.Reference{
-						RealPath: "/path/to/file.txt",
-					},
-				},
 			},
 		},
 		{
@@ -365,13 +322,6 @@ func Test_searchContext_SearchByGlob(t *testing.T) {
 
 			if d := cmp.Diff(tt.want, got, opts...); d != "" {
 				t.Errorf("SearchByGlob() mismatch (-want +got):\n%s", d)
-			}
-
-			expected, err := tt.fields.tree.FilesByGlob(tt.args.glob, tt.args.options...)
-			require.NoError(t, err)
-
-			if d := cmp.Diff(expected, got, opts...); d != "" {
-				t.Errorf("Difference relative to tree results mismatch (-want +got):\n%s", d)
 			}
 		})
 	}
@@ -456,562 +406,53 @@ func Test_searchContext_SearchByMIMEType(t *testing.T) {
 	}
 }
 
-func Test_searchContext_allPathsToNode(t *testing.T) {
-	type input struct {
-		query *filenode.FileNode
-		sc    *searchContext
+func Test_complexSymlinkPerformance(t *testing.T) {
+	tr := New()
+	idx := NewIndex()
+
+	var realPaths []string
+
+	numPkgs := 30
+
+	for num := 0; num < numPkgs; num++ {
+		// add a concrete path
+		realPath := fmt.Sprintf("/pkgs/lib-%d/package.json", num)
+		realPaths = append(realPaths, realPath)
+		r, err := tr.AddFile(file.Path(realPath))
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		idx.Add(*r, file.Metadata{Type: file.TypeRegular})
+
+		// add dependencies on all previous packages
+		for dep := num + 1; dep < numPkgs-1; dep++ {
+			r, err = tr.AddSymLink(file.Path(fmt.Sprintf("/pkgs/lib-%d/libs/lib-%d", num, dep)), file.Path(fmt.Sprintf("/pkgs/lib-%d", dep)))
+			require.NoError(t, err)
+			require.NotNil(t, r)
+			idx.Add(*r, file.Metadata{Type: file.TypeSymLink})
+		}
 	}
 
 	tests := []struct {
-		name    string
-		input   input
-		want    []file.Path
-		wantErr require.ErrorAssertionFunc
+		glob     string
+		expected []string
 	}{
 		{
-			name: "simple dir",
-			want: []file.Path{
-				"/path/to",
-			},
-			input: func() input {
-				tree := New()
-
-				fileRef, err := tree.AddFile("/path/to/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, fileRef)
-
-				idx := NewIndex()
-				idx.Add(*fileRef, file.Metadata{MIMEType: "plain/text", Type: file.TypeRegular})
-
-				na, err := tree.node("/path/to", linkResolutionStrategy{
-					FollowAncestorLinks:          false,
-					FollowBasenameLinks:          false,
-					DoNotFollowDeadBasenameLinks: false,
-				})
-				require.NoError(t, err)
-				require.NotNil(t, na)
-				require.NotNil(t, na.FileNode)
-				require.Equal(t, file.Path("/path/to"), na.FileNode.RealPath)
-
-				return input{
-					query: na.FileNode,
-					sc:    NewSearchContext(tree, idx).(*searchContext),
-				}
-			}(),
-		},
-		{
-			name: "dead symlink",
-			want: []file.Path{
-				"/path/to/file.txt",
-			},
-			input: func() input {
-				tree := New()
-
-				deafLinkRef, err := tree.AddSymLink("/link-to-file", "/path/to/dead/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, deafLinkRef)
-
-				fileRef, err := tree.AddFile("/path/to/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, fileRef)
-
-				idx := NewIndex()
-				idx.Add(*fileRef, file.Metadata{MIMEType: "plain/text", Type: file.TypeRegular})
-				idx.Add(*deafLinkRef, file.Metadata{Type: file.TypeSymLink})
-
-				na, err := tree.node(fileRef.RealPath, linkResolutionStrategy{
-					FollowAncestorLinks:          false,
-					FollowBasenameLinks:          false,
-					DoNotFollowDeadBasenameLinks: false,
-				})
-				require.NoError(t, err)
-				require.NotNil(t, na)
-				require.NotNil(t, na.FileNode)
-				require.Equalf(t, fileRef.ID(), na.FileNode.Reference.ID(), "query node should be the same as the file node")
-
-				return input{
-					query: na.FileNode,
-					sc:    NewSearchContext(tree, idx).(*searchContext),
-				}
-			}(),
-		},
-		{
-			name: "symlink triangle cycle",
-			want: []file.Path{
-				"/1",
-				"/2",
-				"/3",
-			},
-			input: func() input {
-				tree := New()
-
-				link1, err := tree.AddSymLink("/1", "/2")
-				require.NoError(t, err)
-				require.NotNil(t, link1)
-
-				link2, err := tree.AddSymLink("/2", "/3")
-				require.NoError(t, err)
-				require.NotNil(t, link2)
-
-				link3, err := tree.AddSymLink("/3", "/1")
-				require.NoError(t, err)
-				require.NotNil(t, link3)
-
-				idx := NewIndex()
-				idx.Add(*link1, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*link2, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*link3, file.Metadata{Type: file.TypeSymLink})
-
-				na, err := tree.node(link1.RealPath, linkResolutionStrategy{
-					FollowAncestorLinks:          false,
-					FollowBasenameLinks:          false,
-					DoNotFollowDeadBasenameLinks: false,
-				})
-				require.NoError(t, err)
-				require.NotNil(t, na)
-				require.NotNil(t, na.FileNode)
-				require.Equalf(t, link1.ID(), na.FileNode.Reference.ID(), "query node should be the same as the first link")
-
-				return input{
-					query: na.FileNode,
-					sc:    NewSearchContext(tree, idx).(*searchContext),
-				}
-			}(),
-		},
-		{
-			// note: this isn't a real link cycle, but it does look like one while resolving from a leaf to the root
-			name: "reverse symlink cycle",
-			want: []file.Path{
-				"/bin/ttyd",
-				"/usr/bin/X11/ttyd",
-				"/usr/bin/ttyd",
-			},
-			input: func() input {
-				tree := New()
-
-				usrRef, err := tree.AddDir("/usr")
-				require.NoError(t, err)
-				require.NotNil(t, usrRef)
-
-				usrBinRef, err := tree.AddDir("/usr/bin")
-				require.NoError(t, err)
-				require.NotNil(t, usrBinRef)
-
-				ttydRef, err := tree.AddFile("/usr/bin/ttyd")
-				require.NoError(t, err)
-				require.NotNil(t, ttydRef)
-
-				binLinkRef, err := tree.AddSymLink("/bin", "usr/bin")
-				require.NoError(t, err)
-				require.NotNil(t, binLinkRef)
-
-				x11LinkRef, err := tree.AddSymLink("/usr/bin/X11", ".")
-				require.NoError(t, err)
-				require.NotNil(t, x11LinkRef)
-
-				idx := NewIndex()
-				idx.Add(*usrRef, file.Metadata{Type: file.TypeDirectory})
-				idx.Add(*usrBinRef, file.Metadata{Type: file.TypeDirectory})
-				idx.Add(*binLinkRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*x11LinkRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*ttydRef, file.Metadata{Type: file.TypeRegular})
-
-				na, err := tree.node(ttydRef.RealPath, linkResolutionStrategy{
-					FollowAncestorLinks:          false,
-					FollowBasenameLinks:          false,
-					DoNotFollowDeadBasenameLinks: false,
-				})
-				require.NoError(t, err)
-				require.NotNil(t, na)
-				require.NotNil(t, na.FileNode)
-				require.Equalf(t, ttydRef.ID(), na.FileNode.Reference.ID(), "query node should be the same as usr/bin/ttyd binary")
-
-				return input{
-					query: na.FileNode,
-					sc:    NewSearchContext(tree, idx).(*searchContext),
-				}
-			}(),
-		},
-		{
-			name: "single leaf symlink",
-			want: []file.Path{
-				"/link-to-file",
-				"/path/to/file.txt",
-			},
-			input: func() input {
-				tree := New()
-
-				linkToFileRef, err := tree.AddSymLink("/link-to-file", "/path/to/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, linkToFileRef)
-
-				fileRef, err := tree.AddFile("/path/to/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, fileRef)
-
-				idx := NewIndex()
-				idx.Add(*fileRef, file.Metadata{MIMEType: "plain/text", Type: file.TypeRegular})
-				idx.Add(*linkToFileRef, file.Metadata{Type: file.TypeSymLink})
-
-				na, err := tree.node(fileRef.RealPath, linkResolutionStrategy{
-					FollowAncestorLinks:          false,
-					FollowBasenameLinks:          false,
-					DoNotFollowDeadBasenameLinks: false,
-				})
-				require.NoError(t, err)
-				require.NotNil(t, na)
-				require.NotNil(t, na.FileNode)
-				require.Equalf(t, fileRef.ID(), na.FileNode.Reference.ID(), "query node should be the same as the file node")
-
-				return input{
-					query: na.FileNode,
-					sc:    NewSearchContext(tree, idx).(*searchContext),
-				}
-			}(),
-		},
-		{
-			name: "2 deep leaf symlink",
-			want: []file.Path{
-				"/double-link-to-file",
-				"/link-to-file",
-				"/path/to/file.txt",
-			},
-			input: func() input {
-				tree := New()
-
-				doubleLinkToFileRef, err := tree.AddSymLink("/double-link-to-file", "/link-to-file")
-				require.NoError(t, err)
-				require.NotNil(t, doubleLinkToFileRef)
-
-				linkToFileRef, err := tree.AddSymLink("/link-to-file", "/path/to/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, linkToFileRef)
-
-				fileRef, err := tree.AddFile("/path/to/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, fileRef)
-
-				idx := NewIndex()
-				idx.Add(*fileRef, file.Metadata{MIMEType: "plain/text", Type: file.TypeRegular})
-				idx.Add(*linkToFileRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*doubleLinkToFileRef, file.Metadata{Type: file.TypeSymLink})
-
-				na, err := tree.node(fileRef.RealPath, linkResolutionStrategy{
-					FollowAncestorLinks:          false,
-					FollowBasenameLinks:          false,
-					DoNotFollowDeadBasenameLinks: false,
-				})
-				require.NoError(t, err)
-				require.NotNil(t, na)
-				require.NotNil(t, na.FileNode)
-				require.Equalf(t, fileRef.ID(), na.FileNode.Reference.ID(), "query node should be the same as the file node")
-
-				return input{
-					query: na.FileNode,
-					sc:    NewSearchContext(tree, idx).(*searchContext),
-				}
-			}(),
-		},
-		{
-			name: "single ancestor symlink",
-			want: []file.Path{
-				"/link-to-to/file.txt",
-				"/path/to/file.txt",
-			},
-			input: func() input {
-				tree := New()
-
-				dirTo, err := tree.AddDir("/path/to")
-				require.NoError(t, err)
-				require.NotNil(t, dirTo)
-
-				linkToToRef, err := tree.AddSymLink("/link-to-to", "/path/to")
-				require.NoError(t, err)
-				require.NotNil(t, linkToToRef)
-
-				fileRef, err := tree.AddFile("/path/to/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, fileRef)
-
-				idx := NewIndex()
-				idx.Add(*fileRef, file.Metadata{MIMEType: "plain/text", Type: file.TypeRegular})
-				idx.Add(*linkToToRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*dirTo, file.Metadata{Type: file.TypeDirectory})
-
-				na, err := tree.node(fileRef.RealPath, linkResolutionStrategy{
-					FollowAncestorLinks:          false,
-					FollowBasenameLinks:          false,
-					DoNotFollowDeadBasenameLinks: false,
-				})
-				require.NoError(t, err)
-				require.NotNil(t, na)
-				require.NotNil(t, na.FileNode)
-				require.Equalf(t, fileRef.ID(), na.FileNode.Reference.ID(), "query node should be the same as the file node")
-
-				return input{
-					query: na.FileNode,
-					sc:    NewSearchContext(tree, idx).(*searchContext),
-				}
-			}(),
-		},
-		{
-			name: "2 deep, single sibling ancestor symlink",
-			want: []file.Path{
-				"/link-to-path/to/file.txt",
-				"/link-to-to/file.txt",
-				"/path/to/file.txt",
-			},
-			input: func() input {
-				tree := New()
-
-				dirTo, err := tree.AddDir("/path/to")
-				require.NoError(t, err)
-				require.NotNil(t, dirTo)
-
-				linkToPathRef, err := tree.AddSymLink("/link-to-path", "/path")
-				require.NoError(t, err)
-				require.NotNil(t, linkToPathRef)
-
-				linkToToRef, err := tree.AddSymLink("/link-to-to", "/path/to")
-				require.NoError(t, err)
-				require.NotNil(t, linkToToRef)
-
-				fileRef, err := tree.AddFile("/path/to/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, fileRef)
-
-				idx := NewIndex()
-				idx.Add(*fileRef, file.Metadata{MIMEType: "plain/text", Type: file.TypeRegular})
-				idx.Add(*linkToToRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*linkToPathRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*dirTo, file.Metadata{Type: file.TypeDirectory})
-
-				na, err := tree.node(fileRef.RealPath, linkResolutionStrategy{
-					FollowAncestorLinks:          false,
-					FollowBasenameLinks:          false,
-					DoNotFollowDeadBasenameLinks: false,
-				})
-				require.NoError(t, err)
-				require.NotNil(t, na)
-				require.NotNil(t, na.FileNode)
-				require.Equalf(t, fileRef.ID(), na.FileNode.Reference.ID(), "query node should be the same as the file node")
-
-				return input{
-					query: na.FileNode,
-					sc:    NewSearchContext(tree, idx).(*searchContext),
-				}
-			}(),
-		},
-		{
-			name: "2 deep, multiple sibling ancestor symlink",
-			want: []file.Path{
-				"/another-link-to-path/to/file.txt",
-				"/another-link-to-to/file.txt",
-				"/link-to-path/to/file.txt",
-				"/link-to-to/file.txt",
-				"/path/to/file.txt",
-			},
-			input: func() input {
-				tree := New()
-
-				dirTo, err := tree.AddDir("/path/to")
-				require.NoError(t, err)
-				require.NotNil(t, dirTo)
-
-				linkToPathRef, err := tree.AddSymLink("/link-to-path", "/path")
-				require.NoError(t, err)
-				require.NotNil(t, linkToPathRef)
-
-				anotherLinkToPathRef, err := tree.AddSymLink("/another-link-to-path", "/path")
-				require.NoError(t, err)
-				require.NotNil(t, anotherLinkToPathRef)
-
-				linkToToRef, err := tree.AddSymLink("/link-to-to", "/path/to")
-				require.NoError(t, err)
-				require.NotNil(t, linkToToRef)
-
-				anotherLinkToToRef, err := tree.AddSymLink("/another-link-to-to", "/path/to")
-				require.NoError(t, err)
-				require.NotNil(t, anotherLinkToToRef)
-
-				fileRef, err := tree.AddFile("/path/to/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, fileRef)
-
-				idx := NewIndex()
-				idx.Add(*fileRef, file.Metadata{MIMEType: "plain/text", Type: file.TypeRegular})
-				idx.Add(*linkToToRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*linkToPathRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*anotherLinkToPathRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*anotherLinkToToRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*dirTo, file.Metadata{Type: file.TypeDirectory})
-
-				na, err := tree.node(fileRef.RealPath, linkResolutionStrategy{
-					FollowAncestorLinks:          false,
-					FollowBasenameLinks:          false,
-					DoNotFollowDeadBasenameLinks: false,
-				})
-				require.NoError(t, err)
-				require.NotNil(t, na)
-				require.NotNil(t, na.FileNode)
-				require.Equalf(t, fileRef.ID(), na.FileNode.Reference.ID(), "query node should be the same as the file node")
-
-				return input{
-					query: na.FileNode,
-					sc:    NewSearchContext(tree, idx).(*searchContext),
-				}
-			}(),
-		},
-		{
-			name: "2 deep, multiple nested ancestor symlink",
-			want: []file.Path{
-				"/link-to-path/link-to-another/file.txt",
-				"/link-to-path/to/another/file.txt",
-				"/link-to-path/to/link-to-file",
-				"/link-to-to/another/file.txt",
-				"/link-to-to/link-to-file",
-				"/path/link-to-another/file.txt",
-				"/path/to/another/file.txt",
-				"/path/to/link-to-file",
-			},
-			input: func() input {
-				tree := New()
-
-				linkToAnotherViaLinkRef, err := tree.AddSymLink("/path/link-to-another", "/link-to-to/another")
-				require.NoError(t, err)
-				require.NotNil(t, linkToAnotherViaLinkRef)
-
-				linkToPathRef, err := tree.AddSymLink("/link-to-path", "/path")
-				require.NoError(t, err)
-				require.NotNil(t, linkToPathRef)
-
-				linkToToRef, err := tree.AddSymLink("/link-to-to", "/path/to")
-				require.NoError(t, err)
-				require.NotNil(t, linkToToRef)
-
-				pathToLinkToFileRef, err := tree.AddSymLink("/path/to/link-to-file", "/path/to/another/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, pathToLinkToFileRef)
-
-				dirTo, err := tree.AddDir("/path/to")
-				require.NoError(t, err)
-				require.NotNil(t, dirTo)
-
-				dirAnother, err := tree.AddDir("/path/to/another")
-				require.NoError(t, err)
-				require.NotNil(t, dirAnother)
-
-				fileRef, err := tree.AddFile("/path/to/another/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, fileRef)
-
-				idx := NewIndex()
-				idx.Add(*fileRef, file.Metadata{MIMEType: "plain/text", Type: file.TypeRegular})
-				idx.Add(*linkToAnotherViaLinkRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*linkToPathRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*linkToToRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*pathToLinkToFileRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*dirTo, file.Metadata{Type: file.TypeDirectory})
-				idx.Add(*dirAnother, file.Metadata{Type: file.TypeDirectory})
-
-				na, err := tree.node(fileRef.RealPath, linkResolutionStrategy{
-					FollowAncestorLinks:          false,
-					FollowBasenameLinks:          false,
-					DoNotFollowDeadBasenameLinks: false,
-				})
-				require.NoError(t, err)
-				require.NotNil(t, na)
-				require.NotNil(t, na.FileNode)
-				require.Equalf(t, fileRef.ID(), na.FileNode.Reference.ID(), "query node should be the same as the file node")
-
-				return input{
-					query: na.FileNode,
-					sc:    NewSearchContext(tree, idx).(*searchContext),
-				}
-			}(),
-		},
-		{
-			name: "relative, 2 deep, multiple nested ancestor symlink",
-			want: []file.Path{
-				"/link-to-path/link-to-another/file.txt",
-				"/link-to-path/to/another/file.txt",
-				"/link-to-path/to/link-to-file",
-				"/link-to-to/another/file.txt",
-				"/link-to-to/link-to-file",
-				"/path/link-to-another/file.txt",
-				"/path/to/another/file.txt",
-				"/path/to/link-to-file",
-			},
-			input: func() input {
-				tree := New()
-
-				linkToAnotherViaLinkRef, err := tree.AddSymLink("/path/link-to-another", "../link-to-to/another")
-				require.NoError(t, err)
-				require.NotNil(t, linkToAnotherViaLinkRef)
-
-				linkToPathRef, err := tree.AddSymLink("/link-to-path", "./path")
-				require.NoError(t, err)
-				require.NotNil(t, linkToPathRef)
-
-				linkToToRef, err := tree.AddSymLink("/link-to-to", "./path/to")
-				require.NoError(t, err)
-				require.NotNil(t, linkToToRef)
-
-				pathToLinkToFileRef, err := tree.AddSymLink("/path/to/link-to-file", "../to/another/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, pathToLinkToFileRef)
-
-				dirTo, err := tree.AddDir("/path/to")
-				require.NoError(t, err)
-				require.NotNil(t, dirTo)
-
-				dirAnother, err := tree.AddDir("/path/to/another")
-				require.NoError(t, err)
-				require.NotNil(t, dirAnother)
-
-				fileRef, err := tree.AddFile("/path/to/another/file.txt")
-				require.NoError(t, err)
-				require.NotNil(t, fileRef)
-
-				idx := NewIndex()
-				idx.Add(*fileRef, file.Metadata{MIMEType: "plain/text", Type: file.TypeRegular})
-				idx.Add(*linkToAnotherViaLinkRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*linkToPathRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*linkToToRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*pathToLinkToFileRef, file.Metadata{Type: file.TypeSymLink})
-				idx.Add(*dirTo, file.Metadata{Type: file.TypeDirectory})
-				idx.Add(*dirAnother, file.Metadata{Type: file.TypeDirectory})
-
-				na, err := tree.node(fileRef.RealPath, linkResolutionStrategy{
-					FollowAncestorLinks:          false,
-					FollowBasenameLinks:          false,
-					DoNotFollowDeadBasenameLinks: false,
-				})
-				require.NoError(t, err)
-				require.NotNil(t, na)
-				require.NotNil(t, na.FileNode)
-				require.Equalf(t, fileRef.ID(), na.FileNode.Reference.ID(), "query node should be the same as the file node")
-
-				return input{
-					query: na.FileNode,
-					sc:    NewSearchContext(tree, idx).(*searchContext),
-				}
-			}(),
+			glob:     "**/package.json",
+			expected: realPaths,
 		},
 	}
+
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.wantErr == nil {
-				tt.wantErr = require.NoError
+		t.Run(tt.glob, func(t *testing.T) {
+			sc := NewSearchContext(tr, idx)
+			gotResolutions, err := sc.SearchByGlob(tt.glob, FollowBasenameLinks)
+			require.NoError(t, err)
+			require.NotNil(t, gotResolutions)
+			var got []string
+			for _, gotResolution := range gotResolutions {
+				got = append(got, string(gotResolution.RealPath))
 			}
-
-			got, err := tt.input.sc.allPathsToNode(tt.input.query)
-			tt.wantErr(t, err, fmt.Sprintf("allPathsToNode(%v)", tt.input.query))
-			if err != nil {
-				return
-			}
-
-			assert.ElementsMatchf(t, tt.want, got, cmp.Diff(tt.want, got), "expected and actual paths should match")
+			require.ElementsMatch(t, tt.expected, got)
 		})
 	}
 }


### PR DESCRIPTION
This PR adjust how symlinks are matched against glob patterns such that we will now only return the first matching path for an index entry. This often requires no symlink resolution at all, for example when glob patterns match the real path. This solves a problem that is beginning to be apparent with complex webs of symlinks such as large pnpm projects and snaps that would result in an explosion of paths returned to be tested against a glob pattern causing excessive memory usage and processing time, which effectively would cause syft to hang.