### PR TITLE
fix: enable Docker API version negotiation

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -17,6 +17,7 @@ import (
 func GetClient() (*client.Client, error) {
 	var clientOpts = []client.Opt{
 		client.FromEnv,
+		client.WithAPIVersionNegotiation(),
 	}
 
 	host := os.Getenv("DOCKER_HOST")


### PR DESCRIPTION
## Summary

- Add `client.WithAPIVersionNegotiation()` to the Docker client options in `GetClient()`

## Problem

The Docker client in `internal/docker/client.go` uses `client.FromEnv` but does not enable API version negotiation. This means the client defaults to the API version compiled into the `moby/moby` library (currently `v1.53`).

When stereoscope connects to an older Docker daemon — for example one that only supports API `v1.43` — the daemon rejects requests with:

```
Error response from daemon: client version 1.53 is too new. Maximum supported API version is 1.43
```

This breaks tools like grype when scanning images on hosts running older Docker versions (e.g. Docker 25.x, 26.x, Synology DSM).

## Fix

Adding `client.WithAPIVersionNegotiation()` makes the client ping the daemon on first request and automatically downgrade to the daemon's supported API version. This matches the behavior of the Docker CLI itself and grype's own Docker client in `cmd/grype/cli/commands/completion.go`, which already uses `WithAPIVersionNegotiation()`.

## Test plan

- [x] `go build ./internal/docker/` compiles successfully
- [x] `go test ./internal/docker/` passes
- [ ] Verified scanning works against Docker daemon with API v1.43