### PR TITLE
feat: log when registry transport is configured insecurely

### DIFF
--- a/pkg/image/containerd/daemon_provider.go
+++ b/pkg/image/containerd/daemon_provider.go
@@ -497,6 +497,7 @@ func (p *daemonImageProvider) trackSaveProgress(size int64) *daemonProvideProgre
 func prepareReferenceOptions(registryOptions image.RegistryOptions) []name.Option {
 	var options []name.Option
 	if registryOptions.InsecureUseHTTP {
+		log.Debug("HTTP transport is enabled for registry communication")
 		options = append(options, name.Insecure)
 	}
 	return options

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -166,6 +166,7 @@ func newErrPlatformMismatch(platform *image.Platform, err error) *image.ErrPlatf
 func prepareReferenceOptions(registryOptions image.RegistryOptions) []name.Option {
 	var options []name.Option
 	if registryOptions.InsecureUseHTTP {
+		log.Debug("HTTP transport is enabled for registry communication")
 		options = append(options, name.Insecure)
 	}
 	return options

--- a/pkg/image/registry_options.go
+++ b/pkg/image/registry_options.go
@@ -82,6 +82,10 @@ func (r RegistryOptions) Authenticator(registry string) authn.Authenticator {
 
 // TLSConfig selects the tls.Config object for handling TLS authentication with a registry.
 func (r RegistryOptions) TLSConfig(registry string) (*tls.Config, error) {
+	if r.InsecureSkipTLSVerify {
+		log.Debugf("TLS verification is disabled for registry %q", registry)
+	}
+
 	tlsOptions := r.tlsOptions(registry)
 
 	if tlsOptions == nil {


### PR DESCRIPTION
## Summary

- Emit debug-level logs at the points where insecure registry options are actually applied
- `TLSConfig` logs per-registry when `InsecureSkipTLSVerify` is set
- `prepareReferenceOptions` (in both oci and containerd providers) logs when `InsecureUseHTTP` causes `name.Insecure` to be applied to the reference
- Pure observability — no behavior change

This is the second half of [anchore/grype#3101](https://github.com/anchore/grype/issues/3101). The first half (a one-time CLI warning at config-load time) is in [anchore/grype#3396](https://github.com/anchore/grype/pull/3396); these debug logs complement it by surfacing the actual per-registry application of the flags during low-level tracing.

## Details

Three small additions, 6 lines total:

- [`pkg/image/registry_options.go`](pkg/image/registry_options.go): `log.Debugf` at the top of `TLSConfig` when `InsecureSkipTLSVerify` is true. Includes the registry name via `%q` since `TLSConfig(registry string)` already has it.
- [`pkg/image/oci/registry_provider.go`](pkg/image/oci/registry_provider.go): `log.Debug` inside the existing `if registryOptions.InsecureUseHTTP` branch in `prepareReferenceOptions`.
- [`pkg/image/containerd/daemon_provider.go`](pkg/image/containerd/daemon_provider.go): identical `log.Debug` for the same function (it exists as a duplicate in this provider).

Log style and level match existing patterns in the same files (e.g. `log.Tracef("using registry credentials from config index %d", ...)` and `log.Debugf("pulling %s image=%q", ...)`).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/image/...` — all related tests pass (`Test_prepareReferenceOptions`, registry/TLS tests)
- [x] One pre-existing test failure on Windows (`TestRegistryOptions_TLSConfig_rootCAs/add_root_certs_from_dir`) — confirmed identical failure on clean upstream main, unrelated to this change. Likely a Windows path/glob test issue.

No new tests added: debug logs are observability-only and not typically unit-tested in this codebase (consistent with how the existing `log.Tracef`/`log.Debugf` calls at the same sites have no dedicated tests).