### PR TITLE
Do not process images with unprocessable layers

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -208,8 +208,6 @@ func (i *Image) Read() error {
 		return err
 	}
 
-	log.WithFields("digest", i.Metadata.ID, "mediaType", i.Metadata.MediaType, "tags", i.Metadata.Tags).Debug("reading image")
-
 	startTime := time.Now()
 	lapTime := startTime
 
@@ -217,6 +215,13 @@ func (i *Image) Read() error {
 	if err != nil {
 		return err
 	}
+
+	// validate all layer media types before processing
+	if err := validateLayerMediaTypes(v1Layers); err != nil {
+		return err
+	}
+
+	log.WithFields("digest", i.Metadata.ID, "mediaType", i.Metadata.MediaType, "tags", i.Metadata.Tags).Debug("reading image")
 
 	// let consumers know of a monitorable event (image save + copy stages)
 	readProg := i.trackReadProgress(i.Metadata)

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -84,7 +84,7 @@ func (p *registryImageProvider) Provide(ctx context.Context) (*image.Image, erro
 		return nil, err
 	}
 
-	log.WithFields("image", p.imageStr, "time", time.Since(startTime)).Info("completed downloading image")
+	log.WithFields("image", p.imageStr, "time", time.Since(startTime)).Info("completed downloading manifest")
 
 	// craft a repo digest from the registry reference and the known digest
 	// note: the descriptor is fetched from the registry, and the descriptor digest is the same as the repo digest


### PR DESCRIPTION
Today we only check if a layer's media type is supported when we actually process that layer (downloading the contents just after that). If an image has 10 layers and the last one is unprocessable, we've already wasted time pulling and processing the first 9 layers.


This PR fixes this behavior by checking all layer media types upfront in `Image.Read()` before doing any real work. If any layer can't be processed, fail immediately before we pull any contents.