### PR TITLE
Remove references to make bootstrap

### DIFF
--- a/.github/scripts/trigger-release.sh
+++ b/.github/scripts/trigger-release.sh
@@ -7,7 +7,7 @@ normal=$(tput sgr0)
 GH_CLI=.tool/gh
 
 if ! [ -x "$(command -v $GH_CLI)" ]; then
-    echo "The GitHub CLI could not be found. run: make bootstrap"
+    echo "The GitHub CLI could not be found. Please install it to trigger a release."
     exit 1
 fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,13 +84,9 @@ Date:   Mon Aug 1 11:27:13 2020 -0400
 
 ## Test your changes
 
-This project has a `Makefile` which includes many helpers running both unit and integration tests. Although PRs will have automatic checks for these, it is useful to run them locally, ensuring they pass before submitting changes. Ensure you've bootstrapped once before running tests:
+This project has a `Makefile` (managed in [./.make/main.go](./.make/main.go) by [go-make](https://github.com/anchore/go-make)) which includes many helpers running both unit and integration tests. Run `make help` to see all the current make tasks.
 
-```text
-$ make bootstrap
-```
-
-You only need to bootstrap once. After the bootstrap process, you can run the tests as many times as needed:
+Although PRs will have automatic checks for these, it is useful to run them locally, ensuring they pass before submitting changes.
 
 ```text
 $ make unit

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -10,10 +10,6 @@ In order to test and develop in this repo you will need the following dependenci
 - containerd (for integration tests only)
 - skopeo (for integration tests only)
 
-After cloning the following step can help you get setup:
-1. run `make bootstrap` to download go mod dependencies, create the `/.tmp` dir, and download helper utilities.
-2. run `make help` to view the selection of developer commands in the Makefile
-
 The main make tasks for common static analysis and testing are `lint`, `format`, `lint-fix`, `unit`, and `integration`.
 
 See `make help` for all the current make tasks.


### PR DESCRIPTION
Remove references to `make bootstrap`, which as far as I can tell, no longer exists or is necessary.