### PR TITLE
fix: close layer readers to not block on registry limiter

### DIFF
--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -116,11 +116,13 @@ func (l *Layer) uncompressedCache(uncompressedLayersCacheDir string) (string, er
 	if err != nil {
 		return "", err
 	}
+	defer rawReader.Close()
 
 	fh, err := os.Create(path)
 	if err != nil {
 		return "", fmt.Errorf("unable to create layer cache dir=%q : %w", path, err)
 	}
+	defer fh.Close()
 
 	if _, err := io.Copy(fh, rawReader); err != nil {
 		return "", fmt.Errorf("unable to populate layer cache dir=%q : %w", path, err)

--- a/pkg/image/layer_test.go
+++ b/pkg/image/layer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
 	v1Types "github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/require"
 )
@@ -53,6 +54,53 @@ func fakeLayer(mediaType v1Types.MediaType, err error) v1.Layer {
 		mediaType: mediaType,
 		err:       err,
 	}
+}
+
+// closeSpyLayer decorates a real v1.Layer, recording whether the reader returned by Uncompressed()
+// is closed. The reader still closes for real (Close is delegated), so only the observation is added.
+type closeSpyLayer struct {
+	v1.Layer
+	closed bool
+}
+
+func (l *closeSpyLayer) Uncompressed() (io.ReadCloser, error) {
+	rc, err := l.Layer.Uncompressed()
+	if err != nil {
+		return nil, err
+	}
+	return spyReadCloser{ReadCloser: rc, closed: &l.closed}, nil
+}
+
+type spyReadCloser struct {
+	io.ReadCloser
+	closed *bool
+}
+
+func (r spyReadCloser) Close() error {
+	*r.closed = true
+	return r.ReadCloser.Close()
+}
+
+// TestUncompressedCacheClosesReader guards against a regression where the reader returned by
+// layer.Uncompressed() was never closed.
+func TestUncompressedCacheClosesReader(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	require.NoError(t, err)
+
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.Len(t, layers, 1)
+
+	digest, err := layers[0].Digest()
+	require.NoError(t, err)
+
+	spy := &closeSpyLayer{Layer: layers[0]}
+	layer := Layer{layer: spy}
+	layer.Metadata.Digest = digest.String()
+
+	_, err = layer.uncompressedCache(t.TempDir())
+	require.NoError(t, err)
+	require.True(t, spy.closed, "expected uncompressedCache to close the layer reader to release the pull-limiter token")
 }
 
 func TestRead(t *testing.T) {


### PR DESCRIPTION
## Fix: layer reader leaks which causes a hang in image reads

On `main` `Layer.uncompressedCache` never closed the reader returned by `layer.Uncompressed()`

With go-containerregistry v0.21.6 this leak turns into a hang with image reads containing more than 4 layers.

`v0.21.6` of `go-containerregistry` introduced a pullLimiter in `pkg/v1/remote`. This bounds concurrent blob fetches to defaultJobs = 4. 

This PR closes that reader along with an unclosed file handle in `uncompressedCache.` Closing allows the token to be returned to the new limiter fixing the hang.

### Testing
I built grype against this branch and scanned a reported image from https://github.com/anchore/grype/issues/3492
`go run cmd/grype/main.go openjdk:27-ea-trixie -vvv --from registry` now passes with this patch on my local.

### TBD
There might be some further discussion on configuring/exposing the default concurrency from `go-containerregistry`

Currently it's set at 4: 
https://github.com/google/go-containerregistry/blob/6849394e8a65e2da1177d5b5b00e903551ada1c9/pkg/v1/remote/options.go#L105-L111