### PR TITLE
chore(deps): restore minimum go version to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/stereoscope
 
-go 1.26.2
+go 1.25.6
 
 require (
 	github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible


### PR DESCRIPTION
Restores the go directive in go.mod to 1.25.6 (pre-#572). Bumped in #572 (merge aeb4170b528f8ccac4444033f2662ee1b965ce75).