### PR TITLE
Remove DSA option from podman ssh options

### DIFF
--- a/internal/podman/ssh.go
+++ b/internal/podman/ssh.go
@@ -152,7 +152,6 @@ func httpClientOverSSH(params *sshClientConfig) (*http.Client, error) {
 			HostKeyCallback: getSSHCallback(params),
 			HostKeyAlgorithms: []string{
 				ssh.KeyAlgoRSA,
-				ssh.KeyAlgoDSA,
 				ssh.KeyAlgoECDSA256,
 				ssh.KeyAlgoSKECDSA256,
 				ssh.KeyAlgoECDSA384,


### PR DESCRIPTION
This is currently blocking PRs due to a static analysis failure