### PR TITLE
Tighten workflow permissions and update release shape

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -8,7 +8,6 @@ tools:
   - name: binny
     version:
       want: v0.13.0
-      cooldown: 0  # no cooldown period for internal tools
     method: github-release
     with:
       repo: anchore/binny
@@ -17,7 +16,6 @@ tools:
   - name: chronicle
     version:
       want: v0.8.0
-      cooldown: 0  # no cooldown period for internal tools
     method: github-release
     with:
       repo: anchore/chronicle

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,11 @@
 name: "Release"
 
-permissions:
-  contents: read
+permissions: {}
+
+# there should never be two releases in progress at the same time
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 on:
   workflow_dispatch:
@@ -11,74 +15,24 @@ on:
         required: true
 
 jobs:
-  quality-gate:
-    environment: release
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-        with:
-          persist-credentials: false
 
-      - name: Check if tag already exists
-        # note: this will fail if the tag already exists
-        run: |
-          [[ "${VERSION}" == v* ]] || (echo "version '${VERSION}' does not have a 'v' prefix" && exit 1)
-          git tag "${VERSION}"
-        env:
-          VERSION: ${{ github.event.inputs.version }}
+  version-available:
+    uses: anchore/workflows/.github/workflows/check-version-available.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      version: ${{ github.event.inputs.version }}
 
-      - name: Check static analysis results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: static-analysis
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "Static analysis"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check unit test results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: unit
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "Unit tests"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check integration test results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: integration
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "Integration tests"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check snapshot build
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: snapshot
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "Build snapshot artifacts"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Quality gate
-        if: steps.static-analysis.outputs.conclusion != 'success' || steps.unit.outputs.conclusion != 'success' || steps.integration.outputs.conclusion != 'success' || steps.snapshot.outputs.conclusion != 'success'
-        run: |
-          echo "Static Analysis Status: ${STATIC_ANALYSIS_STATUS}"
-          echo "Unit Test Status: ${UNIT_TEST_STATUS}"
-          echo "Integration Test Status: ${INTEGRATION_TEST_STATUS}"
-          echo "Build snapshot artifacts Status: ${SNAPSHOT_STATUS}"
-          false
-        env:
-          STATIC_ANALYSIS_STATUS: ${{ steps.static-analysis.outputs.conclusion }}
-          UNIT_TEST_STATUS: ${{ steps.unit.outputs.conclusion }}
-          INTEGRATION_TEST_STATUS: ${{ steps.integration.outputs.conclusion }}
-          SNAPSHOT_STATUS: ${{ steps.snapshot.outputs.conclusion }}
+  check-gate:
+    permissions:
+      checks: read   # required for getting the status of specific check names
+    uses: anchore/workflows/.github/workflows/check-gate.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      # these are checks that should be run on pull-request and merges to main.
+      # we do NOT want to kick off a release if these have not been verified on main.
+      # Please see the validations.yaml workflow for the names that should be used here.
+      checks: '["Build snapshot artifacts", "Integration tests", "Static analysis", "Unit tests"]'
 
   release:
-    needs: [quality-gate]
+    needs: [check-gate, version-available]
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -12,8 +12,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -16,14 +16,15 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
 
   Static-Analysis:
     name: "Static analysis"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -38,6 +39,8 @@ jobs:
   Unit-Test:
     name: "Unit tests"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -57,6 +60,8 @@ jobs:
   Integration-Test:
     name: "Integration tests"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -140,6 +145,8 @@ jobs:
   Build-Snapshot-Artifacts:
     name: "Build snapshot artifacts"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Brings workflows into compliance with current standards: empty top-level permissions, job-scoped contents:read where needed, canonical check-gate/check-version-available pattern in release.yaml, and removes the cooldown:0 bypass on binny and chronicle in .binny.yaml.

Changes:
- set top-level `permissions: {}` in release.yaml, validate-github-actions.yaml, and validations.yaml
- push `contents: read` down to job level in validations.yaml jobs
- replace bespoke quality-gate job in release.yaml with reusable check-version-available and check-gate workflows (anchore/workflows v0.4.0)
- add `concurrency: group: release` to release.yaml
- remove `cooldown: 0` overrides on binny and chronicle tools in .binny.yaml

Notes:
- attestation steps and secrets-outside-env warnings are out of scope and addressed separately