### PR TITLE
fix(image): bind hardlinks to the file they name when indexing a layer

### DIFF
--- a/pkg/filetree/filetree.go
+++ b/pkg/filetree/filetree.go
@@ -554,7 +554,7 @@ func (t *FileTree) AddHardLink(realPath file.Path, linkPath file.Path) (*file.Re
 	if fna.HasFileNode() {
 		// this path already exists
 		if fna.FileNode.FileType != file.TypeHardLink {
-			return nil, fmt.Errorf("path=%q already exists but is NOT a symlink file", realPath)
+			return nil, fmt.Errorf("path=%q already exists but is NOT a hardlink file", realPath)
 		}
 		// this is a symlink file, provide a new or existing file.Reference
 		if fna.FileNode.Reference == nil {
@@ -585,7 +585,7 @@ func (t *FileTree) AddDir(realPath file.Path) (*file.Reference, error) {
 	if fna.HasFileNode() {
 		// this path already exists
 		if fna.FileNode.FileType != file.TypeDirectory {
-			return nil, fmt.Errorf("path=%q already exists but is NOT a symlink file", realPath)
+			return nil, fmt.Errorf("path=%q already exists but is NOT a directory", realPath)
 		}
 		// this is a directory, provide a new or existing file.Reference
 		if fna.FileNode.Reference == nil {

--- a/pkg/image/file_catalog.go
+++ b/pkg/image/file_catalog.go
@@ -60,6 +60,14 @@ func (c *FileCatalog) addImageReferences(id file.ID, l *Layer, opener file.Opene
 	}
 }
 
+// opener returns the opener for the given file ID, or nil if there is none.
+func (c *FileCatalog) opener(id file.ID) file.Opener {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.openerByID[id]
+}
+
 func (c *FileCatalog) Layer(f file.Reference) *Layer {
 	c.RLock()
 	defer c.RUnlock()

--- a/pkg/image/hardlink_semantics_test.go
+++ b/pkg/image/hardlink_semantics_test.go
@@ -456,3 +456,49 @@ func TestLayerRead_ConcurrentReadsShareCatalogSafely(t *testing.T) {
 		require.NoErrorf(t, err, "layer %d failed to read", i)
 	}
 }
+
+// TestHardLinkSemantics_AdoptionFallsBackOnMalformedArchives covers the shapes docker will never
+// emit but an untrusted image can still carry. None of them can be honoured, so each name must fall
+// back to what its own header says rather than adopt something it cannot be.
+func TestHardLinkSemantics_AdoptionFallsBackOnMalformedArchives(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []tarEntry
+	}{
+		{
+			name: "link name is not in this layer",
+			entries: []tarEntry{
+				{path: "hard", typeFlag: tar.TypeLink, linkPath: "does-not-exist"},
+			},
+		},
+		{
+			// "" cleans to the tree root, which the "./" member below gives a reference to adopt
+			name: "empty link name",
+			entries: []tarEntry{
+				{path: "./", typeFlag: tar.TypeDir},
+				{path: "a.txt", typeFlag: tar.TypeReg, contents: "CONTENTS"},
+				{path: "hard", typeFlag: tar.TypeLink, linkPath: ""},
+			},
+		},
+		{
+			// link(2) returns EPERM for a directory, so no real filesystem holds this
+			name: "link name is a directory",
+			entries: []tarEntry{
+				{path: "d/", typeFlag: tar.TypeDir},
+				{path: "hard", typeFlag: tar.TypeLink, linkPath: "d"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			img, err := tryReadImageFromLayers(t, layerFromTarEntries(t, tt.entries...))
+			require.NoError(t, err, "a malformed archive must not fail the read")
+
+			entry := catalogEntryForTest(t, img, "/hard")
+			assert.Equal(t, file.TypeHardLink, entry.Metadata.Type, "must keep the type its own header gives it")
+			assert.Equal(t, int64(0), entry.Metadata.Size(), "an un-adopted hardlink header has no data section")
+			assert.False(t, entry.Metadata.IsDir(), "a hardlink is never a directory")
+		})
+	}
+}

--- a/pkg/image/hardlink_semantics_test.go
+++ b/pkg/image/hardlink_semantics_test.go
@@ -2,9 +2,13 @@ package image
 
 import (
 	"archive/tar"
+	"fmt"
 	"io"
 	"io/fs"
+	"sync"
 	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -416,4 +420,39 @@ func TestHardLinkSemantics_AdoptedModeMatchesTarget(t *testing.T) {
 	// ...so nothing deriving a type from the mode can disagree with Type
 	assert.Equal(t, hardSym.Metadata.Type, file.TypeFromMode(hardSym.Metadata.Mode()),
 		"Type and TypeFromMode(Mode()) must describe the same thing")
+}
+
+// TestLayerRead_ConcurrentReadsShareCatalogSafely pins that Layer.Read may be called concurrently
+// against one shared FileCatalog, which is what the catalog's mutex is for. Indexing a hardlink
+// reads the catalog's openers, and a bare map read there races the writes from other layers: in Go
+// that is a fatal throw, not a recoverable error. Only meaningful under -race.
+func TestLayerRead_ConcurrentReadsShareCatalogSafely(t *testing.T) {
+	const layerCount = 8
+
+	layers := make([]v1.Layer, 0, layerCount)
+	for i := 0; i < layerCount; i++ {
+		// each layer both writes openers and, via the hardlink, reads them back
+		layers = append(layers, layerFromTarEntries(t,
+			tarEntry{path: fmt.Sprintf("file-%d.txt", i), typeFlag: tar.TypeReg, contents: fmt.Sprintf("CONTENTS-%d", i)},
+			tarEntry{path: fmt.Sprintf("hard-%d.txt", i), typeFlag: tar.TypeLink, linkPath: fmt.Sprintf("file-%d.txt", i)},
+		))
+	}
+
+	catalog := NewFileCatalog()
+	cacheDir := t.TempDir()
+
+	var wg sync.WaitGroup
+	errs := make([]error, layerCount)
+	for i, l := range layers {
+		wg.Add(1)
+		go func(idx int, v1Layer v1.Layer) {
+			defer wg.Done()
+			errs[idx] = NewLayer(v1Layer).Read(catalog, idx, cacheDir)
+		}(i, l)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "layer %d failed to read", i)
+	}
 }

--- a/pkg/image/hardlink_semantics_test.go
+++ b/pkg/image/hardlink_semantics_test.go
@@ -488,6 +488,14 @@ func TestHardLinkSemantics_AdoptionFallsBackOnMalformedArchives(t *testing.T) {
 				{path: "hard", typeFlag: tar.TypeLink, linkPath: "d"},
 			},
 		},
+		{
+			// the name it points at failed to adopt, so there is nothing to adopt from it either
+			name: "link name is itself an un-adopted hardlink",
+			entries: []tarEntry{
+				{path: "first", typeFlag: tar.TypeLink, linkPath: "does-not-exist"},
+				{path: "hard", typeFlag: tar.TypeLink, linkPath: "first"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -499,6 +507,8 @@ func TestHardLinkSemantics_AdoptionFallsBackOnMalformedArchives(t *testing.T) {
 			assert.Equal(t, file.TypeHardLink, entry.Metadata.Type, "must keep the type its own header gives it")
 			assert.Equal(t, int64(0), entry.Metadata.Size(), "an un-adopted hardlink header has no data section")
 			assert.False(t, entry.Metadata.IsDir(), "a hardlink is never a directory")
+			assert.Equal(t, tt.entries[len(tt.entries)-1].linkPath, entry.Metadata.LinkDestination,
+				"must keep the link destination its own header gives it")
 		})
 	}
 }

--- a/pkg/image/hardlink_semantics_test.go
+++ b/pkg/image/hardlink_semantics_test.go
@@ -1,0 +1,316 @@
+package image
+
+import (
+	"archive/tar"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree"
+)
+
+// These tests state what a container actually serves for each hardlink shape, and assert that
+// stereoscope agrees. They are the specification, not a snapshot of current behavior, so any case
+// stereoscope gets wrong fails here until the code is fixed.
+//
+// The layer layouts are not invented. They were captured from the image built by
+// test/integration/testdata/image-hardlinks/Dockerfile and read back with `docker save`, so the tar
+// header type, ordering and linknames match what a container runtime actually produces. The
+// integration test over that fixture (TestImageHardLinks) is the ground-truth anchor; this file is
+// the docker-free version of the same cases, and can also express layouts docker will not emit.
+//
+// Two properties of that output are load-bearing, and both are easy to guess wrong:
+//
+//   - The data section goes to the ALPHABETICALLY FIRST name, not to the name that was created
+//     first. `printf > orig.txt && ln orig.txt hard.txt` yields a REG header for hard.txt and a
+//     HARDLINK header for orig.txt, because the tar writer walks the directory sorted.
+//   - A hardlink header's target is ALWAYS in the same layer, and always precedes it. `ln` across
+//     layers forces an overlayfs copy-up, so it emits a full REG copy rather than a hardlink header.
+//
+// The rule the cases below encode: a hardlink is a second name for an inode, fixed when the link is
+// created. Replacing, overwriting or deleting the OTHER name of that inode in a later layer does not
+// change what this name refers to.
+
+const (
+	c1Original  = "CASE1-ORIGINAL"
+	c3Modified  = "CASE3-MODIFIED-IN-PLACE"
+	c4Original  = "CASE4-ORIGINAL"
+	c4Replaced  = "CASE4-REPLACED"
+	c5Payload   = "CASE5-PAYLOAD"
+	c6Real      = "CASE6-REAL"
+	c7Payload   = "CASE7-PAYLOAD"
+	c8Payload   = "CASE8-PAYLOAD"
+	c9Original  = "CASE9-ORIGINAL"
+	c9Overwrite = "CASE9-HARDLINK-OVERWRITTEN"
+	c10Payload  = "CASE10-PAYLOAD"
+	c11Payload  = "CASE11-PAYLOAD"
+	c11Replaced = "CASE11-A-REPLACED-LATER"
+)
+
+// hardlinkCase is one path and what the container serves at it.
+type hardlinkCase struct {
+	path string
+	// contents is what `cat path` returns inside the running container.
+	contents string
+	// absent means the path does not exist in the running container.
+	absent bool
+	// note explains why this answer is what it is, where that is not obvious.
+	note string
+}
+
+func hardlinkCases() []hardlinkCase {
+	return []hardlinkCase{
+		// c1: the other name was modified in place, so overlayfs copied it up to a new inode.
+		{path: "/c1/hard.txt", contents: c1Original, note: "keeps the original inode"},
+		{path: "/c1/orig.txt", contents: c3Modified},
+
+		// c2: a cross-layer `ln` is a full copy, so nothing hardlink-specific happens here.
+		{path: "/c2/cross-hard.txt", contents: c1Original},
+
+		// c4: the other name was replaced by a new regular file.
+		{path: "/c4/hard.txt", contents: c4Original},
+		{path: "/c4/orig.txt", contents: c4Replaced},
+
+		// c5: the uv/pip shape. squashed, the installed name is a symlink to the cache name and the
+		// cache name is a hardlink whose link path names the installed name. that is a cycle in the
+		// path graph but not on disk, where the cache name still refers to the original inode.
+		{path: "/c5/bin/tool", contents: c5Payload, note: "symlink into the cache"},
+		{path: "/c5/cache/blob", contents: c5Payload, note: "the surviving name for the payload inode"},
+
+		// c6: `ln` onto a symlink hardlinks the symlink inode, so both names are symlinks to the
+		// same destination and reading either follows through to the real file.
+		{path: "/c6/real.txt", contents: c6Real},
+		{path: "/c6/sym.txt", contents: c6Real, note: "a hardlink naming a symlink IS a symlink"},
+		{path: "/c6/hard-to-sym.txt", contents: c6Real},
+
+		// c7: the other name was deleted.
+		{path: "/c7/hard.txt", contents: c7Payload},
+		{path: "/c7/orig.txt", absent: true},
+
+		// c8: three names, one inode.
+		{path: "/c8/a.txt", contents: c8Payload},
+		{path: "/c8/b.txt", contents: c8Payload},
+		{path: "/c8/c.txt", contents: c8Payload},
+
+		// c9: the data-carrying name was overwritten in a later layer, so the two names diverge.
+		{path: "/c9/hard.txt", contents: c9Overwrite},
+		{path: "/c9/orig.txt", contents: c9Original, note: "still the layer's original inode"},
+
+		// c10: the data-carrying name was whiteouted. deleting one name of an inode does not remove
+		// the others, so z.txt is still readable.
+		{path: "/c10/a.txt", absent: true},
+		{path: "/c10/z.txt", contents: c10Payload},
+
+		// c11: the data-carrying name was replaced in a later layer.
+		{path: "/c11/a.txt", contents: c11Replaced},
+		{path: "/c11/z.txt", contents: c11Payload, note: "still the original inode"},
+	}
+}
+
+// TestHardLinkSemantics_Contents asserts stereoscope serves what the container serves.
+func TestHardLinkSemantics_Contents(t *testing.T) {
+	img := hardlinkReproImage(t)
+
+	for _, tc := range hardlinkCases() {
+		t.Run(tc.path, func(t *testing.T) {
+			contents, err := hardlinkContentsForTest(img, tc.path)
+
+			if tc.absent {
+				require.Error(t, err, "path does not exist in the container: %s", tc.note)
+				return
+			}
+
+			require.NoError(t, err, tc.note)
+			assert.Equal(t, tc.contents, contents, tc.note)
+		})
+	}
+}
+
+// TestHardLinkSemantics_ResolvedPathExists asserts that whatever reference a path resolves to names
+// a path that is actually present in the squashed tree. Resolving to a location the image does not
+// contain is wrong regardless of which name we choose to report.
+func TestHardLinkSemantics_ResolvedPathExists(t *testing.T) {
+	img := hardlinkReproImage(t)
+	tree := img.SquashedTree()
+
+	for _, tc := range hardlinkCases() {
+		if tc.absent {
+			continue
+		}
+
+		t.Run(tc.path, func(t *testing.T) {
+			_, resolution, err := tree.File(file.Path(tc.path), filetree.FollowBasenameLinks)
+			require.NoError(t, err)
+			require.NotNil(t, resolution)
+			require.NotNil(t, resolution.Reference)
+
+			exists, _, err := tree.File(resolution.RealPath)
+			require.NoError(t, err)
+			assert.True(t, exists,
+				"%s resolves to %s, which is not in the squashed tree", tc.path, resolution.RealPath)
+		})
+	}
+}
+
+// TestHardLinkSemantics_Metadata asserts that a hardlinked name reports the size of the inode it
+// names. A hardlink tar header carries no data section, so taking its size straight from the header
+// describes the header rather than the file, and a consumer reading that size sees an empty file.
+//
+// Symlinks are excluded: a symlink inode's size is the length of its link text, not the size of
+// whatever it points at, so size-matches-contents is not the right question for them.
+func TestHardLinkSemantics_Metadata(t *testing.T) {
+	img := hardlinkReproImage(t)
+	tree := img.SquashedTree()
+
+	for _, tc := range hardlinkCases() {
+		if tc.absent {
+			continue
+		}
+
+		t.Run(tc.path, func(t *testing.T) {
+			// the path's OWN node in the squashed tree, with no link following, so this is the entry
+			// a consumer sees for this name rather than the one for some other layer's version of it
+			exists, resolution, err := tree.File(file.Path(tc.path))
+			require.NoError(t, err)
+			require.True(t, exists)
+			require.NotNil(t, resolution.Reference)
+
+			entry, err := img.FileCatalog.Get(*resolution.Reference)
+			require.NoError(t, err)
+
+			if entry.Metadata.Type == file.TypeSymLink {
+				t.Skipf("%s is a symlink; its size is its link text", tc.path)
+			}
+
+			assert.Equal(t, int64(len(tc.contents)), entry.Metadata.Size(),
+				"%s reports a size that does not match the contents the container serves", tc.path)
+		})
+	}
+}
+
+// TestHardLinkSemantics_MIMESearchFindsHardLinks asserts that a hardlinked name is reachable by
+// MIME-driven search. Enumerating by MIME type is how consumers find files to catalog, so a
+// hardlinked binary being invisible to it means the file is silently skipped.
+func TestHardLinkSemantics_MIMESearchFindsHardLinks(t *testing.T) {
+	img := hardlinkReproImage(t)
+
+	refs, err := img.FilesByMIMETypeFromSquash("text/plain")
+	require.NoError(t, err)
+
+	found := make(map[string]bool)
+	for _, ref := range refs {
+		found[string(ref.RealPath)] = true
+	}
+
+	for _, path := range []string{"/c8/a.txt", "/c8/b.txt", "/c8/c.txt"} {
+		assert.True(t, found[path], "%s is text/plain in the container but is not reachable by MIME search", path)
+	}
+}
+
+// hardlinkReproImage builds one image whose layers mirror
+// test/integration/testdata/image-hardlinks/Dockerfile, layer for layer, using the tar header
+// layout captured from the real `docker build` output for that fixture.
+func hardlinkReproImage(t *testing.T) *Image {
+	t.Helper()
+
+	reg := byte(tar.TypeReg)
+	lnk := byte(tar.TypeLink)
+	sym := byte(tar.TypeSymlink)
+
+	return readImageFromLayers(t,
+		// case 1: same-layer hardlink pair. note hard.txt carries the data (alphabetically first).
+		layerFromTarEntries(t,
+			tarEntry{path: "c1/hard.txt", typeFlag: reg, contents: c1Original},
+			tarEntry{path: "c1/orig.txt", typeFlag: lnk, linkPath: "c1/hard.txt"},
+		),
+		// case 2: `ln` to a previous layer's file becomes a full copy, not a hardlink header.
+		layerFromTarEntries(t,
+			tarEntry{path: "c2/cross-hard.txt", typeFlag: reg, contents: c1Original},
+		),
+		// case 3: the data-carrying name's sibling is modified in place; overlayfs copies it up.
+		layerFromTarEntries(t,
+			tarEntry{path: "c1/orig.txt", typeFlag: reg, contents: c3Modified},
+		),
+		// case 4: same-layer pair, then the hardlink name is replaced by a new regular file.
+		layerFromTarEntries(t,
+			tarEntry{path: "c4/hard.txt", typeFlag: reg, contents: c4Original},
+			tarEntry{path: "c4/orig.txt", typeFlag: lnk, linkPath: "c4/hard.txt"},
+		),
+		layerFromTarEntries(t,
+			tarEntry{path: "c4/orig.txt", typeFlag: reg, contents: c4Replaced},
+		),
+		// case 5: the uv/pip shape that motivated #665. installed name hardlinked into a cache, then
+		// replaced by a symlink aimed at the cache name. squashed, the two names name each other.
+		layerFromTarEntries(t,
+			tarEntry{path: "c5/bin/tool", typeFlag: reg, contents: c5Payload},
+			tarEntry{path: "c5/cache/blob", typeFlag: lnk, linkPath: "c5/bin/tool"},
+		),
+		layerFromTarEntries(t,
+			tarEntry{path: "c5/bin/tool", typeFlag: sym, linkPath: "/c5/cache/blob"},
+		),
+		// case 6: `ln` onto a symlink. the hardlink header names a SYMLINK member.
+		layerFromTarEntries(t,
+			tarEntry{path: "c6/hard-to-sym.txt", typeFlag: sym, linkPath: "/c6/real.txt"},
+			tarEntry{path: "c6/real.txt", typeFlag: reg, contents: c6Real},
+			tarEntry{path: "c6/sym.txt", typeFlag: lnk, linkPath: "c6/hard-to-sym.txt"},
+		),
+		// case 7: the hardlink-header name is deleted; the data-carrying name survives.
+		layerFromTarEntries(t,
+			tarEntry{path: "c7/hard.txt", typeFlag: reg, contents: c7Payload},
+			tarEntry{path: "c7/orig.txt", typeFlag: lnk, linkPath: "c7/hard.txt"},
+		),
+		layerFromTarEntries(t,
+			tarEntry{path: "c7/.wh.orig.txt", typeFlag: reg},
+		),
+		// case 8: three names, one inode: one REG header and two HARDLINK headers.
+		layerFromTarEntries(t,
+			tarEntry{path: "c8/a.txt", typeFlag: reg, contents: c8Payload},
+			tarEntry{path: "c8/b.txt", typeFlag: lnk, linkPath: "c8/a.txt"},
+			tarEntry{path: "c8/c.txt", typeFlag: lnk, linkPath: "c8/a.txt"},
+		),
+		// case 9: the data-carrying name is overwritten in a later layer. on disk the other name
+		// keeps the original inode, so the two names diverge.
+		layerFromTarEntries(t,
+			tarEntry{path: "c9/hard.txt", typeFlag: reg, contents: c9Original},
+			tarEntry{path: "c9/orig.txt", typeFlag: lnk, linkPath: "c9/hard.txt"},
+		),
+		layerFromTarEntries(t,
+			tarEntry{path: "c9/hard.txt", typeFlag: reg, contents: c9Overwrite},
+		),
+		// case 10: the data-carrying name is whiteouted, leaving a hardlink header whose linkname is
+		// gone from the squashed tree. the container still serves the file under the other name.
+		layerFromTarEntries(t,
+			tarEntry{path: "c10/a.txt", typeFlag: reg, contents: c10Payload},
+			tarEntry{path: "c10/z.txt", typeFlag: lnk, linkPath: "c10/a.txt"},
+		),
+		layerFromTarEntries(t,
+			tarEntry{path: "c10/.wh.a.txt", typeFlag: reg},
+		),
+		// case 11: the data-carrying name is replaced in a later layer.
+		layerFromTarEntries(t,
+			tarEntry{path: "c11/a.txt", typeFlag: reg, contents: c11Payload},
+			tarEntry{path: "c11/z.txt", typeFlag: lnk, linkPath: "c11/a.txt"},
+		),
+		layerFromTarEntries(t,
+			tarEntry{path: "c11/a.txt", typeFlag: reg, contents: c11Replaced},
+		),
+	)
+}
+
+func hardlinkContentsForTest(img *Image, path string) (string, error) {
+	reader, err := img.OpenPathFromSquash(file.Path(path))
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	contents, err := io.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+
+	return string(contents), nil
+}

--- a/pkg/image/hardlink_semantics_test.go
+++ b/pkg/image/hardlink_semantics_test.go
@@ -342,6 +342,35 @@ func TestHardLinkSemantics_LayerSizeExcludesHardLinkHeaders(t *testing.T) {
 		"a hardlinked name still reports the size of the file it names")
 }
 
+// TestHardLinkSemantics_AdoptedTypeConflictDoesNotAbortRead asserts that a hardlink whose adopted
+// type collides with a node already at that path costs only that entry its adoption. Linkname is
+// attacker-controlled on an untrusted image, so a shape docker will never emit must not be able to
+// fail the whole read.
+func TestHardLinkSemantics_AdoptedTypeConflictDoesNotAbortRead(t *testing.T) {
+	img, err := tryReadImageFromLayers(t,
+		layerFromTarEntries(t,
+			// dangling, so nothing is adopted and /p is indexed as the hardlink its header describes
+			tarEntry{path: "p", typeFlag: tar.TypeLink, linkPath: "does-not-exist"},
+			tarEntry{path: "t", typeFlag: tar.TypeReg, contents: "DATA"},
+			// a duplicate member for the same path, this one adopting a regular file, which cannot be
+			// added over the hardlink node already at /p
+			tarEntry{path: "p", typeFlag: tar.TypeLink, linkPath: "t"},
+		),
+	)
+	require.NoError(t, err, "a malformed archive must cost one entry its adoption, not the whole image")
+
+	// the conflicting entry falls back to what it was before adoption
+	entry := catalogEntryForTest(t, img, "/p")
+	assert.Equal(t, file.TypeHardLink, entry.Metadata.Type)
+	assert.Equal(t, "t", entry.Metadata.LinkDestination)
+	assert.Equal(t, int64(0), entry.Metadata.Size(), "an un-adopted hardlink header has no data section")
+
+	// the rest of the layer is unaffected
+	contents, err := hardlinkContentsForTest(img, "/t")
+	require.NoError(t, err)
+	assert.Equal(t, "DATA", contents)
+}
+
 // catalogEntryForTest returns the catalog entry for a path's OWN node in the squashed tree, with no
 // link following.
 func catalogEntryForTest(t *testing.T, img *Image, path string) filetree.IndexEntry {

--- a/pkg/image/hardlink_semantics_test.go
+++ b/pkg/image/hardlink_semantics_test.go
@@ -3,6 +3,7 @@ package image
 import (
 	"archive/tar"
 	"io"
+	"io/fs"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -385,4 +386,34 @@ func catalogEntryForTest(t *testing.T, img *Image, path string) filetree.IndexEn
 	require.NoError(t, err)
 
 	return entry
+}
+
+// TestHardLinkSemantics_AdoptedModeMatchesTarget asserts that a hardlinked name reports the same
+// mode as the name it shares an inode with. Tar records no file type bits on a link header, so
+// adopting the target's type without its type bits leaves Type and Mode() describing different
+// things, and file.TypeFromMode disagreeing with Type.
+func TestHardLinkSemantics_AdoptedModeMatchesTarget(t *testing.T) {
+	img := readImageFromLayers(t,
+		layerFromTarEntries(t,
+			tarEntry{path: "target.txt", typeFlag: tar.TypeReg, contents: "TARGET", mode: 0o600},
+			tarEntry{path: "sym", typeFlag: tar.TypeSymlink, linkPath: "target.txt", mode: 0o777},
+			// deliberately not 0o777, so the permission bits below can only have come from this header
+			tarEntry{path: "hardsym", typeFlag: tar.TypeLink, linkPath: "sym", mode: 0o644},
+		),
+	)
+
+	sym := catalogEntryForTest(t, img, "/sym")
+	hardSym := catalogEntryForTest(t, img, "/hardsym")
+
+	require.Equal(t, file.TypeSymLink, hardSym.Metadata.Type, "a hardlink naming a symlink is a symlink")
+
+	// the type bits come from the inode, the permission bits from this name's own header
+	assert.Equal(t, sym.Metadata.Mode()&fs.ModeType, hardSym.Metadata.Mode()&fs.ModeType,
+		"two names for one inode must agree on file type bits")
+	assert.Equal(t, fs.FileMode(0o644), hardSym.Metadata.Mode().Perm(),
+		"permission bits stay from the hardlink's own header")
+
+	// ...so nothing deriving a type from the mode can disagree with Type
+	assert.Equal(t, hardSym.Metadata.Type, file.TypeFromMode(hardSym.Metadata.Mode()),
+		"Type and TypeFromMode(Mode()) must describe the same thing")
 }

--- a/pkg/image/hardlink_semantics_test.go
+++ b/pkg/image/hardlink_semantics_test.go
@@ -314,3 +314,46 @@ func hardlinkContentsForTest(img *Image, path string) (string, error) {
 
 	return string(contents), nil
 }
+
+// TestHardLinkSemantics_LayerSizeExcludesHardLinkHeaders asserts that a hardlinked name adds nothing
+// to the reported layer size. A hardlink header carries no data section, so counting the size of the
+// inode it names counts those bytes once per name: busybox:latest has 410 hardlink headers over 16
+// regular ones, which turns a 4 MB layer into a reported 431 MB.
+func TestHardLinkSemantics_LayerSizeExcludesHardLinkHeaders(t *testing.T) {
+	const payload = "0123456789"
+
+	img := readImageFromLayers(t,
+		layerFromTarEntries(t,
+			tarEntry{path: "a.txt", typeFlag: tar.TypeReg, contents: payload},
+			tarEntry{path: "b.txt", typeFlag: tar.TypeLink, linkPath: "a.txt"},
+			tarEntry{path: "c.txt", typeFlag: tar.TypeLink, linkPath: "a.txt"},
+		),
+	)
+
+	require.Len(t, img.Layers, 1)
+	assert.Equal(t, int64(len(payload)), img.Layers[0].Metadata.Size,
+		"layer size must count tar data sections, and only the regular header has one")
+	assert.Equal(t, int64(len(payload)), img.Metadata.Size, "image size is the sum of its layer sizes")
+
+	// ...while the entry for a hardlinked name still describes the inode it names, so this cannot be
+	// "fixed" by dropping adoption
+	entry := catalogEntryForTest(t, img, "/b.txt")
+	assert.Equal(t, int64(len(payload)), entry.Metadata.Size(),
+		"a hardlinked name still reports the size of the file it names")
+}
+
+// catalogEntryForTest returns the catalog entry for a path's OWN node in the squashed tree, with no
+// link following.
+func catalogEntryForTest(t *testing.T, img *Image, path string) filetree.IndexEntry {
+	t.Helper()
+
+	exists, resolution, err := img.SquashedTree().File(file.Path(path))
+	require.NoError(t, err)
+	require.True(t, exists, "%s is not in the squashed tree", path)
+	require.NotNil(t, resolution.Reference)
+
+	entry, err := img.FileCatalog.Get(*resolution.Reference)
+	require.NoError(t, err)
+
+	return entry
+}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -352,7 +352,7 @@ func (i *Image) FileContentsByRef(ref file.Reference) (io.ReadCloser, error) {
 	return i.FileCatalog.Open(ref)
 }
 
-// ResolveLinkByLayerSquash resolves a symlink or hardlink for the given file reference relative to the result from
+// ResolveLinkByLayerSquash resolves a symlink for the given file reference relative to the result from
 // the layer squash of the given layer index argument.
 // If the given file reference is not a link type, or is a unresolvable (dead) link, then the given file reference is returned.
 func (i *Image) ResolveLinkByLayerSquash(ref file.Reference, layer int, options ...filetree.LinkResolutionOption) (*file.Resolution, error) {
@@ -361,7 +361,7 @@ func (i *Image) ResolveLinkByLayerSquash(ref file.Reference, layer int, options 
 	return resolvedRef, err
 }
 
-// ResolveLinkByImageSquash resolves a symlink or hardlink for the given file reference relative to the result from the image squash.
+// ResolveLinkByImageSquash resolves a symlink for the given file reference relative to the result from the image squash.
 // If the given file reference is not a link type, or is a unresolvable (dead) link, then the given file reference is returned.
 func (i *Image) ResolveLinkByImageSquash(ref file.Reference, options ...filetree.LinkResolutionOption) (*file.Resolution, error) {
 	allOptions := append([]filetree.LinkResolutionOption{filetree.FollowBasenameLinks}, options...)

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -319,6 +319,11 @@ func adoptHardLinkInode(ft filetree.Reader, fileCatalog *FileCatalog, metadata *
 	// link(2) does when extracting the archive for real
 	linkPath := file.Path(path.Clean(file.DirSeparator + metadata.LinkDestination))
 
+	// an empty link name cleans to the tree root, which would otherwise adopt the root directory
+	if metadata.LinkDestination == "" || linkPath == file.Path(file.DirSeparator) {
+		return nil, false
+	}
+
 	exists, resolution, err := ft.File(linkPath)
 	if err != nil || !exists || resolution == nil || resolution.Reference == nil {
 		return nil, false
@@ -326,6 +331,12 @@ func adoptHardLinkInode(ft filetree.Reader, fileCatalog *FileCatalog, metadata *
 
 	target, err := fileCatalog.Get(*resolution.Reference)
 	if err != nil {
+		return nil, false
+	}
+
+	// link(2) refuses a directory, so an archive naming one is malformed. adopting it anyway would
+	// describe this name as a directory that cannot be listed or walked
+	if target.Type == file.TypeDirectory {
 		return nil, false
 	}
 

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -362,10 +362,16 @@ func layerTarIndexer(ft filetree.ReadWriter, fileCatalog *FileCatalog, size *int
 		// a hardlink names a file already present in this layer; describe it as that file and read
 		// its contents through that file's opener rather than this header's empty data section
 		var hardLinkOpener file.Opener
+		var preAdoptionMetadata *file.Metadata
 		if metadata.Type == file.TypeHardLink {
+			original := metadata
 			var adopted bool
 			hardLinkOpener, adopted = adoptHardLinkInode(ft, fileCatalog, &metadata)
-			if !adopted {
+			if adopted {
+				// keep the un-adopted description to fall back to: adoption changes the node type this
+				// entry claims, which can conflict with what an earlier header put at the same path
+				preAdoptionMetadata = &original
+			} else {
 				// trace, not warn: resolution still works via the link path, and a per-header warning
 				// would be noisy on any archive that trips this
 				log.WithFields("path", metadata.Path, "linkName", metadata.LinkDestination).
@@ -385,7 +391,22 @@ func layerTarIndexer(ft filetree.ReadWriter, fileCatalog *FileCatalog, size *int
 		// the FileCatalog should NEVER have entries that don't appear in one (or more) FileTree(s).
 		ref, err := builder.Add(metadata)
 		if err != nil {
-			return err
+			if preAdoptionMetadata == nil {
+				return err
+			}
+			// only an adopted hardlink can be described here as something other than what its own
+			// header says, so a malformed archive should cost this one entry its adoption rather than
+			// the whole image. errors on the un-adopted retry are still fatal, as they were before.
+			log.WithFields("path", metadata.Path, "linkName", metadata.LinkDestination, "error", err).
+				Trace("adopted hardlink conflicts with an existing entry, indexing it from its own header")
+
+			metadata = *preAdoptionMetadata
+			hardLinkOpener = nil
+
+			ref, err = builder.Add(metadata)
+			if err != nil {
+				return err
+			}
 		}
 
 		if size != nil {

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -389,7 +389,9 @@ func layerTarIndexer(ft filetree.ReadWriter, fileCatalog *FileCatalog, size *int
 		}
 
 		if size != nil {
-			*(size) += metadata.Size()
+			// what this entry contributes to the layer blob, which is its own header's data section.
+			// NOT metadata.Size(), which for an adopted hardlink is the size of the file it names
+			*(size) += entry.Header.Size
 		}
 		opener := hardLinkOpener
 		if opener == nil {

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -310,10 +310,13 @@ func (l *Layer) FilesByMIMETypeFromSquash(mimeTypes ...string) ([]file.Reference
 //     this path also known as something else", the way nlink would.
 //   - we trust the headers. Data on a link header with an empty regular header would be adopted
 //     backwards and serve nothing.
-//   - when adoption fails, that one name keeps TypeHardLink, size 0 and an empty data section: the
+//   - when adoption fails, or is undone by the caller because the adopted type collides with a node
+//     already at that path, that one name keeps TypeHardLink, size 0 and an empty data section: the
 //     lopsided picture this function exists to avoid.
 func adoptHardLinkInode(ft filetree.Reader, fileCatalog *FileCatalog, metadata *file.Metadata) (file.Opener, bool) {
-	// a hardlink's link name refers to an earlier member of this same archive, verbatim
+	// a hardlink's link name refers to an earlier member of this same archive, relative to its root.
+	// the lookup below is not literal: a miss retries following ancestor symlinks, which is what
+	// link(2) does when extracting the archive for real
 	linkPath := file.Path(path.Clean(file.DirSeparator + metadata.LinkDestination))
 
 	exists, resolution, err := ft.File(linkPath)

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -280,7 +280,71 @@ func (l *Layer) FilesByMIMETypeFromSquash(mimeTypes ...string) ([]file.Reference
 	return refs, nil
 }
 
-func layerTarIndexer(ft filetree.Writer, fileCatalog *FileCatalog, size *int64, layerRef *Layer, monitor *progress.Manual) file.TarIndexVisitor {
+// adoptHardLinkInode rewrites metadata for a hardlink tar header to describe the file it names, and
+// returns that file's opener. Returns false if that file is not in this layer (a malformed archive),
+// leaving the entry to be indexed from its own header.
+//
+// a hardlink is a second name for an inode already in this layer, not a path to resolve later, and
+// its header carries no data section:
+//
+//   - adopted from the target: size, MIME type, type, link destination. A hardlink naming a symlink
+//     is itself a symlink.
+//   - kept from this header: mode, uid, gid, mtime, which tar already records correctly.
+//
+// "inode" is an analogy. There is no such object here: each name keeps its own file.Reference, ID
+// and catalog entry, and what is shared is the opener plus a copy of the values above. Pointing both
+// names at one reference would model the filesystem more literally, but it would leave a node's
+// RealPath disagreeing with its reference's, and drop the second name as a location callers can
+// address at all.
+//
+// Binding here rather than at resolution time is what makes the name immune to later layers: the
+// catalog is keyed by file.ID and is never squashed or merged, so replacing or deleting the other
+// name cannot change what this one refers to, which is what the filesystem does.
+//
+// where this model bends the truth:
+//
+//   - on disk neither name is "the hardlink". Which one a tar marks is an artifact of directory walk
+//     order (alphabetical in practice), so it is often the one a person would call the original.
+//   - adopting erases that mark, so the names come out symmetric. But nothing can then answer "is
+//     this path also known as something else", the way nlink would.
+//   - we trust the headers. Data on a link header with an empty regular header would be adopted
+//     backwards and serve nothing.
+//   - when adoption fails, that one name keeps TypeHardLink, size 0 and an empty data section: the
+//     lopsided picture this function exists to avoid.
+func adoptHardLinkInode(ft filetree.Reader, fileCatalog *FileCatalog, metadata *file.Metadata) (file.Opener, bool) {
+	// a hardlink's link name refers to an earlier member of this same archive, verbatim
+	linkPath := file.Path(path.Clean(file.DirSeparator + metadata.LinkDestination))
+
+	exists, resolution, err := ft.File(linkPath)
+	if err != nil || !exists || resolution == nil || resolution.Reference == nil {
+		return nil, false
+	}
+
+	target, err := fileCatalog.Get(*resolution.Reference)
+	if err != nil {
+		return nil, false
+	}
+
+	opener := fileCatalog.openerByID[resolution.ID()]
+	if opener == nil {
+		return nil, false
+	}
+
+	metadata.FileInfo = file.ManualInfo{
+		NameValue:    path.Base(metadata.Path),
+		SizeValue:    target.Size(),
+		ModeValue:    metadata.Mode(),
+		ModTimeValue: metadata.ModTime(),
+		SysValue:     metadata.Sys(),
+	}
+	metadata.MIMEType = target.MIMEType
+	metadata.Type = target.Type
+	metadata.LinkDestination = target.LinkDestination
+
+	return opener, true
+}
+
+func layerTarIndexer(ft filetree.ReadWriter, fileCatalog *FileCatalog, size *int64, layerRef *Layer, monitor *progress.Manual) file.TarIndexVisitor {
 	builder := filetree.NewBuilder(ft, fileCatalog.Index)
 
 	return func(index file.TarIndexEntry) error {
@@ -294,6 +358,20 @@ func layerTarIndexer(ft filetree.Writer, fileCatalog *FileCatalog, size *int64, 
 			}
 		}()
 		metadata := file.NewMetadata(entry.Header, contents)
+
+		// a hardlink names a file already present in this layer; describe it as that file and read
+		// its contents through that file's opener rather than this header's empty data section
+		var hardLinkOpener file.Opener
+		if metadata.Type == file.TypeHardLink {
+			var adopted bool
+			hardLinkOpener, adopted = adoptHardLinkInode(ft, fileCatalog, &metadata)
+			if !adopted {
+				// trace, not warn: resolution still works via the link path, and a per-header warning
+				// would be noisy on any archive that trips this
+				log.WithFields("path", metadata.Path, "linkName", metadata.LinkDestination).
+					Trace("hardlink names a file that is not in this layer, indexing it from its own header")
+			}
+		}
 
 		// note: the tar header name is independent of surrounding structure, for example, there may be a tar header entry
 		// for /some/path/to/file.txt without any entries to constituent paths (/some, /some/path, /some/path/to ).
@@ -313,9 +391,13 @@ func layerTarIndexer(ft filetree.Writer, fileCatalog *FileCatalog, size *int64, 
 		if size != nil {
 			*(size) += metadata.Size()
 		}
-		fileCatalog.addImageReferences(ref.ID(), layerRef, func() (io.ReadCloser, error) {
-			return index.Open(), nil
-		})
+		opener := hardLinkOpener
+		if opener == nil {
+			opener = func() (io.ReadCloser, error) {
+				return index.Open(), nil
+			}
+		}
+		fileCatalog.addImageReferences(ref.ID(), layerRef, opener)
 
 		if monitor != nil {
 			monitor.Increment()

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -335,8 +335,10 @@ func adoptHardLinkInode(ft filetree.Reader, fileCatalog *FileCatalog, metadata *
 	}
 
 	// link(2) refuses a directory, so an archive naming one is malformed. adopting it anyway would
-	// describe this name as a directory that cannot be listed or walked
-	if target.Type == file.TypeDirectory {
+	// describe this name as a directory that cannot be listed or walked.
+	// a target that is still a hardlink is one that failed to adopt, and taking its description would
+	// spread that failure while reporting success, down to its link destination
+	if target.Type == file.TypeDirectory || target.Type == file.TypeHardLink {
 		return nil, false
 	}
 

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -287,9 +287,10 @@ func (l *Layer) FilesByMIMETypeFromSquash(mimeTypes ...string) ([]file.Reference
 // a hardlink is a second name for an inode already in this layer, not a path to resolve later, and
 // its header carries no data section:
 //
-//   - adopted from the target: size, MIME type, type, link destination. A hardlink naming a symlink
-//     is itself a symlink.
-//   - kept from this header: mode, uid, gid, mtime, which tar already records correctly.
+//   - adopted from the target: size, MIME type, type, link destination, and the file type bits of
+//     the mode, which tar does not record on a link header. A hardlink naming a symlink is itself a
+//     symlink.
+//   - kept from this header: permission bits, uid, gid, mtime, which tar already records correctly.
 //
 // "inode" is an analogy. There is no such object here: each name keeps its own file.Reference, ID
 // and catalog entry, and what is shared is the opener plus a copy of the values above. Pointing both
@@ -331,9 +332,11 @@ func adoptHardLinkInode(ft filetree.Reader, fileCatalog *FileCatalog, metadata *
 	}
 
 	metadata.FileInfo = file.ManualInfo{
-		NameValue:    path.Base(metadata.Path),
-		SizeValue:    target.Size(),
-		ModeValue:    metadata.Mode(),
+		NameValue: path.Base(metadata.Path),
+		SizeValue: target.Size(),
+		// permission bits stay from this header, but the file type bits come from the target: tar
+		// records no type bits on a link header, and two names for one inode share a mode
+		ModeValue:    metadata.Mode()&^fs.ModeType | target.Mode()&fs.ModeType,
 		ModTimeValue: metadata.ModTime(),
 		SysValue:     metadata.Sys(),
 	}

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -326,7 +326,7 @@ func adoptHardLinkInode(ft filetree.Reader, fileCatalog *FileCatalog, metadata *
 		return nil, false
 	}
 
-	opener := fileCatalog.openerByID[resolution.ID()]
+	opener := fileCatalog.opener(resolution.ID())
 	if opener == nil {
 		return nil, false
 	}

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -313,6 +313,12 @@ func (l *Layer) FilesByMIMETypeFromSquash(mimeTypes ...string) ([]file.Reference
 //   - when adoption fails, or is undone by the caller because the adopted type collides with a node
 //     already at that path, that one name keeps TypeHardLink, size 0 and an empty data section: the
 //     lopsided picture this function exists to avoid.
+//   - only this layer is searched. extraction resolves a link name against everything applied so
+//     far, so a name pointing into a lower layer does work in a real runtime and is not adopted
+//     here. matching that needs the squash as of the previous layer, not a walk of each lower tree,
+//     which would resolve names that an intervening whiteout had already deleted. squashing runs
+//     after all layers are read, so threading it in would make every layer's indexing wait on the
+//     one below it. no mainstream builder emits these: they keep the inode table per archive.
 func adoptHardLinkInode(ft filetree.Reader, fileCatalog *FileCatalog, metadata *file.Metadata) (file.Opener, bool) {
 	// a hardlink's link name refers to an earlier member of this same archive, relative to its root.
 	// the lookup below is not literal: a miss retries following ancestor symlinks, which is what
@@ -354,7 +360,9 @@ func adoptHardLinkInode(ft filetree.Reader, fileCatalog *FileCatalog, metadata *
 		// records no type bits on a link header, and two names for one inode share a mode
 		ModeValue:    metadata.Mode()&^fs.ModeType | target.Mode()&fs.ModeType,
 		ModTimeValue: metadata.ModTime(),
-		SysValue:     metadata.Sys(),
+		// deliberately the un-adopted header: it is the escape hatch to what the tar actually said,
+		// so it still reports TypeLink, size 0 and this name's own link name
+		SysValue: metadata.Sys(),
 	}
 	metadata.MIMEType = target.MIMEType
 	metadata.Type = target.Type

--- a/pkg/image/synthetic_image_test.go
+++ b/pkg/image/synthetic_image_test.go
@@ -61,14 +61,24 @@ func layerFromTarEntries(t *testing.T, entries ...tarEntry) v1.Layer {
 func readImageFromLayers(t *testing.T, layers ...v1.Layer) *Image {
 	t.Helper()
 
+	img, err := tryReadImageFromLayers(t, layers...)
+	require.NoError(t, err)
+
+	return img
+}
+
+// tryReadImageFromLayers is readImageFromLayers for tests that need to assert on the read error
+// itself, rather than have it fail the test.
+func tryReadImageFromLayers(t *testing.T, layers ...v1.Layer) (*Image, error) {
+	t.Helper()
+
 	v1Img, err := mutate.AppendLayers(empty.Image, layers...)
 	require.NoError(t, err)
 
 	img := New(v1Img, file.NewTempDirGenerator("image-test"), t.TempDir())
-	require.NoError(t, img.Read())
 	t.Cleanup(func() {
 		require.NoError(t, img.Cleanup())
 	})
 
-	return img
+	return img, img.Read()
 }

--- a/pkg/image/synthetic_image_test.go
+++ b/pkg/image/synthetic_image_test.go
@@ -1,0 +1,74 @@
+package image
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/stereoscope/pkg/file"
+)
+
+// Helpers for building an image out of hand-written tar layers, so a test can express an exact
+// sequence of tar headers without needing docker. Lets tests cover layouts a real build will not
+// produce, which is where the interesting hardlink edge cases live.
+
+// tarEntry is a single tar header and the data section that follows it, if any.
+type tarEntry struct {
+	path     string
+	typeFlag byte
+	linkPath string
+	contents string
+}
+
+func layerFromTarEntries(t *testing.T, entries ...tarEntry) v1.Layer {
+	t.Helper()
+
+	tarPath := filepath.Join(t.TempDir(), "layer.tar")
+	fh, err := os.Create(tarPath)
+	require.NoError(t, err)
+
+	tw := tar.NewWriter(fh)
+	for _, entry := range entries {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name:     entry.path,
+			Typeflag: entry.typeFlag,
+			Linkname: entry.linkPath,
+			Mode:     0o644,
+			Size:     int64(len(entry.contents)),
+		}))
+		if entry.contents != "" {
+			_, err := io.WriteString(tw, entry.contents)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, fh.Close())
+
+	layer, err := tarball.LayerFromFile(tarPath)
+	require.NoError(t, err)
+
+	return layer
+}
+
+func readImageFromLayers(t *testing.T, layers ...v1.Layer) *Image {
+	t.Helper()
+
+	v1Img, err := mutate.AppendLayers(empty.Image, layers...)
+	require.NoError(t, err)
+
+	img := New(v1Img, file.NewTempDirGenerator("image-test"), t.TempDir())
+	require.NoError(t, img.Read())
+	t.Cleanup(func() {
+		require.NoError(t, img.Cleanup())
+	})
+
+	return img
+}

--- a/pkg/image/synthetic_image_test.go
+++ b/pkg/image/synthetic_image_test.go
@@ -26,6 +26,9 @@ type tarEntry struct {
 	typeFlag byte
 	linkPath string
 	contents string
+	// mode is the header's permission bits, defaulting to 0o644 when left unset. Set it only when a
+	// test needs to tell the mode of one entry apart from another's.
+	mode int64
 }
 
 func layerFromTarEntries(t *testing.T, entries ...tarEntry) v1.Layer {
@@ -37,11 +40,15 @@ func layerFromTarEntries(t *testing.T, entries ...tarEntry) v1.Layer {
 
 	tw := tar.NewWriter(fh)
 	for _, entry := range entries {
+		mode := entry.mode
+		if mode == 0 {
+			mode = 0o644
+		}
 		require.NoError(t, tw.WriteHeader(&tar.Header{
 			Name:     entry.path,
 			Typeflag: entry.typeFlag,
 			Linkname: entry.linkPath,
-			Mode:     0o644,
+			Mode:     mode,
 			Size:     int64(len(entry.contents)),
 		}))
 		if entry.contents != "" {

--- a/test/integration/fixture_image_hardlinks_test.go
+++ b/test/integration/fixture_image_hardlinks_test.go
@@ -1,0 +1,143 @@
+//go:build !windows
+
+package integration
+
+import (
+	"io"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/anchore/stereoscope/pkg/imagetest"
+)
+
+// These tests state what the container built by testdata/image-hardlinks/Dockerfile actually serves
+// at each path, and assert that stereoscope agrees. They are the specification, not a snapshot of
+// current behavior, so a shape stereoscope gets wrong fails here until the code is fixed.
+//
+// The rule the cases encode: a hardlink is a second name for an inode, fixed when the link is
+// created. Replacing, overwriting or deleting the OTHER name of that inode in a later layer does not
+// change what this name refers to.
+
+type hardlinkPathCase struct {
+	path string
+	// contents is what `cat path` returns inside the running container.
+	contents string
+	// absent means the path does not exist in the running container.
+	absent bool
+	// note explains why this answer is what it is, where that is not obvious.
+	note string
+}
+
+func hardlinkPathCases() []hardlinkPathCase {
+	return []hardlinkPathCase{
+		// c1: the other name was modified in place, so overlayfs copied it up to a new inode.
+		{path: "/c1/hard.txt", contents: "CASE1-ORIGINAL", note: "keeps the original inode"},
+		{path: "/c1/orig.txt", contents: "CASE3-MODIFIED-IN-PLACE"},
+
+		// c2: a cross-layer `ln` is a full copy, so nothing hardlink-specific happens here.
+		{path: "/c2/cross-hard.txt", contents: "CASE1-ORIGINAL"},
+
+		// c4: the other name was replaced by a new regular file.
+		{path: "/c4/hard.txt", contents: "CASE4-ORIGINAL"},
+		{path: "/c4/orig.txt", contents: "CASE4-REPLACED"},
+
+		// c5: the uv/pip shape. squashed, the installed name is a symlink to the cache name and the
+		// cache name is a hardlink whose link path names the installed name. that is a cycle in the
+		// path graph but not on disk, where the cache name still refers to the original inode.
+		{path: "/c5/bin/tool", contents: "CASE5-PAYLOAD", note: "symlink into the cache"},
+		{path: "/c5/cache/blob", contents: "CASE5-PAYLOAD", note: "the surviving name for the payload inode"},
+
+		// c6: `ln` onto a symlink hardlinks the symlink inode, so both names are symlinks to the
+		// same destination and reading either follows through to the real file.
+		{path: "/c6/real.txt", contents: "CASE6-REAL"},
+		{path: "/c6/sym.txt", contents: "CASE6-REAL", note: "a hardlink naming a symlink IS a symlink"},
+		{path: "/c6/hard-to-sym.txt", contents: "CASE6-REAL"},
+
+		// c7: the other name was deleted.
+		{path: "/c7/hard.txt", contents: "CASE7-PAYLOAD"},
+		{path: "/c7/orig.txt", absent: true},
+
+		// c8: three names, one inode.
+		{path: "/c8/a.txt", contents: "CASE8-PAYLOAD"},
+		{path: "/c8/b.txt", contents: "CASE8-PAYLOAD"},
+		{path: "/c8/c.txt", contents: "CASE8-PAYLOAD"},
+
+		// c9: the data-carrying name was overwritten in a later layer, so the two names diverge.
+		{path: "/c9/hard.txt", contents: "CASE9-HARDLINK-OVERWRITTEN"},
+		{path: "/c9/orig.txt", contents: "CASE9-ORIGINAL", note: "still the layer's original inode"},
+
+		// c10: the data-carrying name was whiteouted. deleting one name of an inode does not remove
+		// the others, so z.txt is still readable.
+		{path: "/c10/a.txt", absent: true},
+		{path: "/c10/z.txt", contents: "CASE10-PAYLOAD"},
+
+		// c11: the data-carrying name was replaced in a later layer.
+		{path: "/c11/a.txt", contents: "CASE11-A-REPLACED-LATER"},
+		{path: "/c11/z.txt", contents: "CASE11-PAYLOAD", note: "still the original inode"},
+	}
+}
+
+func TestImageHardLinks(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{name: "FromTarball", source: "docker-archive"},
+		{name: "FromDocker", source: "docker"},
+		{name: "FromPodman", source: "podman"},
+		{name: "FromContainerd", source: "containerd"},
+		{name: "FromOciTarball", source: "oci-archive"},
+		{name: "FromOciDirectory", source: "oci-dir"},
+		// note: singularity is deliberately absent. it is backed by squashfs, which resolves
+		// hardlinks when the filesystem is built, so there are no hardlink entries left to test.
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if runtime.GOOS != "linux" {
+				switch c.source {
+				case "containerd":
+					t.Skip("containerd is only supported on linux")
+				case "podman":
+					t.Skip("podman is only supported on linux")
+				}
+			}
+
+			img := imagetest.GetFixtureImage(t, c.source, "image-hardlinks")
+
+			for _, tc := range hardlinkPathCases() {
+				t.Run(tc.path, func(t *testing.T) {
+					contents, err := hardlinkContents(img, tc.path)
+
+					if tc.absent {
+						require.Error(t, err, "path does not exist in the container: %s", tc.note)
+						return
+					}
+
+					require.NoError(t, err, tc.note)
+					assert.Equal(t, tc.contents, contents, tc.note)
+				})
+			}
+		})
+	}
+}
+
+func hardlinkContents(img *image.Image, path string) (string, error) {
+	reader, err := img.OpenPathFromSquash(file.Path(path))
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+
+	contents, err := io.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+
+	return string(contents), nil
+}

--- a/test/integration/fixture_image_symlinks_test.go
+++ b/test/integration/fixture_image_symlinks_test.go
@@ -152,11 +152,15 @@ func assertImageSymlinkLinkResolution(t *testing.T, i *image.Image) {
 
 	tests := []linkFetchConfig{
 		// LAYER 0 > FROM busybox:latest (hardlink test)
+		// /bin/busybox and /bin/[ are two names for one inode. the tar gives the data section to
+		// /bin/[ (alphabetically first) and emits /bin/busybox as a hardlink header, but neither name
+		// is a link to the other: both are the file. So /bin/busybox resolves to itself, not to
+		// /bin/[, and reading either name returns the same bytes.
 		{
 			linkLayer:        0,
 			linkPath:         "/bin/busybox",
 			resolveLayer:     0,
-			expectedPath:     "/bin/[",
+			expectedPath:     "/bin/busybox",
 			perspectiveLayer: 0,
 		},
 

--- a/test/integration/testdata/image-hardlinks/Dockerfile
+++ b/test/integration/testdata/image-hardlinks/Dockerfile
@@ -1,0 +1,89 @@
+FROM busybox:1.36@sha256:023917ec6a886d0e8e15f28fb543515a5fcd8d938edb091e8147db4efed388ee
+
+# Hardlink scenarios, one case per directory. Each RUN is its own layer, so the layer boundaries
+# below are meaningful: several cases depend on a later layer touching a path an earlier layer
+# hardlinked.
+#
+# Two properties of the tar that `docker build` produces are load-bearing here, and both are easy to
+# guess wrong:
+#
+#   - The data section goes to the ALPHABETICALLY FIRST name, not to the name created first. In c1
+#     below, `orig.txt` is created and `hard.txt` is the `ln`, yet the tar carries the bytes on
+#     `hard.txt` (REG) and emits `orig.txt` as the hardlink header, because the tar writer walks the
+#     directory sorted.
+#   - A hardlink header's target is always in the same layer, and always precedes it. `ln` across
+#     layers forces an overlayfs copy-up, so it emits a full regular-file copy instead (see c2).
+
+# c1: hardlink pair in one layer, then the OTHER name is modified in place in a later layer.
+# overlayfs copies the modified name up to a new inode, so the two names diverge: hard.txt keeps the
+# original contents.
+RUN mkdir -p /c1 \
+ && printf 'CASE1-ORIGINAL' > /c1/orig.txt \
+ && ln /c1/orig.txt /c1/hard.txt
+
+# c2: `ln` to a file from a PREVIOUS layer. this cannot produce a hardlink header; the layer diff
+# contains a full copy of the contents.
+RUN mkdir -p /c2 \
+ && ln /c1/orig.txt /c2/cross-hard.txt
+
+# c3: c1's other name modified in place, now that c2 has taken its copy of the original contents.
+RUN printf 'CASE3-MODIFIED-IN-PLACE' > /c1/orig.txt
+
+# c4: hardlink pair, then the hardlink-header name is replaced (rm + create) in a later layer.
+RUN mkdir -p /c4 \
+ && printf 'CASE4-ORIGINAL' > /c4/orig.txt \
+ && ln /c4/orig.txt /c4/hard.txt
+RUN rm /c4/orig.txt \
+ && printf 'CASE4-REPLACED' > /c4/orig.txt
+
+# c5: the shape produced by package managers such as uv and pip. an installed file is hardlinked
+# into a content-addressed cache, then a later layer replaces the installed name with a symlink
+# aimed at the cache name. squashed, the two names refer to each other, which reads as a link cycle
+# even though the cache name still refers to the original inode on disk.
+RUN mkdir -p /c5/bin /c5/cache \
+ && printf 'CASE5-PAYLOAD' > /c5/bin/tool \
+ && chmod +x /c5/bin/tool \
+ && ln /c5/bin/tool /c5/cache/blob
+RUN rm /c5/bin/tool \
+ && ln -s /c5/cache/blob /c5/bin/tool
+
+# c6: `ln` onto a SYMLINK. this hardlinks the symlink inode, so both names are symlinks to the same
+# destination, and the tar emits a hardlink header whose target is a symlink member.
+RUN mkdir -p /c6 \
+ && printf 'CASE6-REAL' > /c6/real.txt \
+ && ln -s /c6/real.txt /c6/sym.txt \
+ && ln /c6/sym.txt /c6/hard-to-sym.txt
+
+# c7: the hardlink-header name is deleted in a later layer. the data-carrying name survives.
+RUN mkdir -p /c7 \
+ && printf 'CASE7-PAYLOAD' > /c7/orig.txt \
+ && ln /c7/orig.txt /c7/hard.txt
+RUN rm /c7/orig.txt
+
+# c8: three names for one inode, all in one layer: one regular header and two hardlink headers.
+RUN mkdir -p /c8 \
+ && printf 'CASE8-PAYLOAD' > /c8/a.txt \
+ && ln /c8/a.txt /c8/b.txt \
+ && ln /c8/a.txt /c8/c.txt
+
+# c9: the DATA-CARRYING name (hard.txt, alphabetically first) is overwritten in a later layer. the
+# other name still refers to the original inode.
+RUN mkdir -p /c9 \
+ && printf 'CASE9-ORIGINAL' > /c9/orig.txt \
+ && ln /c9/orig.txt /c9/hard.txt
+RUN printf 'CASE9-HARDLINK-OVERWRITTEN' > /c9/hard.txt
+
+# c10: the data-carrying name is WHITEOUTED in a later layer, leaving a hardlink header whose
+# linkname is absent from the squashed tree. the container still serves the file under z.txt:
+# deleting one name of an inode does not remove the others.
+RUN mkdir -p /c10 \
+ && printf 'CASE10-PAYLOAD' > /c10/a.txt \
+ && ln /c10/a.txt /c10/z.txt
+RUN rm /c10/a.txt
+
+# c11: the data-carrying name is replaced in a later layer, leaving a hardlink header pointing at a
+# path whose contents have since changed.
+RUN mkdir -p /c11 \
+ && printf 'CASE11-PAYLOAD' > /c11/a.txt \
+ && ln /c11/a.txt /c11/z.txt
+RUN printf 'CASE11-A-REPLACED-LATER' > /c11/a.txt


### PR DESCRIPTION
This is an alternative to #665 that came up during its review.

A hardlink is a second name for a file that already exists, not a path to look up later. We store only the link path and re-resolve it against the squashed tree, which makes a hardlink behave like a symlink and gets a few things wrong:

- two names that end up naming each other read as a link cycle. This is what `uv` and `pip` produce (install a file, hardlink it into a content-addressed cache, then a later layer replaces the installed name with a symlink aimed at the cache name) and it aborts resolution for anything walking files
- if a later layer overwrites or replaces the *other* name, we report that layer's contents for this one
- if a later layer deletes the other name, this one reads as missing, though the container serves it fine
- the entry reports size 0 and no MIME type, since a hardlink tar header has no data section, so hardlinked binaries are silently skipped by anything enumerating by MIME type

The fix binds the name to the file it refers to when the layer tar is read instead of re-resolving during path resolution, so `pkg/filetree` is untouched. The catalog is keyed by `file.ID` and is never squashed or merged, so a later layer can't change what a name refers to, which is the guarantee the filesystem actually gives. 

One visible change worth calling out: a hardlinked name is now catalogued as the file it names, so `file.TypeHardLink` no longer appears for well-formed images and such a name resolves to itself rather than to the other name. On disk neither name is "the hardlink", so this is closer to the truth and it's what [syft #5029](https://github.com/anchore/syft/issues/5029) wanted from the other side, but it does mean nothing can answer "is this path also known as something else" anymore.

Tests come in two layers, a real `docker build` fixture over 11 hardlink shapes across every image source plus a docker-free equivalent in the unit suite, and the first commit is deliberately red so the broken cases are visible before the fix lands.