### PR TITLE
Fix: adds support for slightly nonstandard mediaType string in docker image layers

### DIFF
--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -22,9 +22,10 @@ import (
 	"github.com/anchore/stereoscope/pkg/filetree"
 )
 
-const SingularitySquashFSLayer = "application/vnd.sylabs.sif.layer.v1.squashfs"
-
-const BuildKitZstdCompressedLayer = "application/vnd.docker.image.rootfs.diff.tar.zstd"
+const (
+	SingularitySquashFSLayer    = "application/vnd.sylabs.sif.layer.v1.squashfs"
+	BuildKitZstdCompressedLayer = "application/vnd.docker.image.rootfs.diff.tar.zstd"
+)
 
 // Layer represents a single layer within a container image.
 type Layer struct {

--- a/pkg/image/layer_test.go
+++ b/pkg/image/layer_test.go
@@ -79,8 +79,40 @@ func TestRead(t *testing.T) {
 			wantErrContents: "no media type for you",
 		},
 		{
-			name:      "no error",
+			name:      "support OCI layer",
+			mediaType: v1Types.OCILayer,
+		},
+		{
+			name:      "support OCI uncompressed layer",
+			mediaType: v1Types.OCIUncompressedLayer,
+		},
+		{
+			name:      "support OCI restricted layer",
+			mediaType: v1Types.OCIRestrictedLayer,
+		},
+		{
+			name:      "support OCI uncompressed restricted layer",
+			mediaType: v1Types.OCIUncompressedRestrictedLayer,
+		},
+		{
+			name:      "support OCI zstd layer",
+			mediaType: v1Types.OCILayerZStd,
+		},
+		{
+			name:      "support docker tar.gz layer",
 			mediaType: v1Types.DockerLayer,
+		},
+		{
+			name:      "support docker foreign layer",
+			mediaType: v1Types.DockerForeignLayer,
+		},
+		{
+			name:      "support docker uncompressed layer",
+			mediaType: v1Types.DockerUncompressedLayer,
+		},
+		{
+			name:      "support docker tar.zstd layer",
+			mediaType: BuildKitZstdCompressedLayer,
 		},
 	}
 


### PR DESCRIPTION
Adds support (allowlisting) for application/vnd.docker.image.rootfs.diff.tar.zstd layer mediaType.

Fixes #486