### PR TITLE
fix(file): make TempDirGenerator safe for concurrent use

### DIFF
--- a/.make/go.mod
+++ b/.make/go.mod
@@ -2,11 +2,11 @@ module github.com/anchore/stereoscope/.make
 
 go 1.26.2
 
-require github.com/anchore/go-make v0.8.0
+require github.com/anchore/go-make v0.8.1
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
-	golang.org/x/mod v0.37.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/mod v0.40.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 )

--- a/.make/go.sum
+++ b/.make/go.sum
@@ -1,10 +1,10 @@
-github.com/anchore/go-make v0.8.0 h1:3XAD4WNHIbqY4kwFyCQJ7kKiYLzSzjB0UwzDVwRqlUY=
-github.com/anchore/go-make v0.8.0/go.mod h1:4M6TnArb5w693VyWsgr5dCWrk2BLNu/ed4JUcsrzS34=
+github.com/anchore/go-make v0.8.1 h1:GAhPXR+9qVQhFB1pfVlHFOzxAt3dTDTUIA7Tp7nx9tg=
+github.com/anchore/go-make v0.8.1/go.mod h1:xALbVsPsDoJnJxdkjPlxOLZV7GbAdT5Pv3gd0kP1Lz0=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
-golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
-golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
-golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
-golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/mod v0.40.0 h1:hUv+3cXcdRHz08UmSiOob7sadHig73uo5bkXxQ/tvUs=
+golang.org/x/mod v0.40.0/go.mod h1:0/weTWkPWGBikyTWAX3dkjVztMmBA5hM0DH6BElSupE=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/pkg/file/temp_dir_generator.go
+++ b/pkg/file/temp_dir_generator.go
@@ -8,8 +8,9 @@ import (
 )
 
 type TempDirGenerator struct {
-	// lock guards every field below it: one generator is shared by all providers in an
-	// ImageProviders() call, so concurrent GetImage calls reach NewGenerator and NewDirectory at once
+	// lock guards rootLocation and children; rootPrefix is write-once at construction.
+	// One generator is shared by all providers in an ImageProviders() call, so concurrent
+	// GetImage calls reach NewDirectory and NewGenerator at once.
 	lock         sync.Mutex
 	rootPrefix   string
 	rootLocation string
@@ -22,7 +23,21 @@ func NewTempDirGenerator(name string) *TempDirGenerator {
 	}
 }
 
-func (t *TempDirGenerator) getOrCreateRootLocation() (string, error) {
+// NewGenerator creates a child generator capable of making sibling temp directories.
+func (t *TempDirGenerator) NewGenerator() *TempDirGenerator {
+	gen := NewTempDirGenerator(t.rootPrefix)
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.children = append(t.children, gen)
+	return gen
+}
+
+// NewDirectory creates a new temp dir within the generators prefix temp dir.
+func (t *TempDirGenerator) NewDirectory(name ...string) (string, error) {
+	// the lock is held across MkdirTemp so a concurrent Cleanup cannot remove the root
+	// between resolving it and creating the dir under it. This is one mkdirat, unlike
+	// Cleanup's RemoveAll, so the hold is constant and does not scale with the tree.
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
@@ -34,33 +49,19 @@ func (t *TempDirGenerator) getOrCreateRootLocation() (string, error) {
 
 		t.rootLocation = location
 	}
-	return t.rootLocation, nil
-}
 
-// NewGenerator creates a child generator capable of making sibling temp directories.
-func (t *TempDirGenerator) NewGenerator() *TempDirGenerator {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
-	gen := NewTempDirGenerator(t.rootPrefix)
-	t.children = append(t.children, gen)
-	return gen
-}
-
-// NewDirectory creates a new temp dir within the generators prefix temp dir.
-func (t *TempDirGenerator) NewDirectory(name ...string) (string, error) {
-	location, err := t.getOrCreateRootLocation()
-	if err != nil {
-		return "", err
-	}
-
-	return os.MkdirTemp(location, strings.Join(name, "-")+"-")
+	return os.MkdirTemp(t.rootLocation, strings.Join(name, "-")+"-")
 }
 
 // Cleanup deletes all temp dirs created by this generator and any child generator.
+// The generator stays usable afterwards: a later NewDirectory starts a fresh root.
 func (t *TempDirGenerator) Cleanup() error {
+	// detach everything under the lock, then do the slow removal outside it. A caller that
+	// races us gets a fresh root rather than a half-deleted one, and a generator attached
+	// after this point is tracked for the next Cleanup instead of being orphaned.
 	t.lock.Lock()
 	children, rootLocation := t.children, t.rootLocation
+	t.children, t.rootLocation = nil, ""
 	t.lock.Unlock()
 
 	var errs []error

--- a/pkg/file/temp_dir_generator_test.go
+++ b/pkg/file/temp_dir_generator_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTempDirGenerator(t *testing.T) {
@@ -120,4 +121,76 @@ func TestTempDirGenerator_ConcurrentUse(t *testing.T) {
 	if len(root.children) != 16 {
 		t.Errorf("expected 16 children, got %d", len(root.children))
 	}
+}
+
+// Cleanup detaches the root before removing it, so a NewDirectory that races the removal
+// builds a fresh root rather than creating a dir inside one being deleted (which would
+// leave an orphan behind and fail the removal with ENOTEMPTY).
+func TestTempDirGenerator_cleanupDuringNewDirectory(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		gen := NewTempDirGenerator("cleanup-race-prefix")
+		// enough entries that RemoveAll's readdir pass takes a while
+		for j := 0; j < 64; j++ {
+			_, err := gen.NewDirectory("fill")
+			require.NoError(t, err)
+		}
+
+		var dirs []string
+		var mu sync.Mutex
+		var cleanupErr error
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			cleanupErr = gen.Cleanup()
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			for k := 0; k < 16; k++ {
+				d, err := gen.NewDirectory("racer")
+				require.NoError(t, err, "a NewDirectory racing Cleanup must get a usable dir")
+				mu.Lock()
+				dirs = append(dirs, d)
+				mu.Unlock()
+			}
+		}()
+		close(start)
+		wg.Wait()
+
+		require.NoError(t, cleanupErr, "cleanup must not trip over a concurrently created dir")
+
+		// whatever the racer created is still tracked, so a shutdown cleanup reclaims it
+		require.NoError(t, gen.Cleanup())
+		for _, d := range dirs {
+			assert.NoDirExists(t, d, "cleanup left an orphaned dir behind")
+			assert.NoDirExists(t, path.Dir(d), "cleanup left an orphaned root behind")
+		}
+	}
+}
+
+// Cleanup is not a one-way door: providers share one generator (see providers.go), and one
+// provider cleaning up on failure must not poison the generator for the providers after it.
+func TestTempDirGenerator_reuseAfterCleanup(t *testing.T) {
+	gen := NewTempDirGenerator("reuse-prefix")
+	t.Cleanup(func() { assert.NoError(t, gen.Cleanup()) })
+
+	first, err := gen.NewDirectory("first")
+	require.NoError(t, err)
+	require.DirExists(t, first)
+
+	require.NoError(t, gen.Cleanup())
+	assert.NoDirExists(t, first)
+
+	second, err := gen.NewDirectory("second")
+	require.NoError(t, err, "generator must be reusable after cleanup")
+	require.DirExists(t, second)
+	assert.NotContains(t, second, path.Dir(first), "reuse must start a fresh root")
+
+	// cleanup is idempotent
+	require.NoError(t, gen.Cleanup())
+	require.NoError(t, gen.Cleanup())
+	assert.NoDirExists(t, second)
 }

--- a/pkg/image/hardlink_semantics_test.go
+++ b/pkg/image/hardlink_semantics_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
Building sources from concurrent goroutines trips the `-race` detector because of the package-global `rootTempDirGenerator`. Every provider goes through its `NewGenerator()`, which appends to `children` with no lock.

`getOrCreateRootLocation` races the same way and can leak a root dir.

This PR adds a `sync.Mutex` on the three methods that touch shared state. The test spins up 50 goroutines off one root (it fails on `main` under `-race`, passes with these changes):

```shell
go test -race -run TestTempDirGenerator_concurrent -count=20 ./pkg/file/
```