### PR TITLE
fix: lazyBoundedReadCloser correctly close/seek

### DIFF
--- a/pkg/file/lazy_bounded_read_closer_test.go
+++ b/pkg/file/lazy_bounded_read_closer_test.go
@@ -28,7 +28,16 @@ func TestDeferredPartialReadCloser(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, contents, actualContents)
-	require.NotNil(t, dReader.file)
+	require.Nil(t, dReader.file) // file is closed at EOF
+
+	_, err = dReader.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	require.NotNil(t, dReader.file) // file is reopened
+
+	secondReadContents, err := io.ReadAll(dReader)
+	require.NoError(t, err)
+	require.Equal(t, contents, secondReadContents)
+	require.Nil(t, dReader.file) // file is closed again at EOF
 
 	require.NoError(t, dReader.Close())
 	require.Nil(t, dReader.file, "should not have a file, but we do somehow")
@@ -49,7 +58,7 @@ func TestDeferredPartialReadCloser_Seek(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, content[int(off):], actualContent)
-	require.NotNil(t, dReader.file)
+	require.Nil(t, dReader.file) // file is closed at EOF
 
 	require.NoError(t, dReader.Close())
 	require.Nil(t, dReader.file, "should not have a file, but we do somehow")


### PR DESCRIPTION
This PR fixes an issue where reading a lazyBoundedReadCloser is unable to seek due to being closed but not reset properly. In other words: `.Seek(0, io.SeekStart)` attempts to call `d.openFile()`, but since there is a non-nil reference to a reader, it does not reopen the file but fails to seek and read from it afterwards instead of actually reopening it for reading.
