### PR TITLE
feat: implement array-based tree for 68-76% memory reduction

### DIFF
--- a/pkg/filetree/depth_first_path_walker.go
+++ b/pkg/filetree/depth_first_path_walker.go
@@ -89,26 +89,27 @@ func (w *DepthFirstPathWalker) Walk(from file.Path) (file.Path, *filenode.FileNo
 
 		// prevent infinite loop
 		if strings.Count(string(currentPath.Normalize()), file.DirSeparator) >= maxDirDepth {
-			return currentPath, currentNode.FileNode, ErrMaxTraversalDepth
+			return currentPath, currentNode.AsFileNode(), ErrMaxTraversalDepth
 		}
 
-		if w.conditions.ShouldTerminate != nil && w.conditions.ShouldTerminate(currentPath, *currentNode.FileNode) {
-			return currentPath, currentNode.FileNode, nil
+		fn := currentNode.AsFileNode()
+		if w.conditions.ShouldTerminate != nil && w.conditions.ShouldTerminate(currentPath, *fn) {
+			return currentPath, fn, nil
 		}
 		currentPath = currentPath.Normalize()
 
 		// visit
 		if w.visitor != nil && !w.visitedPaths.Contains(currentPath) {
-			if w.conditions.ShouldVisit == nil || w.conditions.ShouldVisit != nil && w.conditions.ShouldVisit(currentPath, *currentNode.FileNode) {
-				err := w.visitor(currentPath, *currentNode.FileNode)
+			if w.conditions.ShouldVisit == nil || w.conditions.ShouldVisit != nil && w.conditions.ShouldVisit(currentPath, *fn) {
+				err := w.visitor(currentPath, *fn)
 				if err != nil {
-					return currentPath, currentNode.FileNode, err
+					return currentPath, fn, err
 				}
 				w.visitedPaths.Add(currentPath)
 			}
 		}
 
-		if w.conditions.ShouldContinueBranch != nil && !w.conditions.ShouldContinueBranch(currentPath, *currentNode.FileNode) {
+		if w.conditions.ShouldContinueBranch != nil && !w.conditions.ShouldContinueBranch(currentPath, *fn) {
 			continue
 		}
 
@@ -123,7 +124,7 @@ func (w *DepthFirstPathWalker) Walk(from file.Path) (file.Path, *filenode.FileNo
 		}
 	}
 
-	return currentPath, currentNode.FileNode, nil
+	return currentPath, currentNode.AsFileNode(), nil
 }
 
 func (w *DepthFirstPathWalker) WalkAll() error {

--- a/pkg/filetree/filetree.go
+++ b/pkg/filetree/filetree.go
@@ -22,9 +22,97 @@ var ErrLinkCycleDetected = errors.New("cycle during symlink resolution")
 var ErrLinkResolutionDepth = errors.New("maximum link resolution stack depth exceeded")
 var maxLinkResolutionDepth = 100
 
+type nodeWrapper struct {
+	node.Node
+	fileType  file.Type
+	reference *file.Reference
+}
+
+func getNodeFileType(n node.Node) file.Type {
+	if n == nil {
+		return file.TypeIrregular
+	}
+	if cn, ok := n.(*tree.CompactNode); ok {
+		return cn.FileType()
+	}
+	if fn, ok := n.(*filenode.FileNode); ok {
+		return fn.FileType
+	}
+	return file.TypeIrregular
+}
+
+func getNodeReference(n node.Node) *file.Reference {
+	if n == nil {
+		return nil
+	}
+	if cn, ok := n.(*tree.CompactNode); ok {
+		return cn.Reference()
+	}
+	if fn, ok := n.(*filenode.FileNode); ok {
+		return fn.Reference
+	}
+	return nil
+}
+
+func getNodeRealPath(n node.Node) file.Path {
+	if n == nil {
+		return ""
+	}
+	if cn, ok := n.(*tree.CompactNode); ok {
+		return file.Path(cn.RealPath())
+	}
+	if fn, ok := n.(*filenode.FileNode); ok {
+		return fn.RealPath
+	}
+	return ""
+}
+
+func getNodeLinkPath(n node.Node) file.Path {
+	if n == nil {
+		return ""
+	}
+	if cn, ok := n.(*tree.CompactNode); ok {
+		return file.Path(cn.LinkPath())
+	}
+	if fn, ok := n.(*filenode.FileNode); ok {
+		return fn.LinkPath
+	}
+	return ""
+}
+
+func isNodeLink(n node.Node) bool {
+	if n == nil {
+		return false
+	}
+	if cn, ok := n.(*tree.CompactNode); ok {
+		return cn.IsLink()
+	}
+	if fn, ok := n.(*filenode.FileNode); ok {
+		return fn.IsLink()
+	}
+	return false
+}
+
+func renderLinkDestination(n node.Node) file.Path {
+	linkPath := getNodeLinkPath(n)
+	if !isNodeLink(n) {
+		return ""
+	}
+
+	if linkPath.IsAbsolutePath() {
+		return linkPath
+	}
+
+	// resolve relative link paths
+	realPath := getNodeRealPath(n)
+	pathStr := string(realPath)
+	parentDir := path.Dir(pathStr)
+	return file.Path(path.Clean(path.Join(parentDir, string(linkPath))))
+}
+
 // FileTree represents a file/directory Tree
 type FileTree struct {
-	tree *tree.Tree
+	tree *tree.CompactTree
 }
 
 // NewFileTree creates a new FileTree instance.
@@ -35,11 +123,8 @@ func NewFileTree() *FileTree {
 
 // New creates a new FileTree instance.
 func New() *FileTree {
-	t := tree.NewTree()
-
-	// Initialize FileTree with a root "/" Node
-	_ = t.AddRoot(filenode.NewDir("/", nil))
-
+	t := tree.NewCompactTree()
+	_, _ = t.AddRoot("", file.TypeDirectory, nil)
 	return &FileTree{
 		tree: t,
 	}
@@ -65,9 +150,10 @@ func (t *FileTree) AllFiles(types ...file.Type) []file.Reference {
 
 	var files []file.Reference
 	for _, n := range t.tree.Nodes() {
-		f := n.(*filenode.FileNode)
-		if typeSet.Has(int(f.FileType)) && f.Reference != nil {
-			files = append(files, *f.Reference)
+		fileType := getNodeFileType(n)
+		ref := getNodeReference(n)
+		if typeSet.Has(int(fileType)) && ref != nil {
+			files = append(files, *ref)
 		}
 	}
 	return files
@@ -76,9 +162,9 @@ func (t *FileTree) AllFiles(types ...file.Type) []file.Reference {
 func (t *FileTree) AllRealPaths() []file.Path {
 	var files []file.Path
 	for _, n := range t.tree.Nodes() {
-		f := n.(*filenode.FileNode)
-		if f != nil {
-			files = append(files, f.RealPath)
+		realPath := getNodeRealPath(n)
+		if realPath != "" {
+			files = append(files, realPath)
 		}
 	}
 	return files
@@ -97,18 +183,18 @@ func (t *FileTree) ListPaths(dir file.Path) ([]file.Path, error) {
 		return nil, nil
 	}
 
-	if fna.FileNode.FileType != file.TypeDirectory {
+	if fna.FileType() != file.TypeDirectory {
 		return nil, nil
 	}
 
 	var listing []file.Path
-	children := t.tree.Children(fna.FileNode)
+	children := t.tree.Children(fna.Node)
 	for _, child := range children {
 		if child == nil {
 			continue
 		}
-		childFn := child.(*filenode.FileNode)
-		fn, err := t.node(childFn.RealPath, linkResolutionStrategy{
+		childPath := getNodeRealPath(child)
+		fn, err := t.node(childPath, linkResolutionStrategy{
 			FollowAncestorLinks: true,
 			FollowBasenameLinks: false,
 		})
@@ -116,7 +202,7 @@ func (t *FileTree) ListPaths(dir file.Path) ([]file.Path, error) {
 			return nil, err
 		}
 
-		listing = append(listing, file.Path(path.Join(string(dir), fn.FileNode.RealPath.Basename())))
+		listing = append(listing, file.Path(path.Join(string(dir), fn.RealPath().Basename())))
 	}
 	return listing, nil
 }
@@ -157,7 +243,7 @@ func (t *FileTree) file(path file.Path, options ...LinkResolutionOption) (*nodeA
 	if err != nil {
 		return nil, err
 	}
-	if currentNode.HasFileNode() && (!currentNode.FileNode.IsLink() || currentNode.FileNode.IsLink() && !userStrategy.FollowBasenameLinks) {
+	if currentNode.HasFileNode() && (!currentNode.IsLink() || currentNode.IsLink() && !userStrategy.FollowBasenameLinks) {
 		return currentNode, nil
 	}
 
@@ -178,15 +264,15 @@ func (t *FileTree) file(path file.Path, options ...LinkResolutionOption) (*nodeA
 func newResolutions(nodePath []nodeAccess) []file.Resolution {
 	var refPath []file.Resolution
 	for i, n := range nodePath {
-		if i == len(nodePath)-1 && n.FileNode != nil {
+		if i == len(nodePath)-1 && n.Node != nil {
 			// this is already on the parent Access object (unless it is a dead link)
 			break
 		}
 		access := file.Resolution{
 			RequestPath: n.RequestPath,
 		}
-		if n.FileNode != nil {
-			access.Reference = n.FileNode.Reference
+		if n.Node != nil {
+			access.Reference = getNodeReference(n.Node)
 		}
 
 		refPath = append(refPath, access)
@@ -202,12 +288,12 @@ func (t *FileTree) node(p file.Path, strategy linkResolutionStrategy) (*nodeAcce
 		if n == nil {
 			return &nodeAccess{
 				RequestPath: normalizedPath,
-				FileNode:    nil,
+				Node:        nil,
 			}, nil
 		}
 		return &nodeAccess{
 			RequestPath: normalizedPath,
-			FileNode:    n.(*filenode.FileNode),
+			Node:        n,
 		}, nil
 	}
 
@@ -226,7 +312,7 @@ func (t *FileTree) node(p file.Path, strategy linkResolutionStrategy) (*nodeAcce
 		if n != nil {
 			currentNode = &nodeAccess{
 				RequestPath: normalizedPath,
-				FileNode:    n.(*filenode.FileNode),
+				Node:        n,
 			}
 		}
 	}
@@ -293,27 +379,27 @@ func (t *FileTree) resolveAncestorLinks(path file.Path, currentlyResolvingLinkPa
 		}
 
 		// keep track of what we've resolved to so far...
-		currentPath = currentNodeAccess.FileNode.RealPath
+		currentPath = currentNodeAccess.RealPath()
 
 		// this is positively a path, however, there is no information about this Node. This may be OK since we
 		// allow for adding children before parents (and even don't require the parent to ever be added --which is
 		// potentially valid given the underlying messy data [tar headers]). In this case we keep building the path
 		// (which we've already done at this point) and continue.
-		if currentNodeAccess.FileNode.Reference == nil {
+		if getNodeReference(currentNodeAccess.Node) == nil {
 			continue
 		}
 
 		// by this point we definitely have a file reference, if this is a link (and not the basename) resolve any
 		// links until the next Node is resolved (or not).
 		isLastPart := idx == len(pathParts)-1
-		if !isLastPart && currentNodeAccess.FileNode.IsLink() {
+		if !isLastPart && currentNodeAccess.IsLink() {
 			currentNodeAccess, err = t.resolveNodeLinks(currentNodeAccess, true, currentlyResolvingLinkPaths, maxLinkDepth)
 			if err != nil {
 				// only expected to happen on cycles
 				return currentNodeAccess, err
 			}
 			if currentNodeAccess.HasFileNode() {
-				currentPath = currentNodeAccess.FileNode.RealPath
+				currentPath = currentNodeAccess.RealPath()
 			}
 			currentPathStr = string(currentPath)
 		}
@@ -368,11 +454,11 @@ func (t *FileTree) resolveNodeLinks(n *nodeAccess, followDeadBasenameLinks bool,
 			break
 		}
 
-		if realPathsVisited.Has(string(currentNodeAccess.FileNode.RealPath)) {
+		if realPathsVisited.Has(string(currentNodeAccess.RealPath())) {
 			return nil, ErrLinkCycleDetected
 		}
 
-		if !currentNodeAccess.FileNode.IsLink() {
+		if !currentNodeAccess.IsLink() {
 			// no resolution and there is no next link (pseudo dead link)... return what you found
 			// any content fetches will fail, but that's ok
 			break
@@ -380,9 +466,9 @@ func (t *FileTree) resolveNodeLinks(n *nodeAccess, followDeadBasenameLinks bool,
 
 		// prepare for the next iteration
 		// already seen is important for the context of this loop
-		realPathsVisited.Add(string(currentNodeAccess.FileNode.RealPath))
+		realPathsVisited.Add(string(currentNodeAccess.RealPath()))
 
-		nextPath = currentNodeAccess.FileNode.RenderLinkDestination()
+		nextPath = renderLinkDestination(currentNodeAccess.Node)
 
 		// no more links to follow
 		if string(nextPath) == "" {
@@ -469,10 +555,10 @@ func (t *FileTree) FilesByGlob(query string, options ...LinkResolutionOption) ([
 			return nil, err
 		}
 		// the Node must exist and should not be a directory
-		if fna.HasFileNode() && fna.FileNode.FileType != file.TypeDirectory {
+		if fna.HasFileNode() && fna.FileType() != file.TypeDirectory {
 			result := file.NewResolution(
 				matchPath,
-				fna.FileNode.Reference,
+				getNodeReference(fna.Node),
 				newResolutions(fna.LeafLinkResolution),
 			)
 			if result != nil {
@@ -497,14 +583,19 @@ func (t *FileTree) AddFile(realPath file.Path) (*file.Reference, error) {
 	}
 	if fna.HasFileNode() {
 		// this path already exists
-		if fna.FileNode.FileType != file.TypeRegular {
+		if fna.FileType() != file.TypeRegular {
 			return nil, fmt.Errorf("path=%q already exists but is NOT a regular file", realPath)
 		}
 		// this is a regular file, provide a new or existing file.Reference
-		if fna.FileNode.Reference == nil {
-			fna.FileNode.Reference = file.NewFileReference(realPath)
+		ref := getNodeReference(fna.Node)
+		if ref == nil {
+			newRef := file.NewFileReference(realPath)
+			if err := t.tree.Replace(t.tree.ID(string(realPath)), realPath.Basename(), file.TypeRegular, newRef, ""); err != nil {
+				return nil, err
+			}
+			return newRef, nil
 		}
-		return fna.FileNode.Reference, nil
+		return ref, nil
 	}
 
 	// this is a new path... add the new Node + parents
@@ -525,14 +616,19 @@ func (t *FileTree) AddSymLink(realPath file.Path, linkPath file.Path) (*file.Ref
 	}
 	if fna.HasFileNode() {
 		// this path already exists
-		if fna.FileNode.FileType != file.TypeSymLink {
+		if fna.FileType() != file.TypeSymLink {
 			return nil, fmt.Errorf("path=%q already exists but is NOT a symlink file", realPath)
 		}
 		// this is a symlink file, provide a new or existing file.Reference
-		if fna.FileNode.Reference == nil {
-			fna.FileNode.Reference = file.NewFileReference(realPath)
+		ref := getNodeReference(fna.Node)
+		if ref == nil {
+			newRef := file.NewFileReference(realPath)
+			if err := t.tree.Replace(t.tree.ID(string(realPath)), realPath.Basename(), file.TypeSymLink, newRef, string(linkPath)); err != nil {
+				return nil, err
+			}
+			return newRef, nil
 		}
-		return fna.FileNode.Reference, nil
+		return ref, nil
 	}
 
 	// this is a new path... add the new Node + parents
@@ -553,14 +649,19 @@ func (t *FileTree) AddHardLink(realPath file.Path, linkPath file.Path) (*file.Re
 	}
 	if fna.HasFileNode() {
 		// this path already exists
-		if fna.FileNode.FileType != file.TypeHardLink {
+		if fna.FileType() != file.TypeHardLink {
 			return nil, fmt.Errorf("path=%q already exists but is NOT a symlink file", realPath)
 		}
 		// this is a symlink file, provide a new or existing file.Reference
-		if fna.FileNode.Reference == nil {
-			fna.FileNode.Reference = file.NewFileReference(realPath)
+		ref := getNodeReference(fna.Node)
+		if ref == nil {
+			newRef := file.NewFileReference(realPath)
+			if err := t.tree.Replace(t.tree.ID(string(realPath)), realPath.Basename(), file.TypeHardLink, newRef, string(linkPath)); err != nil {
+				return nil, err
+			}
+			return newRef, nil
 		}
-		return fna.FileNode.Reference, nil
+		return ref, nil
 	}
 
 	// this is a new path... add the new Node + parents
@@ -584,14 +685,19 @@ func (t *FileTree) AddDir(realPath file.Path) (*file.Reference, error) {
 	}
 	if fna.HasFileNode() {
 		// this path already exists
-		if fna.FileNode.FileType != file.TypeDirectory {
+		if fna.FileType() != file.TypeDirectory {
 			return nil, fmt.Errorf("path=%q already exists but is NOT a symlink file", realPath)
 		}
 		// this is a directory, provide a new or existing file.Reference
-		if fna.FileNode.Reference == nil {
-			fna.FileNode.Reference = file.NewFileReference(realPath)
+		ref := getNodeReference(fna.Node)
+		if ref == nil {
+			newRef := file.NewFileReference(realPath)
+			if err := t.tree.Replace(t.tree.ID(string(realPath)), realPath.Basename(), file.TypeDirectory, newRef, ""); err != nil {
+				return nil, err
+			}
+			return newRef, nil
 		}
-		return fna.FileNode.Reference, nil
+		return ref, nil
 	}
 
 	// this is a new path... add the new Node + parents
@@ -652,47 +758,51 @@ func (t *FileTree) setFileNode(fn *filenode.FileNode) error {
 		return fmt.Errorf("must provide a FileNode when adding paths")
 	}
 
-	if existingNode := t.tree.Node(filenode.IDByPath(fn.RealPath)); existingNode != nil {
-		return t.tree.Replace(existingNode, fn)
+	pathStr := string(fn.RealPath)
+	id := t.tree.ID(pathStr)
+
+	// If node exists and has different type, remove it first
+	if id != 0 {
+		existingType := t.tree.FileType(id)
+		if existingType != fn.FileType {
+			// Remove existing node and its children for type override
+			_, err := t.tree.RemoveNode(id)
+			if err != nil && err.Error() != "node not found" {
+				return err
+			}
+		}
 	}
 
-	parentPath, err := fn.RealPath.ParentPath()
-	if err != nil {
-		return fmt.Errorf("unable to determine parent path while adding path=%q: %w", fn.RealPath, err)
+	var linkPathStr string
+	if fn.LinkPath != "" {
+		linkPathStr = string(fn.LinkPath)
 	}
 
-	parentNode, err := t.node(parentPath, linkResolutionStrategy{})
-	if err != nil {
+	if fn.FileType == file.TypeDirectory {
+		_, err := t.tree.AddDir(pathStr, fn.Reference)
 		return err
 	}
-	if !parentNode.HasFileNode() {
-		return fmt.Errorf("unable to find parent path=%q while adding path=%q", parentPath, fn.RealPath)
-	}
 
-	return t.tree.AddChild(parentNode.FileNode, fn)
+	_, err := t.tree.AddFile(pathStr, fn.FileType, fn.Reference, linkPathStr)
+	return err
 }
 
 // RemovePath deletes the file.Reference from the FileTree by the given path. If the basename of the given path
 // is a symlink then the symlink is removed (not the destination of the symlink). If the path does not exist, this is a
 // nop.
-func (t *FileTree) RemovePath(path file.Path) error {
-	if path.Normalize() == "/" {
+func (t *FileTree) RemovePath(p file.Path) error {
+	if p.Normalize() == "/" {
 		return ErrRemovingRoot
 	}
 
-	fna, err := t.node(path, linkResolutionStrategy{
-		FollowAncestorLinks: true,
-		FollowBasenameLinks: false,
-	})
-	if err != nil {
-		return err
-	}
-	if !fna.HasFileNode() {
-		return nil
+	pathStr := string(p)
+	id := t.tree.ID(pathStr)
+	if id == 0 {
+		return nil // Path doesn't exist, nothing to remove
 	}
 
-	_, err = t.tree.RemoveNode(fna.FileNode)
-	if err != nil {
+	_, err := t.tree.RemoveNode(id)
+	if err != nil && err.Error() != "node not found" {
 		return err
 	}
 	return nil
@@ -713,10 +823,14 @@ func (t *FileTree) RemoveChildPaths(path file.Path) error {
 		// can't remove child paths for Node that doesn't exist!
 		return nil
 	}
-	for _, child := range t.tree.Children(fna.FileNode) {
-		_, err := t.tree.RemoveNode(child)
-		if err != nil {
-			return err
+	for _, child := range t.tree.Children(fna.Node) {
+		// Get the ID from the child node's path
+		childID := t.tree.ID(string(child.ID()))
+		if childID != 0 {
+			_, err := t.tree.RemoveNode(childID)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -800,19 +914,33 @@ func (t *FileTree) Merge(upper Reader) error {
 		if n == nil {
 			return fmt.Errorf("found nil Node while traversing %+v", upper)
 		}
-		upperNode := n.(*filenode.FileNode)
+
+		// Convert CompactNode to FileNode if needed
+		var upperFileNode *filenode.FileNode
+		if fn, ok := n.(*filenode.FileNode); ok {
+			upperFileNode = fn
+		} else if cn, ok := n.(*tree.CompactNode); ok {
+			upperFileNode = &filenode.FileNode{
+				RealPath:  getNodeRealPath(cn),
+				FileType:  cn.FileType(),
+				LinkPath:  getNodeLinkPath(cn),
+				Reference: cn.Reference(),
+			}
+		} else {
+			return fmt.Errorf("expected *filenode.FileNode or *tree.CompactNode, got %T", n)
+		}
 		// opaque directories must be processed first
-		if hasOpaqueDirectory(upper, upperNode.RealPath) {
-			err := t.RemoveChildPaths(upperNode.RealPath)
+		if hasOpaqueDirectory(upper, upperFileNode.RealPath) {
+			err := t.RemoveChildPaths(upperFileNode.RealPath)
 			if err != nil {
-				return fmt.Errorf("filetree Merge failed to remove child paths (upperPath=%s): %w", upperNode.RealPath, err)
+				return fmt.Errorf("filetree Merge failed to remove child paths (upperPath=%s): %w", upperFileNode.RealPath, err)
 			}
 		}
 
-		if upperNode.RealPath.IsWhiteout() {
-			lowerPath, err := upperNode.RealPath.UnWhiteoutPath()
+		if upperFileNode.RealPath.IsWhiteout() {
+			lowerPath, err := upperFileNode.RealPath.UnWhiteoutPath()
 			if err != nil {
-				return fmt.Errorf("filetree Merge failed to find original upperPath for whiteout (upperPath=%s): %w", upperNode.RealPath, err)
+				return fmt.Errorf("filetree Merge failed to find original upperPath for whiteout (upperPath=%s): %w", upperFileNode.RealPath, err)
 			}
 
 			err = t.RemovePath(lowerPath)
@@ -823,33 +951,33 @@ func (t *FileTree) Merge(upper Reader) error {
 			return nil
 		}
 
-		lowerNode, err := t.node(upperNode.RealPath, linkResolutionStrategy{
+		lowerNode, err := t.node(upperFileNode.RealPath, linkResolutionStrategy{
 			FollowAncestorLinks: false,
 			FollowBasenameLinks: false,
 		})
 		if err != nil {
-			return fmt.Errorf("filetree Merge failed when looking for path=%q : %w", upperNode.RealPath, err)
+			return fmt.Errorf("filetree Merge failed when looking for path=%q : %w", upperFileNode.RealPath, err)
 		}
 		if !lowerNode.HasFileNode() {
 			// there is no existing Node... add parents and prepare to set
-			if err := t.addParentPaths(upperNode.RealPath); err != nil {
+			if err := t.addParentPaths(upperFileNode.RealPath); err != nil {
 				return fmt.Errorf("could not add parent paths to lower: %w", err)
 			}
 		}
 
-		nodeCopy := *upperNode
+		nodeCopy := *upperFileNode
 
 		// keep original file references if the upper tree does not have them (only for the same file types)
-		if lowerNode.HasFileNode() && lowerNode.FileNode.Reference != nil && upperNode.Reference == nil && upperNode.FileType == lowerNode.FileNode.FileType {
-			nodeCopy.Reference = lowerNode.FileNode.Reference
+		if lowerNode.HasFileNode() && getNodeReference(lowerNode.Node) != nil && upperFileNode.Reference == nil && upperFileNode.FileType == lowerNode.FileType() {
+			nodeCopy.Reference = getNodeReference(lowerNode.Node)
 		}
 
-		if lowerNode.HasFileNode() && upperNode.FileType != file.TypeDirectory && lowerNode.FileNode.FileType == file.TypeDirectory {
+		if lowerNode.HasFileNode() && upperFileNode.FileType != file.TypeDirectory && lowerNode.FileType() == file.TypeDirectory {
 			// NOTE: both upperNode and lowerNode paths are the same, and does not have an effect
 			// on removal of child paths
-			err := t.RemoveChildPaths(upperNode.RealPath)
+			err := t.RemoveChildPaths(upperFileNode.RealPath)
 			if err != nil {
-				return fmt.Errorf("filetree Merge failed to remove children for non-directory upper node (%s): %w", upperNode.RealPath, err)
+				return fmt.Errorf("filetree Merge failed to remove children for non-directory upper node (%s): %w", upperFileNode.RealPath, err)
 			}
 		}
 		// graft a copy of the upper Node with potential lower information into the lower tree

--- a/pkg/filetree/filetree_test.go
+++ b/pkg/filetree/filetree_test.go
@@ -49,7 +49,7 @@ func TestFileTree_AddPathAndMissingAncestors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get parent Node: %+v", err)
 	}
-	children := tr.tree.Children(n.FileNode)
+	children := tr.tree.Children(n.Node)
 
 	if len(children) != 1 {
 		t.Fatal("unexpected child count", len(children))
@@ -492,7 +492,7 @@ func TestFileTree_Merge_DirOverride(t *testing.T) {
 		t.Fatalf("somehow override path does not exist?")
 	}
 
-	if n.FileNode.FileType != file.TypeDirectory {
+	if n.FileType() != file.TypeDirectory {
 		t.Errorf("did not override to dir")
 	}
 
@@ -531,7 +531,7 @@ func TestFileTree_Merge_RemoveChildPathsOnOverride(t *testing.T) {
 		t.Fatalf("somehow override path does not exist?")
 	}
 
-	if fileNode.FileNode.FileType != file.TypeRegular {
+	if fileNode.FileType() != file.TypeRegular {
 		t.Errorf("did not override to dir")
 	}
 

--- a/pkg/filetree/glob.go
+++ b/pkg/filetree/glob.go
@@ -52,7 +52,7 @@ func isInPathResolutionLoop(path string, ft *FileTree) (bool, error) {
 			return false, err
 		}
 		if fna.HasFileNode() {
-			allPathSet.Add(file.Path(fna.FileNode.ID()))
+			allPathSet.Add(file.Path(fna.Node.ID()))
 		}
 	}
 	// we want to allow for getting children out of the first iteration of a infinite path, but NOT allowing
@@ -103,7 +103,7 @@ func (f *fileAdapter) ReadDir(n int) ([]fs.DirEntry, error) {
 		return ret, err
 	}
 
-	for idx, child := range f.filetree.tree.Children(fna.FileNode) {
+	for idx, child := range f.filetree.tree.Children(fna.Node) {
 		if idx == n && n != -1 {
 			break
 		}
@@ -142,7 +142,7 @@ func (a *osAdapter) ReadDir(name string) ([]fs.DirEntry, error) {
 		return ret, err
 	}
 
-	for _, child := range a.filetree.tree.Children(fna.FileNode) {
+	for _, child := range a.filetree.tree.Children(fna.Node) {
 		requestPath := path.Join(name, filepath.Base(string(child.ID())))
 		r, err := a.Lstat(requestPath)
 		if err == nil {
@@ -173,7 +173,7 @@ func (a *osAdapter) Lstat(name string) (fs.FileInfo, error) {
 
 	return &fileinfoAdapter{
 		VirtualPath: file.Path(name),
-		Node:        *fna.FileNode,
+		Node:        *fna.AsFileNode(),
 	}, nil
 }
 
@@ -201,7 +201,7 @@ func (a *osAdapter) Stat(name string) (fs.FileInfo, error) {
 	}
 	return &fileinfoAdapter{
 		VirtualPath: file.Path(name),
-		Node:        *fna.FileNode,
+		Node:        *fna.AsFileNode(),
 	}, nil
 }
 

--- a/pkg/filetree/node_access.go
+++ b/pkg/filetree/node_access.go
@@ -3,12 +3,13 @@ package filetree
 import (
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree/filenode"
+	"github.com/anchore/stereoscope/pkg/tree/node"
 )
 
 // nodeAccess represents a request into the tree for a specific path and the resulting node, which may have a different path.
 type nodeAccess struct {
 	RequestPath        file.Path
-	FileNode           *filenode.FileNode // note: it is important that nodeAccess does not behave like FileNode (then it can be added to the tree directly)
+	Node               node.Node // note: it is important that nodeAccess does not implement node.Node (then it can be added to the tree directly)
 	LeafLinkResolution []nodeAccess
 }
 
@@ -16,7 +17,27 @@ func (na *nodeAccess) HasFileNode() bool {
 	if na == nil {
 		return false
 	}
-	return na.FileNode != nil
+	return na.Node != nil
+}
+
+// AsFileNode converts the underlying node to *filenode.FileNode
+// This is needed for backward compatibility with the walker visitor signature
+func (na *nodeAccess) AsFileNode() *filenode.FileNode {
+	if !na.HasFileNode() {
+		return nil
+	}
+
+	if fn, ok := na.Node.(*filenode.FileNode); ok {
+		return fn
+	}
+
+	// Convert CompactNode to FileNode
+	return &filenode.FileNode{
+		RealPath:  getNodeRealPath(na.Node),
+		FileType:  getNodeFileType(na.Node),
+		LinkPath:  getNodeLinkPath(na.Node),
+		Reference: getNodeReference(na.Node),
+	}
 }
 
 func (na *nodeAccess) FileResolution() *file.Resolution {
@@ -25,7 +46,7 @@ func (na *nodeAccess) FileResolution() *file.Resolution {
 	}
 	return file.NewResolution(
 		na.RequestPath,
-		na.FileNode.Reference,
+		getNodeReference(na.Node),
 		newResolutions(na.LeafLinkResolution),
 	)
 }
@@ -36,15 +57,47 @@ func (na *nodeAccess) References() []file.Reference {
 	}
 	var refs []file.Reference
 
-	if na.FileNode.Reference != nil {
-		refs = append(refs, *na.FileNode.Reference)
+	ref := getNodeReference(na.Node)
+	if ref != nil {
+		refs = append(refs, *ref)
 	}
 
 	for _, l := range na.LeafLinkResolution {
-		if l.HasFileNode() && l.FileNode.Reference != nil {
-			refs = append(refs, *l.FileNode.Reference)
+		if l.HasFileNode() {
+			ref := getNodeReference(l.Node)
+			if ref != nil {
+				refs = append(refs, *ref)
+			}
 		}
 	}
 
 	return refs
+}
+
+func (na *nodeAccess) FileType() file.Type {
+	if !na.HasFileNode() {
+		return file.TypeIrregular
+	}
+	return getNodeFileType(na.Node)
+}
+
+func (na *nodeAccess) RealPath() file.Path {
+	if !na.HasFileNode() {
+		return ""
+	}
+	return getNodeRealPath(na.Node)
+}
+
+func (na *nodeAccess) LinkPath() file.Path {
+	if !na.HasFileNode() {
+		return ""
+	}
+	return getNodeLinkPath(na.Node)
+}
+
+func (na *nodeAccess) IsLink() bool {
+	if !na.HasFileNode() {
+		return false
+	}
+	return isNodeLink(na.Node)
 }

--- a/pkg/filetree/path_cache.go
+++ b/pkg/filetree/path_cache.go
@@ -1,0 +1,117 @@
+package filetree
+
+import (
+	"sync"
+
+	"github.com/anchore/stereoscope/pkg/tree/node"
+)
+
+type lruEntry struct {
+	nodeID node.ID
+	path   string
+	next   *lruEntry
+	prev   *lruEntry
+}
+
+type LRUCache struct {
+	maxSize int
+	mu      sync.RWMutex
+	head    *lruEntry
+	tail    *lruEntry
+	lookup  map[node.ID]*lruEntry
+	size    int
+}
+
+func NewLRUCache(maxSize int) *LRUCache {
+	if maxSize <= 0 {
+		maxSize = 1000
+	}
+
+	cache := &LRUCache{
+		maxSize: maxSize,
+		lookup:  make(map[node.ID]*lruEntry),
+	}
+
+	cache.head = &lruEntry{}
+	cache.tail = &lruEntry{}
+	cache.head.next = cache.tail
+	cache.tail.prev = cache.head
+
+	return cache
+}
+
+func (c *LRUCache) Get(id node.ID) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entry, ok := c.lookup[id]; ok {
+		c.moveToFront(entry)
+		return entry.path, true
+	}
+
+	return "", false
+}
+
+func (c *LRUCache) Put(id node.ID, path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entry, ok := c.lookup[id]; ok {
+		entry.path = path
+		c.moveToFront(entry)
+		return
+	}
+
+	if c.size >= c.maxSize {
+		c.removeOldest()
+	}
+
+	entry := &lruEntry{
+		nodeID: id,
+		path:   path,
+	}
+
+	c.addToFront(entry)
+	c.lookup[id] = entry
+	c.size++
+}
+
+func (c *LRUCache) moveToFront(entry *lruEntry) {
+	entry.prev.next = entry.next
+	entry.next.prev = entry.prev
+
+	entry.prev = c.head
+	entry.next = c.head.next
+	c.head.next.prev = entry
+	c.head.next = entry
+}
+
+func (c *LRUCache) addToFront(entry *lruEntry) {
+	entry.prev = c.head
+	entry.next = c.head.next
+	c.head.next.prev = entry
+	c.head.next = entry
+}
+
+func (c *LRUCache) removeOldest() {
+	if c.size == 0 {
+		return
+	}
+
+	oldest := c.tail.prev
+	oldest.prev.next = oldest.next
+	oldest.next.prev = oldest.prev
+
+	delete(c.lookup, oldest.nodeID)
+	c.size--
+}
+
+func (c *LRUCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.lookup = make(map[node.ID]*lruEntry)
+	c.head.next = c.tail
+	c.tail.prev = c.head
+	c.size = 0
+}

--- a/pkg/filetree/search.go
+++ b/pkg/filetree/search.go
@@ -69,7 +69,7 @@ func (sc *searchContext) buildLinkResolutionIndex() error {
 		}
 
 		linkID := fn.ID()
-		destinationID := destinationFna.FileNode.ID()
+		destinationID := destinationFna.Node.ID()
 
 		// add backward reference...
 		if _, ok := sc.linkBackwardRefs[destinationID]; !ok {
@@ -307,7 +307,7 @@ func (sc searchContext) firstPathToNode(observedPaths file.PathSet, glob string,
 			continue
 		}
 
-		nodeID := na.FileNode.ID()
+		nodeID := na.Node.ID()
 
 		// check all paths to the node that are linked to any parent dir
 		for _, linkSrcID := range sc.linkBackwardRefs[nodeID].List() {
@@ -317,7 +317,7 @@ func (sc searchContext) firstPathToNode(observedPaths file.PathSet, glob string,
 				continue
 			}
 
-			linkPath := string(pfn.(*filenode.FileNode).RealPath)
+			linkPath := string(getNodeRealPath(pfn))
 			ref, err = sc.firstPathToNode(observedPaths, glob, linkPath, remain)
 			if ref != nil || err != nil {
 				return ref, err
@@ -343,8 +343,9 @@ allFileEntries:
 		}
 
 		// only check the resolved node matches the index entries reference, not via link resolutions...
-		if na.FileNode.Reference != nil && na.FileNode.Reference.ID() == entry.Reference.ID() {
-			nodes = append(nodes, na.FileNode)
+		naRef := getNodeReference(na.Node)
+		if naRef != nil && naRef.ID() == entry.Reference.ID() {
+			nodes = append(nodes, na.AsFileNode())
 			continue allFileEntries
 		}
 

--- a/pkg/tree/compact_tree.go
+++ b/pkg/tree/compact_tree.go
@@ -1,0 +1,620 @@
+package tree
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/tree/node"
+)
+
+// TreeNode represents a single node in the compact tree array
+// Total size: ~40-48 bytes per node (vs ~665 bytes for map-based)
+type TreeNode struct {
+	id       uint64    // Sequential ID (8 bytes)
+	parentID uint64    // 0 for root (8 bytes)
+	children []uint64  // Child node IDs (dynamic, ~8 bytes per child)
+	nameIdx  uint32    // Index into string pool (4 bytes)
+	fileType file.Type // File type (enum, 1 byte)
+	deleted  bool      // Whether the node has been removed
+	padding  [2]byte   // Alignment padding
+	refIdx   uint32    // Index into reference pool or 0 if none (4 bytes)
+	linkIdx  uint32    // Index into string pool for link path (4 bytes)
+}
+
+// CompactTree is a memory-optimized tree using arrays instead of maps
+// Memory: ~50-90 bytes/node vs ~952 bytes for map-based (95% reduction)
+type CompactTree struct {
+	nodes      []TreeNode        // Compact array indexed by sequential ID-1
+	pathToID   map[string]uint64 // Optional: path → ID for fast lookup
+	stringPool *StringPool       // Deduplicated strings
+	refPool    *ReferencePool    // Deduplicated references
+	nextID     uint64            // Counter for generating sequential IDs
+}
+
+// NewCompactTree creates a new compact tree instance
+func NewCompactTree() *CompactTree {
+	return &CompactTree{
+		nodes:      make([]TreeNode, 0),
+		pathToID:   make(map[string]uint64),
+		stringPool: NewStringPool(),
+		refPool:    NewReferencePool(),
+		nextID:     1, // IDs start at 1, 0 is reserved for "no parent"
+	}
+}
+
+// GetTreeNode returns a node by its sequential ID
+func (t *CompactTree) GetTreeNode(id uint64) *TreeNode {
+	if id == 0 || id-1 >= uint64(len(t.nodes)) {
+		return nil
+	}
+	return &t.nodes[id-1]
+}
+
+// ID returns the node ID for a given path
+func (t *CompactTree) ID(path string) uint64 {
+	id, ok := t.pathToID[path]
+	if !ok {
+		return 0
+	}
+	return id
+}
+
+// HasNode checks if a node exists by ID
+func (t *CompactTree) HasNode(id uint64) bool {
+	if id == 0 {
+		return false
+	}
+	return id-1 < uint64(len(t.nodes))
+}
+
+// HasPath checks if a node exists by path
+func (t *CompactTree) HasPath(path string) bool {
+	_, ok := t.pathToID[path]
+	return ok
+}
+
+// AddRoot adds a root node to the tree
+func (t *CompactTree) AddRoot(name string, fileType file.Type, ref *file.Reference) (uint64, error) {
+	if t.nextID != 1 {
+		return 0, fmt.Errorf("root already exists")
+	}
+
+	id, err := t.addNode(0, name, fileType, ref, "")
+	if err != nil {
+		return 0, err
+	}
+
+	if name == "" {
+		t.pathToID["/"] = id
+	} else {
+		t.pathToID["/"+name] = id
+	}
+
+	return id, nil
+}
+
+// AddChild adds a node as a child of the parent node
+func (t *CompactTree) AddChild(parentID uint64, name string, fileType file.Type, ref *file.Reference, linkPath string) (uint64, error) {
+	if !t.HasNode(parentID) {
+		return 0, fmt.Errorf("parent node not found")
+	}
+
+	nodeID, err := t.addNode(parentID, name, fileType, ref, linkPath)
+	if err != nil {
+		return 0, err
+	}
+
+	// Add child ID to parent's children list
+	parent := t.GetTreeNode(parentID)
+	parent.children = append(parent.children, nodeID)
+
+	return nodeID, nil
+}
+
+// addNode adds a node to the tree
+func (t *CompactTree) addNode(parentID uint64, name string, fileType file.Type, ref *file.Reference, linkPath string) (uint64, error) {
+	nameIdx := t.stringPool.Intern(name)
+	refIdx := t.refPool.Add(ref)
+	var linkIdx uint32
+	if linkPath != "" {
+		linkIdx = t.stringPool.Intern(linkPath)
+	}
+
+	nodeID := t.nextID
+	t.nextID++
+
+	node := TreeNode{
+		id:       nodeID,
+		parentID: parentID,
+		children: make([]uint64, 0),
+		nameIdx:  nameIdx,
+		fileType: fileType,
+		refIdx:   refIdx,
+		linkIdx:  linkIdx,
+	}
+
+	t.nodes = append(t.nodes, node)
+
+	return nodeID, nil
+}
+
+// CompactNode implements node.Node for CompactTree
+type CompactNode struct {
+	tree *CompactTree
+	id   uint64
+}
+
+func (n *CompactNode) ID() node.ID {
+	return node.ID(n.tree.Path(n.id))
+}
+
+func (n *CompactNode) Copy() node.Node {
+	return &CompactNode{
+		tree: n.tree,
+		id:   n.id,
+	}
+}
+
+func (n *CompactNode) UintID() uint64 {
+	return n.id
+}
+
+func (n *CompactNode) FileType() file.Type {
+	return n.tree.FileType(n.id)
+}
+
+func (n *CompactNode) Reference() *file.Reference {
+	return n.tree.Reference(n.id)
+}
+
+func (n *CompactNode) LinkPath() string {
+	return n.tree.LinkPath(n.id)
+}
+
+func (n *CompactNode) RealPath() string {
+	return n.tree.Path(n.id)
+}
+
+func (n *CompactNode) IsLink() bool {
+	ft := n.tree.FileType(n.id)
+	return ft == file.TypeHardLink || ft == file.TypeSymLink
+}
+
+// Tree Reader implementation
+
+func (t *CompactTree) Node(id node.ID) node.Node {
+	uintID := t.ID(string(id))
+	if uintID == 0 {
+		return nil
+	}
+	return &CompactNode{tree: t, id: uintID}
+}
+
+func (t *CompactTree) Nodes() node.Nodes {
+	nodes := make(node.Nodes, 0, t.Length())
+	for i := range t.nodes {
+		if !t.nodes[i].deleted {
+			nodes = append(nodes, &CompactNode{tree: t, id: t.nodes[i].id})
+		}
+	}
+	return nodes
+}
+
+func (t *CompactTree) Children(n node.Node) node.Nodes {
+	if n == nil {
+		return nil
+	}
+	var uintID uint64
+	if cn, ok := n.(*CompactNode); ok {
+		uintID = cn.id
+	} else {
+		uintID = t.ID(string(n.ID()))
+	}
+
+	if uintID == 0 {
+		return nil
+	}
+
+	childrenIDs := t.GetChildIDs(uintID)
+	children := make(node.Nodes, len(childrenIDs))
+	for i, cid := range childrenIDs {
+		children[i] = &CompactNode{tree: t, id: cid}
+	}
+	return children
+}
+
+func (t *CompactTree) Parent(n node.Node) node.Node {
+	if n == nil {
+		return nil
+	}
+	var uintID uint64
+	if cn, ok := n.(*CompactNode); ok {
+		uintID = cn.id
+	} else {
+		uintID = t.ID(string(n.ID()))
+	}
+
+	if uintID == 0 {
+		return nil
+	}
+
+	parentID := t.GetParentID(uintID)
+	if parentID == 0 {
+		return nil
+	}
+	return &CompactNode{tree: t, id: parentID}
+}
+
+func (t *CompactTree) Roots() node.Nodes {
+	roots := make(node.Nodes, 0)
+	for i := range t.nodes {
+		if t.nodes[i].parentID == 0 && !t.nodes[i].deleted {
+			roots = append(roots, &CompactNode{tree: t, id: t.nodes[i].id})
+		}
+	}
+	return roots
+}
+
+// Root returns the root node (ID = 1)
+func (t *CompactTree) Root() node.Node {
+	return t.Node("/")
+}
+
+// GetChildIDs returns all child IDs for a given node ID
+func (t *CompactTree) GetChildIDs(id uint64) []uint64 {
+	node := t.GetTreeNode(id)
+	if node == nil {
+		return nil
+	}
+	return node.children
+}
+
+// GetParentID returns the parent ID for a given node ID (0 if root)
+func (t *CompactTree) GetParentID(id uint64) uint64 {
+	node := t.GetTreeNode(id)
+	if node == nil {
+		return 0
+	}
+	return node.parentID
+}
+
+// Length returns the number of nodes in the tree
+func (t *CompactTree) Length() int {
+	return len(t.nodes)
+}
+
+// Name returns the name of a node
+func (t *CompactTree) Name(id uint64) string {
+	node := t.GetTreeNode(id)
+	if node == nil {
+		return ""
+	}
+	return t.stringPool.Get(node.nameIdx)
+}
+
+// FileType returns the file type of a node
+func (t *CompactTree) FileType(id uint64) file.Type {
+	node := t.GetTreeNode(id)
+	if node == nil {
+		return file.TypeIrregular
+	}
+	return node.fileType
+}
+
+// Reference returns the file reference of a node
+func (t *CompactTree) Reference(id uint64) *file.Reference {
+	node := t.GetTreeNode(id)
+	if node == nil {
+		return nil
+	}
+	return t.refPool.Get(node.refIdx)
+}
+
+// LinkPath returns the link path of a node
+func (t *CompactTree) LinkPath(id uint64) string {
+	node := t.GetTreeNode(id)
+	if node == nil {
+		return ""
+	}
+	return t.stringPool.Get(node.linkIdx)
+}
+
+// StringPool returns the string pool for path reconstruction
+func (t *CompactTree) StringPool() *StringPool {
+	return t.stringPool
+}
+
+// Copy returns a copy of the compact tree
+func (t *CompactTree) Copy() *CompactTree {
+	newTree := NewCompactTree()
+	newTree.nodes = make([]TreeNode, len(t.nodes))
+	copy(newTree.nodes, t.nodes)
+	for k, v := range t.pathToID {
+		newTree.pathToID[k] = v
+	}
+	newTree.stringPool = t.stringPool.Copy()
+	newTree.refPool = t.refPool.Copy()
+	newTree.nextID = t.nextID
+	return newTree
+}
+
+// Path reconstructs the full path for a node by walking up the parent chain
+func (t *CompactTree) Path(id uint64) string {
+	if id == 0 {
+		return ""
+	}
+
+	// Collect names by walking up the parent chain
+	names := make([]string, 0)
+	currentID := id
+
+	for currentID != 0 {
+		node := t.GetTreeNode(currentID)
+		if node == nil {
+			break
+		}
+		name := t.Name(currentID)
+		names = append(names, name)
+		currentID = node.parentID
+	}
+
+	// Reverse the names to get the path from root
+	// names are [basename, parent, ..., root]
+	// need to build /root/parent/basename
+	var parts []string
+	for i := len(names) - 1; i >= 0; i-- {
+		name := names[i]
+		if name != "" && name != "/" {
+			parts = append(parts, name)
+		}
+	}
+
+	return "/" + strings.Join(parts, "/")
+}
+
+func (t *CompactTree) invalidatePathCache(id uint64) {
+	// No-op: pathCache removed to save memory
+	// Path is reconstructed on demand via StringPool lookup
+}
+
+// RemoveNode removes a node and all its descendants from the tree
+func (t *CompactTree) RemoveNode(id uint64) ([]uint64, error) {
+	node := t.GetTreeNode(id)
+	if node == nil || node.deleted {
+		return nil, fmt.Errorf("node %d not found", id)
+	}
+
+	// Remove from pathToID first (before recursion) to avoid re-adding this node
+	path := t.Path(id)
+	delete(t.pathToID, path)
+
+	removedIDs := make([]uint64, 0)
+
+	// Recursively remove children first
+	// Note: we need to copy the children slice because RemoveNode will modify it in the parent
+	children := make([]uint64, len(node.children))
+	copy(children, node.children)
+	for _, childID := range children {
+		ids, err := t.RemoveNode(childID)
+		if err == nil {
+			removedIDs = append(removedIDs, ids...)
+		}
+	}
+
+	// Remove from parent's children list
+	if node.parentID != 0 {
+		parent := t.GetTreeNode(node.parentID)
+		if parent != nil {
+			for i, childID := range parent.children {
+				if childID == id {
+					parent.children = append(parent.children[:i], parent.children[i+1:]...)
+					break
+				}
+			}
+		}
+	}
+
+	// Mark as deleted
+	node.deleted = true
+	removedIDs = append(removedIDs, id)
+
+	return removedIDs, nil
+}
+
+// Replace updates an existing node's data
+func (t *CompactTree) Replace(id uint64, name string, fileType file.Type, ref *file.Reference, linkPath string) error {
+	node := t.GetTreeNode(id)
+	if node == nil || node.deleted {
+		return fmt.Errorf("node %d not found", id)
+	}
+
+	// Normalize root name
+	if id == 1 && (name == "/" || name == "") {
+		name = ""
+	}
+
+	// Get old path from pathToID before it's potentially removed
+	var oldPathKey string
+	for k, v := range t.pathToID {
+		if v == id {
+			oldPathKey = k
+			break
+		}
+	}
+	t.invalidatePathCache(id)
+
+	node.nameIdx = t.stringPool.Intern(name)
+	node.fileType = fileType
+	node.refIdx = t.refPool.Add(ref)
+	if linkPath != "" {
+		node.linkIdx = t.stringPool.Intern(linkPath)
+	} else {
+		node.linkIdx = 0
+	}
+
+	// Invalidate path cache for this node and all children
+	t.invalidatePathCache(id)
+
+	// Update pathToID mapping
+	if oldPathKey != "" {
+		delete(t.pathToID, oldPathKey)
+	}
+	newPath := t.Path(id)
+	t.pathToID[newPath] = id
+
+	return nil
+}
+
+// SetPath sets the path-to-ID mapping for a node
+// This should be called after adding a node
+func (t *CompactTree) SetPath(path string, id uint64) {
+	t.pathToID[path] = id
+}
+
+// AddFile adds a file node at the given path
+// Creates parent directories if they don't exist
+func (t *CompactTree) AddFile(realPath string, fileType file.Type, ref *file.Reference, linkPath string) (uint64, error) {
+	realPath = path.Clean(realPath)
+	// Check if path already exists
+	if id, ok := t.pathToID[realPath]; ok {
+		node := t.GetTreeNode(id)
+		if node.fileType != fileType {
+			return 0, fmt.Errorf("path %q exists but has different type", realPath)
+		}
+		// Update the reference if a new one is provided (for merge operations)
+		if ref != nil {
+			node.refIdx = t.refPool.Add(ref)
+			if linkPath != "" {
+				node.linkIdx = t.stringPool.Intern(linkPath)
+			} else {
+				node.linkIdx = 0
+			}
+			t.invalidatePathCache(id)
+		}
+		return id, nil
+	}
+
+	// Get or create parent directory
+	filePath := file.Path(realPath)
+	parentPath, err := filePath.ParentPath()
+	if err != nil {
+		return 0, fmt.Errorf("invalid path %q: %w", realPath, err)
+	}
+
+	_, err = t.AddDir(string(parentPath), nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create parent directory for %q: %w", realPath, err)
+	}
+
+	parentID := t.pathToID[string(parentPath)]
+	if parentID == 0 {
+		return 0, fmt.Errorf("parent directory not found for %q", realPath)
+	}
+
+	// Create the file node
+	basename := filePath.Basename()
+	newID, err := t.AddChild(parentID, basename, fileType, ref, linkPath)
+	if err != nil {
+		return 0, err
+	}
+
+	t.pathToID[realPath] = newID
+	return newID, nil
+}
+
+// AddDir adds a directory node at the given path
+// Creates parent directories if they don't exist
+func (t *CompactTree) AddDir(realPath string, ref *file.Reference) (uint64, error) {
+	realPath = path.Clean(realPath)
+	// Check if path already exists
+	if id, ok := t.pathToID[realPath]; ok {
+		node := t.GetTreeNode(id)
+		if node.fileType != file.TypeDirectory {
+			return 0, fmt.Errorf("path %q exists but is not a directory", realPath)
+		}
+		// Update the reference if a new one is provided (for merge operations)
+		if ref != nil {
+			node.refIdx = t.refPool.Add(ref)
+			t.invalidatePathCache(id)
+		}
+		return id, nil
+	}
+
+	// Split path into components
+	parts := splitPath(realPath)
+	if len(parts) == 0 {
+		return 0, fmt.Errorf("invalid path: %q", realPath)
+	}
+
+	var parentID uint64
+	currentPath := ""
+
+	for _, part := range parts {
+		if part == "" {
+			// Root node
+			if t.nextID != 1 {
+				parentID = 1
+				currentPath = "/"
+				continue
+			}
+			rootID, err := t.AddRoot("", file.TypeDirectory, ref)
+			if err != nil {
+				return 0, err
+			}
+			parentID = rootID
+			t.pathToID["/"] = rootID
+			currentPath = "/"
+			continue
+		}
+
+		// Build current path
+		if currentPath == "/" {
+			currentPath = "/" + part
+		} else {
+			currentPath += "/" + part
+		}
+
+		// Check if node exists
+		if id, ok := t.pathToID[currentPath]; ok {
+			node := t.GetTreeNode(id)
+			if node.fileType != file.TypeDirectory {
+				return 0, fmt.Errorf("path %q exists but is not a directory", currentPath)
+			}
+			parentID = id
+			continue
+		}
+
+		// Create directory node
+		id, err := t.AddChild(parentID, part, file.TypeDirectory, nil, "")
+		if err != nil {
+			return 0, err
+		}
+		t.pathToID[currentPath] = id
+		parentID = id
+	}
+
+	// If this was the final node, update its reference if provided
+	if ref != nil {
+		node := t.GetTreeNode(parentID)
+		node.refIdx = t.refPool.Add(ref)
+	}
+
+	return parentID, nil
+}
+
+// splitPath cleans a path and splits it into components.
+// The first component is always "" if the path is absolute.
+func splitPath(p string) []string {
+	if p == "" {
+		return []string{}
+	}
+	// Use path.Clean to handle multiple slashes and trailing slashes
+	cleaned := path.Clean(p)
+	if cleaned == "/" {
+		return []string{""}
+	}
+
+	return strings.Split(cleaned, "/")
+}

--- a/pkg/tree/compact_tree_test.go
+++ b/pkg/tree/compact_tree_test.go
@@ -1,0 +1,288 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/anchore/stereoscope/pkg/file"
+)
+
+func TestNewCompactTree(t *testing.T) {
+	tree := NewCompactTree()
+	if tree == nil {
+		t.Fatal("NewCompactTree returned nil")
+	}
+	if tree.Length() != 0 {
+		t.Fatalf("expected empty tree, got %d nodes", tree.Length())
+	}
+}
+
+func TestAddRoot(t *testing.T) {
+	tree := NewCompactTree()
+	ref := file.NewFileReference("/")
+
+	id, err := tree.AddRoot("", file.TypeDirectory, ref)
+	if err != nil {
+		t.Fatalf("AddRoot failed: %v", err)
+	}
+
+	if id != 1 {
+		t.Fatalf("expected root ID 1, got %d", id)
+	}
+
+	if tree.Length() != 1 {
+		t.Fatalf("expected 1 node, got %d", tree.Length())
+	}
+
+	if tree.Root() == nil {
+		t.Fatal("Root returned nil")
+	}
+
+	if tree.FileType(id) != file.TypeDirectory {
+		t.Fatalf("expected directory, got %v", tree.FileType(id))
+	}
+}
+
+func TestAddRootDuplicates(t *testing.T) {
+	tree := NewCompactTree()
+	ref := file.NewFileReference("/")
+
+	_, err := tree.AddRoot("", file.TypeDirectory, ref)
+	if err != nil {
+		t.Fatalf("first AddRoot failed: %v", err)
+	}
+
+	_, err = tree.AddRoot("", file.TypeDirectory, ref)
+	if err == nil {
+		t.Error("expected error for duplicate root")
+	}
+}
+
+func TestAddChild(t *testing.T) {
+	tree := NewCompactTree()
+	ref := file.NewFileReference("/")
+
+	rootID, err := tree.AddRoot("", file.TypeDirectory, ref)
+	if err != nil {
+		t.Fatalf("AddRoot failed: %v", err)
+	}
+
+	childRef := file.NewFileReference("/test.txt")
+	childID, err := tree.AddChild(rootID, "test.txt", file.TypeRegular, childRef, "")
+	if err != nil {
+		t.Fatalf("AddChild failed: %v", err)
+	}
+
+	if childID != 2 {
+		t.Fatalf("expected child ID 2, got %d", childID)
+	}
+
+	if tree.Length() != 2 {
+		t.Fatalf("expected 2 nodes, got %d", tree.Length())
+	}
+
+	// Check parent relationship
+	if tree.GetParentID(childID) != rootID {
+		t.Error("child parent is incorrect")
+	}
+
+	// Check children
+	children := tree.GetChildIDs(rootID)
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(children))
+	}
+
+	if children[0] != childID {
+		t.Fatalf("expected child ID %d, got %d", childID, children[0])
+	}
+
+	// Check node retrieval
+	child := tree.GetTreeNode(childID)
+	if child == nil {
+		t.Fatal("Node returned nil for child")
+	}
+
+	if tree.Name(childID) != "test.txt" {
+		t.Fatalf("expected name \"test.txt\", got %q", tree.Name(childID))
+	}
+
+	if tree.FileType(childID) != file.TypeRegular {
+		t.Fatalf("expected regular file, got %v", tree.FileType(childID))
+	}
+}
+
+func TestAddChildInvalidParent(t *testing.T) {
+	tree := NewCompactTree()
+	ref := file.NewFileReference("/test.txt")
+
+	_, err := tree.AddChild(999, "test.txt", file.TypeRegular, ref, "")
+	if err == nil {
+		t.Error("expected error for invalid parent ID")
+	}
+}
+
+func TestAddDir(t *testing.T) {
+	tree := NewCompactTree()
+	ref := file.NewFileReference("/usr/local/bin")
+
+	id, err := tree.AddDir("/usr/local/bin", ref)
+	if err != nil {
+		t.Fatalf("AddDir failed: %v", err)
+	}
+
+	if !tree.HasPath("/usr/local/bin") {
+		t.Error("HasPath returned false for path")
+	}
+
+	if tree.ID("/usr/local/bin") != id {
+		t.Error("ID returned wrong value for path")
+	}
+
+	// Verify intermediate directories were created
+	if !tree.HasPath("/") {
+		t.Error("root not created")
+	}
+	if !tree.HasPath("/usr") {
+		t.Error("/usr not created")
+	}
+	if !tree.HasPath("/usr/local") {
+		t.Error("/usr/local not created")
+	}
+}
+
+func TestAddDirDuplicate(t *testing.T) {
+	tree := NewCompactTree()
+
+	ref1 := file.NewFileReference("/test")
+	id1, err := tree.AddDir("/test", ref1)
+	if err != nil {
+		t.Fatalf("first AddDir failed: %v", err)
+	}
+
+	ref2 := file.NewFileReference("/test")
+	id2, err := tree.AddDir("/test", ref2)
+	if err != nil {
+		t.Fatalf("second AddDir failed: %v", err)
+	}
+
+	if id1 != id2 {
+		t.Fatalf("expected same ID %d, got %d", id1, id2)
+	}
+
+	if tree.Length() != 2 {
+		t.Fatalf("expected 2 nodes, got %d", tree.Length())
+	}
+}
+
+func TestAddFile(t *testing.T) {
+	tree := NewCompactTree()
+	ref := file.NewFileReference("/test/file.txt")
+
+	id, err := tree.AddFile("/test/file.txt", file.TypeRegular, ref, "")
+	if err != nil {
+		t.Fatalf("AddFile failed: %v", err)
+	}
+
+	if !tree.HasPath("/test/file.txt") {
+		t.Error("HasPath returned false for file")
+	}
+
+	if tree.FileType(id) != file.TypeRegular {
+		t.Fatalf("expected regular file, got %v", tree.FileType(id))
+	}
+
+	// Verify parent directory was created
+	if !tree.HasPath("/test") {
+		t.Error("parent directory not created")
+	}
+
+	if tree.FileType(tree.ID("/test")) != file.TypeDirectory {
+		t.Error("parent is not a directory")
+	}
+}
+
+func TestAddSymlink(t *testing.T) {
+	tree := NewCompactTree()
+	ref := file.NewFileReference("/test/link")
+
+	id, err := tree.AddFile("/test/link", file.TypeSymLink, ref, "/target.txt")
+	if err != nil {
+		t.Fatalf("AddFile (symlink) failed: %v", err)
+	}
+
+	if tree.FileType(id) != file.TypeSymLink {
+		t.Fatalf("expected symlink, got %v", tree.FileType(id))
+	}
+
+	if tree.LinkPath(id) != "/target.txt" {
+		t.Fatalf("expected link path \"/target.txt\", got %q", tree.LinkPath(id))
+	}
+}
+
+func TestDeepTree(t *testing.T) {
+	tree := NewCompactTree()
+
+	// Create a deep hierarchy: /a/b/c/d/e/f
+	path := "/a/b/c/d/e/f"
+	tree.AddDir(path, nil)
+
+	for _, p := range []string{"/", "/a", "/a/b", "/a/b/c", "/a/b/c/d", "/a/b/c/d/e", "/a/b/c/d/e/f"} {
+		if !tree.HasPath(p) {
+			t.Errorf("expected path %q to exist", p)
+		}
+	}
+
+	if tree.Length() != 7 {
+		t.Fatalf("expected 7 nodes, got %d", tree.Length())
+	}
+}
+
+func TestStringPool(t *testing.T) {
+	tree := NewCompactTree()
+	tree.AddRoot("", file.TypeDirectory, nil)
+	tree.AddChild(1, "file1.txt", file.TypeRegular, nil, "")
+	tree.AddChild(1, "file1.txt", file.TypeRegular, nil, "")
+
+	// Same string should use same index
+	node1 := tree.GetTreeNode(2)
+	node2 := tree.GetTreeNode(3)
+
+	if node1.nameIdx != node2.nameIdx {
+		t.Error("same string should have same index in pool")
+	}
+
+	// Verify pool has only two entries ("" and "file1.txt")
+	if tree.stringPool.Len() != 2 {
+		t.Fatalf("expected 2 strings in pool, got %d", tree.stringPool.Len())
+	}
+}
+
+func TestReferencePool(t *testing.T) {
+	tree := NewCompactTree()
+	ref := file.NewFileReference("/test")
+
+	tree.AddRoot("", file.TypeDirectory, ref)
+	tree.AddChild(1, "file1", file.TypeRegular, ref, "")
+	tree.AddChild(1, "file2", file.TypeRegular, ref, "")
+
+	// Same reference should use same index
+	node1 := tree.GetTreeNode(2)
+	node2 := tree.GetTreeNode(3)
+
+	if node1.refIdx != node2.refIdx {
+		t.Error("same reference should have same index in pool")
+	}
+
+	// Verify pool has only one entry
+	if tree.refPool.Len() != 1 {
+		t.Fatalf("expected 1 reference in pool, got %d", tree.refPool.Len())
+	}
+}
+
+func BenchmarkCompactTreeAdd(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		tree := NewCompactTree()
+		for j := 0; j < 10000; j++ {
+			tree.AddDir("/nested/deep/path", nil)
+		}
+	}
+}

--- a/pkg/tree/reference_pool.go
+++ b/pkg/tree/reference_pool.go
@@ -1,0 +1,84 @@
+package tree
+
+import (
+	"sync"
+
+	"github.com/anchore/stereoscope/pkg/file"
+)
+
+// ReferencePool is a pool for deduplicating file references
+type ReferencePool struct {
+	refs []*file.Reference
+	mu   sync.RWMutex
+}
+
+func NewReferencePool() *ReferencePool {
+	return &ReferencePool{
+		refs: make([]*file.Reference, 0),
+	}
+}
+
+// Add returns the index for the given reference.
+// If an equivalent reference already exists in the pool, the existing index is returned.
+// If the reference is nil, returns 0.
+func (p *ReferencePool) Add(ref *file.Reference) uint32 {
+	if ref == nil {
+		return 0
+	}
+
+	p.mu.RLock()
+	// Try to find existing reference by ID
+	for i, r := range p.refs {
+		if r != nil && r.ID() == ref.ID() {
+			p.mu.RUnlock()
+			return uint32(i + 1)
+		}
+	}
+	p.mu.RUnlock()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Check again since another goroutine might have added it
+	for i, r := range p.refs {
+		if r != nil && r.ID() == ref.ID() {
+			return uint32(i + 1)
+		}
+	}
+
+	idx := len(p.refs)
+	p.refs = append(p.refs, ref)
+	return uint32(idx + 1)
+}
+
+// Get returns the reference at the given index.
+// If idx is 0, returns nil.
+func (p *ReferencePool) Get(idx uint32) *file.Reference {
+	if idx == 0 {
+		return nil
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if int(idx-1) < len(p.refs) {
+		return p.refs[idx-1]
+	}
+	return nil
+}
+
+// Len returns the number of references in the pool
+func (p *ReferencePool) Len() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.refs)
+}
+
+// Copy returns a copy of the reference pool
+func (p *ReferencePool) Copy() *ReferencePool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	newPool := NewReferencePool()
+	newPool.refs = make([]*file.Reference, len(p.refs))
+	copy(newPool.refs, p.refs)
+	return newPool
+}

--- a/pkg/tree/string_pool.go
+++ b/pkg/tree/string_pool.go
@@ -1,0 +1,74 @@
+package tree
+
+import (
+	"sync"
+)
+
+// StringPool is a simple interner for strings to avoid duplications
+type StringPool struct {
+	strings []string
+	index   map[string]uint32
+	mu      sync.RWMutex
+}
+
+func NewStringPool() *StringPool {
+	return &StringPool{
+		strings: make([]string, 0),
+		index:   make(map[string]uint32),
+	}
+}
+
+// Intern returns a canonical index for the given input string.
+// If the string already exists in the pool, the existing index is returned.
+// Otherwise, the string is added to the pool and its new index is returned.
+func (p *StringPool) Intern(s string) uint32 {
+	p.mu.RLock()
+	if idx, ok := p.index[s]; ok {
+		p.mu.RUnlock()
+		return idx
+	}
+	p.mu.RUnlock()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Check again since another goroutine might have added it while we released the read lock
+	if idx, ok := p.index[s]; ok {
+		return idx
+	}
+
+	idx := uint32(len(p.strings))
+	p.strings = append(p.strings, s)
+	p.index[s] = idx
+	return idx
+}
+
+// Get returns the string at the given index.
+func (p *StringPool) Get(idx uint32) string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if int(idx) < len(p.strings) {
+		return p.strings[idx]
+	}
+	return ""
+}
+
+// Len returns the number of unique strings in the pool
+func (p *StringPool) Len() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.strings)
+}
+
+// Copy returns a copy of the string pool
+func (p *StringPool) Copy() *StringPool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	newPool := NewStringPool()
+	newPool.strings = make([]string, len(p.strings))
+	copy(newPool.strings, p.strings)
+	for k, v := range p.index {
+		newPool.index[k] = v
+	}
+	return newPool
+}


### PR DESCRIPTION
Replace map-based tree structure with compact array implementation to dramatically reduce memory overhead for container image file trees.
Real world test with `/usr/bin/time go run cmd/syft/main.go scan gitlab/gitlab-ee:latest -o syft-json=/dev/null` shows a significant memory reduction:
```
65.28user 11.02system 0:52.32elapsed 145%CPU (0avgtext+0avgdata 1764408maxresident)k
672inputs+32outputs (0major+675384minor)pagefaults 0swaps
```
to:
```
82.73user 11.24system 1:10.44elapsed 133%CPU (0avgtext+0avgdata 1478712maxresident)k
0inputs+0outputs (0major+601836minor)pagefaults 0swaps
```