### PR TITLE
fix: handling of variant in platform string and image config

### DIFF
--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -80,7 +80,7 @@ func (p *registryImageProvider) Provide(ctx context.Context) (*image.Image, erro
 		return nil, fmt.Errorf("failed to get image config from registry: %+v", err)
 	}
 
-	if err := validatePlatform(platform, c.OS, c.Architecture); err != nil {
+	if err := validatePlatform(platform, c.OS, c.Architecture, c.Variant); err != nil {
 		return nil, err
 	}
 
@@ -130,7 +130,7 @@ func (p *registryImageProvider) finalizePlatform(descriptor *remote.Descriptor, 
 	}
 }
 
-func validatePlatform(platform *image.Platform, givenOs, givenArch string) error {
+func validatePlatform(platform *image.Platform, givenOs, givenArch, givenVariant string) error {
 	if platform == nil {
 		return nil
 	}
@@ -138,6 +138,9 @@ func validatePlatform(platform *image.Platform, givenOs, givenArch string) error
 		return newErrPlatformMismatch(platform, fmt.Errorf("missing architecture or OS from image config when user specified platform=%q", platform.String()))
 	}
 	platformStr := fmt.Sprintf("%s/%s", givenOs, givenArch)
+	if givenVariant != "" {
+		platformStr += "/" + givenVariant
+	}
 	actualPlatform, err := containerregistryV1.ParsePlatform(platformStr)
 	if err != nil {
 		return newErrPlatformMismatch(platform, fmt.Errorf("failed to parse platform from image config: %w", err))


### PR DESCRIPTION
Fix issue reported in #454 

Fails with latest syft v1.32.0:
```
% syft --from registry --platform linux/arm/v7  nginx@sha256:ed96b79909c5581d90b690b4cdcec049974c7abb11edaaee4f353c8465445d8a
[0001] ERROR could not determine source: an error occurred attempting to resolve 'nginx@sha256:ed96b79909c5581d90b690b4cdcec049974c7abb11edaaee4f353c8465445d8a': oci-registry: mismatched platform (expected linux/arm/v7): image platform="linux/arm" does not match user specified platform="linux/arm/v7"
```

Fixed with this PR:
```
% ./syft-fix-454 --from registry --platform linux/arm/v7  nginx@sha256:ed96b79909c5581d90b690b4cdcec049974c7abb11edaaee4f353c8465445d8a
 ✔ Parsed image                                                                                sha256:4d91c7f14eb7b81f5c8a008a3d4c8d697c71cf87f29591b1903e00b0e80af8a5
 ✔ Cataloged contents                                                                                 ed96b79909c5581d90b690b4cdcec049974c7abb11edaaee4f353c8465445d8a
   ├── ✔ Packages                        [151 packages]
   ├── ✔ Executables                     [848 executables]
   ├── ✔ File metadata                   [3,738 locations]
   └── ✔ File digests                    [3,738 files]
```

Including w/o variant:
```
% ./syft-fix-454 --from registry --platform linux/arm  nginx@sha256:ed96b79909c5581d90b690b4cdcec049974c7abb11edaaee4f353c8465445d8a
 ✔ Parsed image                                                                                sha256:4d91c7f14eb7b81f5c8a008a3d4c8d697c71cf87f29591b1903e00b0e80af8a5
 ✔ Cataloged contents                                                                                 ed96b79909c5581d90b690b4cdcec049974c7abb11edaaee4f353c8465445d8a
   ├── ✔ Packages                        [151 packages]
   ├── ✔ Executables                     [848 executables]
   ├── ✔ File metadata                   [3,738 locations]
   └── ✔ File digests                    [3,738 files]
```