### PR TITLE
Future proof tar zstd variant mediatype

### DIFF
--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	SingularitySquashFSLayer    = "application/vnd.sylabs.sif.layer.v1.squashfs"
-	BuildKitZstdCompressedLayer = "application/vnd.docker.image.rootfs.diff.tar.zstd"
+	SingularitySquashFSLayer       = "application/vnd.sylabs.sif.layer.v1.squashfs"
+	BuildKitZstdCompressedLayer    = "application/vnd.docker.image.rootfs.diff.tar.zstd"
+	BuildKitZstdCompressedLayerAlt = "application/vnd.docker.image.rootfs.diff.tar+zstd" // we're future proofing against a possible media type variation
 )
 
 // Layer represents a single layer within a container image.
@@ -105,7 +106,8 @@ func (l *Layer) Read(catalog *FileCatalog, idx int, uncompressedLayersCacheDir s
 		types.DockerLayer,
 		types.DockerForeignLayer,
 		types.DockerUncompressedLayer,
-		BuildKitZstdCompressedLayer:
+		BuildKitZstdCompressedLayer,
+		BuildKitZstdCompressedLayerAlt:
 
 		err := l.readStandardImageLayer(idx, uncompressedLayersCacheDir, tree)
 		if err != nil {

--- a/pkg/image/layer_test.go
+++ b/pkg/image/layer_test.go
@@ -114,6 +114,10 @@ func TestRead(t *testing.T) {
 			name:      "support docker tar.zstd layer",
 			mediaType: BuildKitZstdCompressedLayer,
 		},
+		{
+			name:      "support docker tar+zstd layer",
+			mediaType: BuildKitZstdCompressedLayerAlt,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This is a follow up to #487 , adding a variant to what was added in case the media type changes in the future.