### PR TITLE
chore: fix format string in unit tests

### DIFF
--- a/pkg/file/id_set_test.go
+++ b/pkg/file/id_set_test.go
@@ -55,7 +55,7 @@ func TestIDSet_Add(t *testing.T) {
 			tt.s.Add(tt.args.ids...)
 			for _, id := range tt.args.ids {
 				if !tt.s.Contains(id) {
-					t.Errorf("expected set to contain %q", id)
+					t.Errorf("expected set to contain %d", id)
 				}
 			}
 		})
@@ -85,12 +85,12 @@ func TestIDSet_Remove(t *testing.T) {
 			tt.s.Remove(tt.args.ids...)
 			for _, id := range tt.args.ids {
 				if tt.s.Contains(id) {
-					t.Errorf("expected set to NOT contain %q", id)
+					t.Errorf("expected set to NOT contain %d", id)
 				}
 			}
 			for _, id := range tt.expected {
 				if !tt.s.Contains(id) {
-					t.Errorf("expected set to contain %q", id)
+					t.Errorf("expected set to contain %d", id)
 				}
 			}
 		})


### PR DESCRIPTION
It becomes a go vet error in later versions. Fix it ahead of upgrading go.

Some places in the codebase we have `t.Errorf("expected set to NOT contain %q", id)` where id is a string, in which case `%q` makes sense. Some places we have the same assertion, but id is an int (uint64 I think), which makes `%q` a go vet error in later versions of go.