### PR TITLE
file: do not treat a bare .wh. as a whiteout marker

### DIFF
--- a/pkg/file/path.go
+++ b/pkg/file/path.go
@@ -49,7 +49,8 @@ func (p Path) IsDirWhiteout() bool {
 
 // IsWhiteout indicates if the file basename has a whiteout prefix (which means that the file should be removed during squashing)
 func (p Path) IsWhiteout() bool {
-	return strings.HasPrefix(p.Basename(), WhiteoutPrefix)
+	basename := p.Basename()
+	return strings.HasPrefix(basename, WhiteoutPrefix) && basename != WhiteoutPrefix
 }
 
 // UnWhiteoutPath is a representation of the current path with no whiteout prefixes

--- a/pkg/file/path_test.go
+++ b/pkg/file/path_test.go
@@ -132,6 +132,14 @@ func TestPath_Whiteout(t *testing.T) {
 	if !path.IsWhiteout() {
 		t.Fatal("path should be a whiteout")
 	}
+
+	// a bare .wh. (the prefix with nothing after it) is not a valid whiteout marker:
+	// treating it as one makes UnWhiteoutPath resolve to the parent directory itself
+	path = "/some/path/to/.wh."
+
+	if path.IsWhiteout() {
+		t.Fatal("a bare .wh. should not be treated as a whiteout")
+	}
 }
 
 func TestPath_UnWhiteoutPath(t *testing.T) {

--- a/pkg/filetree/union_filetree_test.go
+++ b/pkg/filetree/union_filetree_test.go
@@ -93,6 +93,35 @@ func TestUnionFileTree_Squash(t *testing.T) {
 
 }
 
+func TestUnionFileTree_Squash_bareWhiteout(t *testing.T) {
+	// a bare .wh. (the whiteout prefix with no name after it) is not a valid whiteout
+	// marker. If it is treated as one, UnWhiteoutPath resolves to the parent directory
+	// itself and squashing deletes the whole parent instead of a single named sibling.
+	ut := NewUnionFileTree()
+	base := New()
+
+	base.AddFile("/etc/passwd")
+	base.AddFile("/etc/hostname")
+
+	top := New()
+	top.AddFile("/etc/" + file.WhiteoutPrefix)
+
+	ut.PushTree(base)
+	ut.PushTree(top)
+
+	squashed, err := ut.Squash()
+	if err != nil {
+		t.Fatal("could not squash trees", err)
+	}
+
+	if !squashed.HasPath(file.Path("/etc/passwd")) {
+		t.Error("expected /etc/passwd to survive a bare .wh. but it was deleted")
+	}
+	if !squashed.HasPath(file.Path("/etc/hostname")) {
+		t.Error("expected /etc/hostname to survive a bare .wh. but it was deleted")
+	}
+}
+
 func TestUnionFileTree_Squash_whiteout(t *testing.T) {
 	ut := NewUnionFileTree()
 	base := New()


### PR DESCRIPTION
`IsWhiteout` returns true for a basename of exactly `.wh.` (the whiteout prefix with nothing after it). `UnWhiteoutPath` then joins the parent directory with an empty name and returns the parent itself, so during squash a crafted layer entry has two effects, both reachable from untrusted image-layer content:

- `/etc/.wh.` deletes the entire `/etc` directory (and all its children) from the squashed tree, instead of a single named sibling.
- a `.wh.` at the image root resolves to `/`, so the merge calls remove on the root path and returns an error that aborts the whole `Squash`. Any consumer (a syft SBOM, a grype scan) then fails to process the image.

The fix requires a non-empty name after the prefix, so a bare `.wh.` is treated as an ordinary file. The opaque marker `.wh..wh..opq` is unaffected. I added a path test for the bare/normal/opaque cases and a squash test showing `/etc/.wh.` no longer wipes `/etc`.