### PR TITLE
perf: overlap layer fetch and indexing in Image.Read

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,10 @@ require (
 	golang.org/x/crypto v0.55.0
 )
 
-require golang.org/x/tools v0.49.0
+require (
+	github.com/anchore/go-sync v0.1.2
+	golang.org/x/tools v0.49.0
+)
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/anchore/go-homedir v0.1.1 h1:KpaO5BPrVT7cVMcEZ9KfFfEi0iuo3DtagPGl0C74
 github.com/anchore/go-homedir v0.1.1/go.mod h1:9B0DGhbmMAJVGGEbrlb+PkORM5eDFCEOtZ3xQ22qaLA=
 github.com/anchore/go-logger v0.1.1 h1:HPBNmQVBdYliwaFVUL7oJ3UvSlaoXAMj/ZagAIYaCpA=
 github.com/anchore/go-logger v0.1.1/go.mod h1:ekWuh5BkZVwyXnyEd4fwL29N4pNLssgRsqh2+kFN/b8=
+github.com/anchore/go-sync v0.1.2 h1:RDD5RCanrWqhbtBulqPSZpERadUlgcYjpybYzYd3Uk8=
+github.com/anchore/go-sync v0.1.2/go.mod h1:grjZH059bCHM6f6jh+Y7VYvX/q8YcjkDJqG6nplHGkE=
 github.com/aws/aws-sdk-go-v2 v1.41.2 h1:LuT2rzqNQsauaGkPK/7813XxcZ3o3yePY0Iy891T2ls=
 github.com/aws/aws-sdk-go-v2 v1.41.2/go.mod h1:IvvlAZQXvTXznUPfRVfryiG1fbzE2NGK6m9u39YQ+S4=
 github.com/aws/aws-sdk-go-v2/config v1.32.10 h1:9DMthfO6XWZYLfzZglAgW5Fyou2nRI5CuV44sTedKBI=

--- a/pkg/filetree/index.go
+++ b/pkg/filetree/index.go
@@ -207,7 +207,11 @@ func (c *index) GetByExtension(extensions ...string) ([]IndexEntry, error) {
 func (c *index) GetByBasename(basenames ...string) ([]IndexEntry, error) {
 	c.RLock()
 	defer c.RUnlock()
+	return c.getByBasename(basenames...)
+}
 
+// getByBasename is the lock-free implementation of GetByBasename. The caller must hold at least a read lock.
+func (c *index) getByBasename(basenames ...string) ([]IndexEntry, error) {
 	var entries []IndexEntry
 
 	for _, basename := range basenames {
@@ -249,7 +253,7 @@ func (c *index) GetByBasenameGlob(globs ...string) ([]IndexEntry, error) {
 		var e error
 		c.basenames.Each(func(b string) bool {
 			if patternObj.IsMatch(b) {
-				bns, err := c.GetByBasename(b)
+				bns, err := c.getByBasename(b)
 				if err != nil {
 					e = fmt.Errorf("unable to fetch file references by basename (%q): %w", b, err)
 					return false

--- a/pkg/filetree/index_test.go
+++ b/pkg/filetree/index_test.go
@@ -3,10 +3,13 @@
 package filetree
 
 import (
+	"fmt"
 	"io/fs"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -802,5 +805,54 @@ func TestFileCatalog_GetBasenames(t *testing.T) {
 			actual := fileIndex.(*index).basenames.List()
 			assert.ElementsMatchf(t, tt.want, actual, "diff: %s", cmp.Diff(tt.want, actual))
 		})
+	}
+}
+
+// TestIndex_GetByBasenameGlob_concurrentAddDoesNotDeadlock guards against a nested RLock: sync.RWMutex
+// is not reentrant, so a reader that takes RLock and then, from inside that critical section, takes
+// RLock again deadlocks as soon as a writer's Lock call is pending in between (the pending writer
+// blocks new readers, including the reader's own nested one). GetByBasenameGlob used to call the
+// exported, locking GetByBasename from inside its own RLock, which was only safe while Add ran from a
+// single goroutine after all reads finished. This is no longer true, so Add and searches now race.
+func TestIndex_GetByBasenameGlob_concurrentAddDoesNotDeadlock(t *testing.T) {
+	idx := NewIndex()
+
+	// many basenames so a single GetByBasenameGlob call spends real time inside its RLock, widening
+	// the window for a concurrent Add's Lock() to land in between
+	const seedCount = 2000
+	for i := 0; i < seedCount; i++ {
+		ref := file.NewFileReference(file.Path(fmt.Sprintf("/dir/file-%d.txt", i)))
+		idx.Add(*ref, file.Metadata{Path: string(ref.RealPath), Type: file.TypeRegular})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 300; i++ {
+				_, _ = idx.GetByBasenameGlob("file-*.txt")
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 300; i++ {
+				ref := file.NewFileReference(file.Path(fmt.Sprintf("/dir/extra-%d.txt", i)))
+				idx.Add(*ref, file.Metadata{Path: string(ref.RealPath), Type: file.TypeRegular})
+			}
+		}()
+
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("GetByBasenameGlob and Add deadlocked: a nested RLock inside GetByBasenameGlob blocked behind a pending writer")
 	}
 }

--- a/pkg/image/docker/tarball_provider.go
+++ b/pkg/image/docker/tarball_provider.go
@@ -40,7 +40,7 @@ func (p *tarballImageProvider) Name() string {
 }
 
 // Provide an image object that represents the docker image tar at the configured location on disk.
-func (p *tarballImageProvider) Provide(_ context.Context) (*image.Image, error) {
+func (p *tarballImageProvider) Provide(ctx context.Context) (*image.Image, error) {
 	startTime := time.Now()
 
 	img, err := tarball.ImageFromPath(p.path, nil)
@@ -98,7 +98,7 @@ func (p *tarballImageProvider) Provide(_ context.Context) (*image.Image, error) 
 	}
 
 	out := image.New(img, p.tmpDirGen, contentTempDir, metadata...)
-	err = out.Read()
+	err = out.Read(ctx)
 	if err != nil {
 		cleanErr := out.Cleanup()
 		return nil, errors.Join(err, cleanErr)

--- a/pkg/image/hardlink_semantics_test.go
+++ b/pkg/image/hardlink_semantics_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"maps"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -352,6 +354,31 @@ func (i *Image) Read(ctx context.Context) error {
 func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *FileCatalog, readProg *progress.Manual, gates *layerGates) error {
 	ctx = withLayerExecutors(ctx, len(layers))
 
+	// errors are recorded by layer index and reported in that order. Both stages run every layer
+	// they were given, so several can fail, and go-sync joins its own errors in completion order -
+	// which would name a different layer first from one run to the next.
+	var (
+		errMu     sync.Mutex
+		layerErrs = map[int]error{}
+	)
+	recordErr := func(idx int, err error) {
+		errMu.Lock()
+		defer errMu.Unlock()
+		if _, seen := layerErrs[idx]; !seen {
+			layerErrs[idx] = err
+		}
+	}
+	orderedErrs := func() []error {
+		errMu.Lock()
+		defer errMu.Unlock()
+		idxs := slices.Sorted(maps.Keys(layerErrs))
+		out := make([]error, 0, len(idxs))
+		for _, idx := range idxs {
+			out = append(out, layerErrs[idx])
+		}
+		return out
+	}
+
 	idxs := make([]int, len(layers))
 	for n := range idxs {
 		idxs[n] = n
@@ -370,7 +397,10 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 				if err := layers[idx].fetch(idx, i.contentCacheDir); err != nil {
 					// the index stage will never see this layer, so open its gate here
 					gates.done(idx, false)
-					return idx, fmt.Errorf("failed to fetch layer %d: %w", idx, err)
+					// reported through recordErr rather than back to Collect, so that what Collect
+					// returns is only ever a panic it recovered
+					recordErr(idx, fmt.Errorf("failed to fetch layer %d: %w", idx, err))
+					return idx, nil
 				}
 				fetched <- idx
 				return idx, nil
@@ -386,7 +416,8 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 			// open the gate either way: squash decides what to do with the outcome
 			gates.done(idx, err == nil)
 			if err != nil {
-				return idx, fmt.Errorf("failed to index layer %d: %w", idx, err)
+				recordErr(idx, fmt.Errorf("failed to index layer %d: %w", idx, err))
+				return idx, nil
 			}
 			readProg.Increment()
 			return idx, nil
@@ -396,7 +427,8 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 			i.Metadata.Size += layers[idx].Metadata.Size
 		})
 
-	return errors.Join(<-fetchDone, indexErr)
+	// what the stages report, lowest layer first, then anything go-sync recovered on its own
+	return errors.Join(append(orderedErrs(), <-fetchDone, indexErr)...)
 }
 
 // LayerFetchExecutor and LayerIndexExecutor name the go-sync executors bounding each stage of a

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -372,7 +372,7 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 	go func() {
 		err := async.Collect(&fetchCtx, LayerFetchExecutor, async.ToSeq(idxs),
 			func(idx int) (int, error) {
-				if err := layers[idx].Fetch(idx, i.contentCacheDir); err != nil {
+				if err := layers[idx].fetch(idx, i.contentCacheDir); err != nil {
 					// the index stage will never see this layer, so open its gate here
 					gates.done(idx, false)
 					return idx, fmt.Errorf("failed to fetch layer %d: %w", idx, err)
@@ -387,7 +387,7 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 	indexCtx := ctx
 	indexErr := async.Collect(&indexCtx, LayerIndexExecutor, seqOfChannel(fetched),
 		func(idx int) (int, error) {
-			err := layers[idx].Index(fileCatalog)
+			err := layers[idx].index(fileCatalog)
 			// open the gate either way: squash decides what to do with the outcome
 			gates.done(idx, err == nil)
 			if err != nil {

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -267,13 +269,8 @@ func (i *Image) Read(ctx context.Context) error {
 		diffIDs = nil
 	}
 
-	// Layers move through two stages. Fetch downloads and decompresses a layer into the cache;
-	// Index walks the result into the layer's file tree and the shared (mutex-guarded) catalog.
-	// Fetch concurrency is the provider's call: a registry provider asks for one at a time,
-	// because concurrent downloads split a link a single stream already saturates, while local
-	// sources decompress several layers at once. Indexing always runs in parallel, so the previous
-	// layer is indexed while the next one is still downloading. Only the squash below needs the
-	// layers in order, and it runs after every layer is in.
+	// fetch, index and squash all run concurrently from here; see readLayers for how the stages
+	// are bounded and squashLayers for why consuming in manifest order keeps it correct
 	layers := make([]*Layer, len(v1Layers))
 	for idx, v1Layer := range v1Layers {
 		var knownDiffID string
@@ -283,25 +280,56 @@ func (i *Image) Read(ctx context.Context) error {
 		layers[idx] = newLayer(v1Layer, knownDiffID)
 	}
 
-	if err := i.readLayers(ctx, layers, fileCatalog, readProg); err != nil {
-		// release the layers that did read. The caller has an error and may never reach Cleanup,
-		// and a half-built layer set must not be left visible either: accessors like SquashedTree
-		// read the last layer, which here was never squashed. i.Layers is not assigned until
-		// success below, so what needs releasing is the local slice, not i.Layers.
+	// squash runs alongside the read stages rather than after them. It consumes layers in
+	// manifest order, blocking on each layer's gate until that layer is indexed, so layer 0 is
+	// being squashed while layer 3 is still downloading.
+	gates := newLayerGates(len(layers))
+	squashDone := make(chan error, 1)
+	// capture what the goroutine logs, and send last: once Read receives from squashDone it may
+	// return, and a caller is free to call Read again, which rewrites i.Metadata
+	squashDigest := i.Metadata.ID
+	go func() {
+		squashStart := time.Now()
+		err := i.squashLayers(layers, gates, readProg)
+		log.WithFields("digest", squashDigest, "time", time.Since(squashStart)).Trace("completed image squash")
+		squashDone <- err
+	}()
+
+	readErr := i.readLayers(ctx, layers, fileCatalog, readProg, gates)
+
+	// release any layer the read never reached, so squash cannot block on a gate that will
+	// never open (a cancelled context stops the stages from starting queued work)
+	gates.releaseAll()
+	squashErr := <-squashDone
+
+	// i.Layers is not assigned until every one of these succeeds, so each failure releases the
+	// local slice rather than i.Layers - the caller has an error and may never reach Cleanup, and
+	// a half-built layer set must not be left visible either: accessors like SquashedTree read the
+	// last layer, which here was never squashed.
+	if readErr != nil {
 		for _, closeErr := range closeLayers(layers) {
 			log.WithFields("error", closeErr).Trace("unable to release a layer tar after a failed read")
 		}
-		return err
+		return readErr
+	}
+	if err := ctx.Err(); err != nil {
+		// checked before squashErr because cancellation is the root cause a caller wants to see:
+		// the stages stop starting queued work, so neither raises a per-layer failure and the
+		// squash just finds layers that were never indexed
+		for _, closeErr := range closeLayers(layers) {
+			log.WithFields("error", closeErr).Trace("unable to release a layer tar after a cancelled read")
+		}
+		return fmt.Errorf("unable to read image: %w", err)
+	}
+	if squashErr != nil {
+		for _, closeErr := range closeLayers(layers) {
+			log.WithFields("error", closeErr).Trace("unable to release a layer tar after a failed squash")
+		}
+		return squashErr
 	}
 	i.Layers = layers
 
-	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image layer copy")
-	lapTime = time.Now()
-
-	// in order to resolve symlinks all squashed trees must be available
-	err = i.squash(readProg)
-
-	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image squash")
+	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image layer read and squash")
 	lapTime = time.Now()
 
 	i.FileCatalog = fileCatalog
@@ -310,7 +338,7 @@ func (i *Image) Read(ctx context.Context) error {
 	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image search context")
 	log.WithFields("digest", i.Metadata.ID, "mediaType", i.Metadata.MediaType, "tags", i.Metadata.Tags, "time", time.Since(startTime)).Info("completed image read")
 
-	return err
+	return nil
 }
 
 // readLayers drives the two stages of a layer read: a fetch stage (download + decompress into the
@@ -326,7 +354,7 @@ func (i *Image) Read(ctx context.Context) error {
 // Errors from both stages are joined. Panics inside either stage are captured as errors rather
 // than taking down the process, and a cancelled context stops either stage from starting more
 // work.
-func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *FileCatalog, readProg *progress.Manual) error {
+func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *FileCatalog, readProg *progress.Manual, gates *layerGates) error {
 	ctx = i.withLayerExecutors(ctx, len(layers))
 
 	idxs := make([]int, len(layers))
@@ -345,6 +373,8 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 		err := async.Collect(&fetchCtx, LayerFetchExecutor, async.ToSeq(idxs),
 			func(idx int) (int, error) {
 				if err := layers[idx].Fetch(idx, i.contentCacheDir); err != nil {
+					// the index stage will never see this layer, so open its gate here
+					gates.done(idx, false)
 					return idx, fmt.Errorf("failed to fetch layer %d: %w", idx, err)
 				}
 				fetched <- idx
@@ -357,7 +387,10 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 	indexCtx := ctx
 	indexErr := async.Collect(&indexCtx, LayerIndexExecutor, seqOfChannel(fetched),
 		func(idx int) (int, error) {
-			if err := layers[idx].Index(fileCatalog); err != nil {
+			err := layers[idx].Index(fileCatalog)
+			// open the gate either way: squash decides what to do with the outcome
+			gates.done(idx, err == nil)
+			if err != nil {
 				return idx, fmt.Errorf("failed to index layer %d: %w", idx, err)
 			}
 			readProg.Increment()
@@ -395,6 +428,53 @@ func (i *Image) withLayerExecutors(ctx context.Context, layers int) context.Cont
 			async.NewExecutor(layerReadWorkers(layers, 0)))
 	}
 	return ctx
+}
+
+// layerGates lets the squash stage consume layers in manifest order while the read stages
+// complete them in any order: squash blocks on gate idx until the read stages are done with that
+// layer, and learns from the gate whether it is safe to squash.
+//
+// Release is idempotent so the read stages and the caller's cleanup pass can both call it. A
+// layer the read never reached is released as not-ok, which is what stops squash blocking
+// forever on a cancelled read.
+type layerGates struct {
+	wg   []sync.WaitGroup
+	once []sync.Once
+	ok   []atomic.Bool
+}
+
+func newLayerGates(layers int) *layerGates {
+	g := &layerGates{
+		wg:   make([]sync.WaitGroup, layers),
+		once: make([]sync.Once, layers),
+		ok:   make([]atomic.Bool, layers),
+	}
+	for idx := range g.wg {
+		g.wg[idx].Add(1)
+	}
+	return g
+}
+
+// done opens a layer's gate, reporting whether that layer is indexed and safe to squash.
+func (g *layerGates) done(idx int, ok bool) {
+	g.once[idx].Do(func() {
+		g.ok[idx].Store(ok)
+		g.wg[idx].Done()
+	})
+}
+
+// wait blocks until the layer's gate opens and reports whether it is safe to squash.
+func (g *layerGates) wait(idx int) bool {
+	g.wg[idx].Wait()
+	return g.ok[idx].Load()
+}
+
+// releaseAll opens every gate that is still closed, so nothing is left waiting on a layer the
+// read stages never got to.
+func (g *layerGates) releaseAll() {
+	for idx := range g.wg {
+		g.done(idx, false)
+	}
 }
 
 // seqOfChannel adapts a channel to an iter.Seq so a go-sync Collect can consume a stage's output
@@ -440,10 +520,17 @@ func layerReadWorkers(layers int, override int) int {
 
 // squash generates a squash tree for each layer in the image. For instance, layer 2 squash =
 // squash(layer 0, layer 1, layer 2), layer 3 squash = squash(layer 0, layer 1, layer 2, layer 3), and so on.
-func (i *Image) squash(prog *progress.Manual) error {
+func (i *Image) squashLayers(layers []*Layer, gates *layerGates, prog *progress.Manual) error {
 	var lastSquashTree filetree.ReadWriter
 
-	for idx, layer := range i.Layers {
+	for idx, layer := range layers {
+		if !gates.wait(idx) {
+			// the read stages gave up on this layer, so there is no tree to squash. Report it
+			// rather than returning nil and trusting the read stages to raise something: if their
+			// error is ever lost, a nil return here lets Read carry on and build the image search
+			// context over a layer that was never squashed, which panics on the nil tree.
+			return fmt.Errorf("unable to squash: layer %d was not indexed", idx)
+		}
 		if idx == 0 {
 			lastSquashTree = layer.Tree.(filetree.ReadWriter)
 			layer.SquashedTree = layer.Tree

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -384,10 +384,14 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 		idxs[n] = n
 	}
 
-	// fetched hands layer indexes from the fetch stage to the index stage. Buffered to the layer
-	// count so a fetch worker can never block on the handoff, which keeps the two stages free of
-	// any ordering dependency on each other.
-	fetched := make(chan int, len(layers))
+	// fetched hands layer indexes from the fetch stage to the index stage. Small and bounded on
+	// purpose: a fetch worker blocking here is backpressure, not a bug, so decompressed-but-
+	// unindexed layers cannot pile up unbounded while indexing lags behind. This cannot deadlock -
+	// index tasks never submit work back to the fetch stage or this channel, so the index side
+	// always keeps draining until it is done or ctx is cancelled, and a fetch worker that is
+	// blocked on the handoff when the caller cancels bails out via ctx rather than blocking
+	// forever on a stage that has stopped reading.
+	fetched := make(chan int, 1)
 	fetchDone := make(chan error, 1)
 
 	fetchCtx := ctx
@@ -402,15 +406,28 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 					recordErr(idx, fmt.Errorf("failed to fetch layer %d: %w", idx, err))
 					return idx, nil
 				}
-				fetched <- idx
+				// ctx may already be cancelled by the caller by the time this fetch finishes;
+				// bail via Done rather than block forever on a handoff nothing is reading anymore
+				select {
+				case fetched <- idx:
+				case <-fetchCtx.Done():
+					gates.done(idx, false)
+				}
 				return idx, nil
 			}, nil)
-		close(fetched)
+		// only safe once every fetch worker above has actually returned. Collect can return here
+		// while a worker is still parked in the select above, but only by taking its ctx.Done
+		// branch - and that branch can only fire once ctx is cancelled, which is permanent, so if
+		// we observe no cancellation here Collect must have waited for all of them (its ctx.Done
+		// alternative never became ready)
+		if fetchCtx.Err() == nil {
+			close(fetched)
+		}
 		fetchDone <- err
 	}()
 
 	indexCtx := ctx
-	indexErr := async.Collect(&indexCtx, LayerIndexExecutor, seqOfChannel(fetched),
+	indexErr := async.Collect(&indexCtx, LayerIndexExecutor, seqOfChannel(indexCtx, fetched),
 		func(idx int) (int, error) {
 			err := layers[idx].index(fileCatalog)
 			// open the gate either way: squash decides what to do with the outcome
@@ -511,11 +528,23 @@ func (g *layerGates) releaseAll() {
 }
 
 // seqOfChannel adapts a channel to an iter.Seq so a go-sync Collect can consume a stage's output
-// as it is produced rather than waiting for all of it.
-func seqOfChannel[T any](ch <-chan T) iter.Seq[T] {
+// as it is produced rather than waiting for all of it. Also watches ctx directly: Collect's own
+// cancellation check only runs between values it already received, so a plain channel range would
+// hang forever waiting on a value that a cancelled upstream stage has stopped sending (and may
+// never close, since closing an unclosed channel here is what a concurrent, still-in-flight sender
+// could panic on).
+func seqOfChannel[T any](ctx context.Context, ch <-chan T) iter.Seq[T] {
 	return func(yield func(T) bool) {
-		for v := range ch {
-			if !yield(v) {
+		for {
+			select {
+			case v, ok := <-ch:
+				if !ok {
+					return
+				}
+				if !yield(v) {
+					return
+				}
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -215,7 +216,10 @@ func (i *Image) applyOverrideMetadata() error {
 
 // Read parses information from the underlying image tar into this struct. This includes image metadata, layer
 // metadata, layer file trees, and layer squash trees (which implies the image squash tree).
-func (i *Image) Read() error {
+//
+// The context bounds the read: cancelling it abandons work that has not started and stops the
+// layer pools from picking up more.
+func (i *Image) Read(ctx context.Context) error {
 	var err error
 	i.Metadata, err = readImageMetadata(i.image)
 	if err != nil {

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -319,7 +319,15 @@ func (i *Image) Read(ctx context.Context) error {
 	lapTime = time.Now()
 
 	i.FileCatalog = fileCatalog
-	i.SquashedSearchContext = filetree.NewSearchContext(i.SquashedTree(), i.FileCatalog)
+	// the top layer's squash IS the image squash, and squashLayers already built a search context
+	// over that same tree and index. Rebuilding it here walked every symlink and hardlink in the
+	// whole catalog a second time, which with the squash now overlapped was the largest piece of
+	// serial work left in Read.
+	if len(i.Layers) > 0 {
+		i.SquashedSearchContext = i.Layers[len(i.Layers)-1].SquashedSearchContext
+	} else {
+		i.SquashedSearchContext = filetree.NewSearchContext(i.SquashedTree(), i.FileCatalog)
+	}
 
 	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image search context")
 	log.WithFields("digest", i.Metadata.ID, "mediaType", i.Metadata.MediaType, "tags", i.Metadata.Tags, "time", time.Since(startTime)).Info("completed image read")

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -41,9 +43,26 @@ type Image struct {
 	SquashedSearchContext filetree.Searcher
 
 	overrideMetadata []AdditionalMetadata
+
+	// layerReadConcurrency is the per-image override for how many layers are read at once (0 = default)
+	layerReadConcurrency int
 }
 
 type AdditionalMetadata func(*Image) error
+
+// WithLayerReadConcurrency bounds how many layers this image fetches (downloads and decompresses)
+// at once; indexing of fetched layers always proceeds in parallel alongside. Providers that read
+// from a network source pass 1: even two concurrent downloads split a link that a single stream
+// already saturates (measured against nvcr.io: one stream ~62 MB/s, two ~20% slower overall, four
+// ~27 MB/s in aggregate), and the overlap worth having - indexing the previous layer while the next
+// downloads - does not need a second download. Local sources - daemon tarballs, OCI layouts - are
+// disk-bound and use the default.
+func WithLayerReadConcurrency(n int) AdditionalMetadata {
+	return func(image *Image) error {
+		image.layerReadConcurrency = n
+		return nil
+	}
+}
 
 func WithTags(tags ...string) AdditionalMetadata {
 	return func(image *Image) error {
@@ -243,29 +262,36 @@ func (i *Image) Read() error {
 		diffIDs = nil
 	}
 
+	// Layers move through two stages. Fetch downloads and decompresses a layer into the cache;
+	// Index walks the result into the layer's file tree and the shared (mutex-guarded) catalog.
+	// Fetch concurrency is the provider's call: a registry provider asks for one at a time,
+	// because concurrent downloads split a link a single stream already saturates, while local
+	// sources decompress several layers at once. Indexing always runs in parallel, so the previous
+	// layer is indexed while the next one is still downloading. Only the squash below needs the
+	// layers in order, and it runs after every layer is in.
+	layers := make([]*Layer, len(v1Layers))
 	for idx, v1Layer := range v1Layers {
 		var knownDiffID string
 		if diffIDs != nil {
 			knownDiffID = diffIDs[idx].String()
 		}
-
-		layer := newLayer(v1Layer, knownDiffID)
-		if err := layer.Read(fileCatalog, idx, i.contentCacheDir); err != nil {
-			// release the layers that did read. The caller has an error and may never reach Cleanup,
-			// and a half-built layer set must not be left visible either: accessors like SquashedTree
-			// read the last layer, which here was never squashed.
-			// A failed Layer.Read holds nothing itself, NewTarIndex closes its own handle
-			for _, closeErr := range i.closeLayers() {
-				log.WithFields("error", closeErr).Trace("unable to release a layer tar after a failed read")
-			}
-			i.Layers = nil
-			return err
-		}
-		i.Layers = append(i.Layers, layer)
-		i.Metadata.Size += layer.Metadata.Size
-
-		readProg.Increment()
+		layers[idx] = newLayer(v1Layer, knownDiffID)
 	}
+
+	if err := i.readLayers(layers, fileCatalog, readProg); err != nil {
+		// release the layers that did read. The caller has an error and may never reach Cleanup,
+		// and a half-built layer set must not be left visible either: accessors like SquashedTree
+		// read the last layer, which here was never squashed. i.Layers is not assigned until
+		// success below, so what needs releasing is the local slice, not i.Layers.
+		for _, closeErr := range closeLayers(layers) {
+			log.WithFields("error", closeErr).Trace("unable to release a layer tar after a failed read")
+		}
+		return err
+	}
+	for _, layer := range layers {
+		i.Metadata.Size += layer.Metadata.Size
+	}
+	i.Layers = layers
 
 	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image layer copy")
 	lapTime = time.Now()
@@ -283,6 +309,113 @@ func (i *Image) Read() error {
 	log.WithFields("digest", i.Metadata.ID, "mediaType", i.Metadata.MediaType, "tags", i.Metadata.Tags, "time", time.Since(startTime)).Info("completed image read")
 
 	return err
+}
+
+// readLayers drives the two stages of a layer read over the image's layers: a fetch pool
+// (download + decompress into the cache) sized by the provider's concurrency choice, and an index
+// pool (tar walk into the file catalog) that always runs alongside, so the previous layer is
+// indexed while the next is still being fetched. It returns the first error any layer hit.
+func (i *Image) readLayers(layers []*Layer, fileCatalog *FileCatalog, readProg *progress.Manual) error {
+	fetchWorkers := layerReadWorkers(len(layers), i.layerReadConcurrency)
+	indexWorkers := layerReadWorkers(len(layers), 0)
+
+	var (
+		errMu    sync.Mutex
+		firstErr error
+	)
+	fail := func(stage string, idx int, err error) {
+		errMu.Lock()
+		defer errMu.Unlock()
+		if firstErr == nil {
+			firstErr = fmt.Errorf("failed to %s layer %d: %w", stage, idx, err)
+		}
+	}
+	failed := func() bool {
+		errMu.Lock()
+		defer errMu.Unlock()
+		return firstErr != nil
+	}
+
+	toFetch := make(chan int)
+	toIndex := make(chan int, len(layers))
+
+	var fetchWG sync.WaitGroup
+	for w := 0; w < fetchWorkers; w++ {
+		fetchWG.Add(1)
+		go func() {
+			defer fetchWG.Done()
+			for idx := range toFetch {
+				if failed() {
+					continue
+				}
+				if err := layers[idx].Fetch(idx, i.contentCacheDir); err != nil {
+					fail("fetch", idx, err)
+					continue
+				}
+				toIndex <- idx
+			}
+		}()
+	}
+	go func() {
+		for idx := range layers {
+			toFetch <- idx
+		}
+		close(toFetch)
+	}()
+	go func() {
+		fetchWG.Wait()
+		close(toIndex)
+	}()
+
+	var indexWG sync.WaitGroup
+	for w := 0; w < indexWorkers; w++ {
+		indexWG.Add(1)
+		go func() {
+			defer indexWG.Done()
+			for idx := range toIndex {
+				if failed() {
+					continue
+				}
+				if err := layers[idx].Index(fileCatalog); err != nil {
+					fail("index", idx, err)
+					continue
+				}
+				readProg.Increment()
+			}
+		}()
+	}
+	indexWG.Wait()
+
+	return firstErr
+}
+
+// LayerReadConcurrency is the default bound on how many layers are fetched at once (and on how many
+// are indexed at once) while an image is read; WithLayerReadConcurrency overrides the fetch bound
+// per image. Zero selects the number of CPUs, at most 8.
+var LayerReadConcurrency int
+
+// RegistryLayerReadConcurrency is what the registry provider asks for: one download at a time, with
+// indexing of already-fetched layers overlapping it.
+const RegistryLayerReadConcurrency = 1
+
+func layerReadWorkers(layers int, override int) int {
+	n := override
+	if n <= 0 {
+		n = LayerReadConcurrency
+	}
+	if n <= 0 {
+		n = runtime.NumCPU()
+		if n > 8 {
+			n = 8
+		}
+	}
+	if n > layers {
+		n = layers
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
 }
 
 // squash generates a squash tree for each layer in the image. For instance, layer 2 squash =
@@ -393,15 +526,21 @@ func (i *Image) ResolveLinkByImageSquash(ref file.Reference, options ...filetree
 	return resolvedRef, err
 }
 
-// closeLayers releases every layer tar descriptor this image is holding open.
-func (i *Image) closeLayers() []error {
+// closeLayers releases every layer tar descriptor in the given slice. Free-standing so a layer
+// set that never became i.Layers (an in-flight Read that failed) can be released too.
+func closeLayers(layers []*Layer) []error {
 	var errs []error
-	for _, l := range i.Layers {
+	for _, l := range layers {
 		if err := l.close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errs
+}
+
+// closeLayers releases every layer tar descriptor this image is holding open.
+func (i *Image) closeLayers() []error {
+	return closeLayers(i.Layers)
 }
 
 // Cleanup removes all temporary files created from parsing the image. Future calls to image will not function correctly after this call.

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -349,17 +349,27 @@ func (i *Image) Read(ctx context.Context) error {
 // express.
 //
 // Errors from both stages are joined. Panics inside either stage are captured as errors rather
-// than taking down the process, and a cancelled context stops either stage from starting more
-// work.
+// than taking down the process. A cancelled context stops either stage from starting more work,
+// and the first layer failure sets an internal flag that does the same to its peers' fetches -
+// no sense downloading layer 7 after layer 2 is already known to be corrupt.
 func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *FileCatalog, readProg *progress.Manual, gates *layerGates) error {
 	ctx = withLayerExecutors(ctx, len(layers))
 
-	// errors are recorded by layer index and reported in that order. Both stages run every layer
-	// they were given, so several can fail, and go-sync joins its own errors in completion order -
-	// which would name a different layer first from one run to the next.
+	// errors are recorded by layer index and reported in that order. Both stages can run several
+	// layers before either one fails, so more than one can fail, and go-sync joins its own errors
+	// in completion order - which would name a different layer first from one run to the next.
+	//
+	// aborted is deliberately not a cancelled context: ctx keeps meaning only "the caller gave
+	// up", checked by Collect itself before queueing and inside each task. Cancelling an internal
+	// context here instead would let Collect's own early return (it does not wait for stragglers
+	// once its context is done) abandon a peer's fetch mid-flight before that peer's own recordErr
+	// call - the very call whose result we are about to read - had a chance to run. aborted only
+	// stops fetchIdxs from handing out layers nothing has started on yet; anything already
+	// dispatched is always run to completion.
 	var (
 		errMu     sync.Mutex
 		layerErrs = map[int]error{}
+		aborted   atomic.Bool
 	)
 	recordErr := func(idx int, err error) {
 		errMu.Lock()
@@ -367,6 +377,7 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 		if _, seen := layerErrs[idx]; !seen {
 			layerErrs[idx] = err
 		}
+		aborted.Store(true)
 	}
 	orderedErrs := func() []error {
 		errMu.Lock()
@@ -384,6 +395,20 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 		idxs[n] = n
 	}
 
+	// fetchIdxs stops handing out new layer indices once aborted is set, so Collect never starts
+	// a fetch for a layer we already know we will not need. Whatever it already started keeps
+	// running to completion regardless - see the aborted comment above for why that matters.
+	fetchIdxs := func(yield func(int) bool) {
+		for _, idx := range idxs {
+			if aborted.Load() {
+				return
+			}
+			if !yield(idx) {
+				return
+			}
+		}
+	}
+
 	// fetched hands layer indexes from the fetch stage to the index stage. Small and bounded on
 	// purpose: a fetch worker blocking here is backpressure, not a bug, so decompressed-but-
 	// unindexed layers cannot pile up unbounded while indexing lags behind. This cannot deadlock -
@@ -396,7 +421,7 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 
 	fetchCtx := ctx
 	go func() {
-		err := async.Collect(&fetchCtx, LayerFetchExecutor, async.ToSeq(idxs),
+		err := async.Collect(&fetchCtx, LayerFetchExecutor, fetchIdxs,
 			func(idx int) (int, error) {
 				if err := layers[idx].fetch(idx, i.contentCacheDir); err != nil {
 					// the index stage will never see this layer, so open its gate here
@@ -444,8 +469,12 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 			i.Metadata.Size += layers[idx].Metadata.Size
 		})
 
+	// fetchDone is read before orderedErrs, not inline in the Join call: Collect only guarantees
+	// the fetch stage's own recordErr calls are visible once it has actually signalled done, and
+	// argument evaluation order would otherwise let orderedErrs run first and race them.
+	fetchErr := <-fetchDone
 	// what the stages report, lowest layer first, then anything go-sync recovered on its own
-	return errors.Join(append(orderedErrs(), <-fetchDone, indexErr)...)
+	return errors.Join(append(orderedErrs(), fetchErr, indexErr)...)
 }
 
 // LayerFetchExecutor and LayerIndexExecutor name the go-sync executors bounding each stage of a

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -234,6 +234,9 @@ func (i *Image) Read(ctx context.Context) error {
 
 	// let consumers know of a monitorable event (image save + copy stages)
 	readProg := i.trackReadProgress(i.Metadata)
+	// deferred rather than completed at the end of the squash: every early return between here and
+	// there used to leave a consumer's bar stuck at whatever it had reached
+	defer readProg.SetCompleted()
 
 	fileCatalog := NewFileCatalog()
 
@@ -538,8 +541,6 @@ func (i *Image) squashLayers(layers []*Layer, gates *layerGates, prog *progress.
 
 		prog.Increment()
 	}
-
-	prog.SetCompleted()
 
 	return nil
 }

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -47,26 +47,9 @@ type Image struct {
 	SquashedSearchContext filetree.Searcher
 
 	overrideMetadata []AdditionalMetadata
-
-	// layerReadConcurrency is the per-image override for how many layers are read at once (0 = default)
-	layerReadConcurrency int
 }
 
 type AdditionalMetadata func(*Image) error
-
-// WithLayerReadConcurrency bounds how many layers this image fetches (downloads and decompresses)
-// at once; indexing of fetched layers always proceeds in parallel alongside. Providers that read
-// from a network source pass 1: even two concurrent downloads split a link that a single stream
-// already saturates (measured against nvcr.io: one stream ~62 MB/s, two ~20% slower overall, four
-// ~27 MB/s in aggregate), and the overlap worth having - indexing the previous layer while the next
-// downloads - does not need a second download. Local sources - daemon tarballs, OCI layouts - are
-// disk-bound and use the default.
-func WithLayerReadConcurrency(n int) AdditionalMetadata {
-	return func(image *Image) error {
-		image.layerReadConcurrency = n
-		return nil
-	}
-}
 
 func WithTags(tags ...string) AdditionalMetadata {
 	return func(image *Image) error {
@@ -347,15 +330,16 @@ func (i *Image) Read(ctx context.Context) error {
 //
 // Each stage is bounded by its own go-sync executor pulled from the context, which is what lets a
 // caller fold stereoscope into a process-wide concurrency budget: install executors under
-// LayerFetchExecutor and LayerIndexExecutor and they win. Read installs defaults when they are
-// absent, so the two bounds stay independent - the registry provider wants one download at a time
-// and eight indexers, which a single fused bound cannot express.
+// LayerFetchExecutor and LayerIndexExecutor and they win. Read fills in the default for whichever
+// stage the caller left out, so the two bounds stay independent - the registry provider installs a
+// fetch executor of one and leaves indexing at the default, which a single fused bound cannot
+// express.
 //
 // Errors from both stages are joined. Panics inside either stage are captured as errors rather
 // than taking down the process, and a cancelled context stops either stage from starting more
 // work.
 func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *FileCatalog, readProg *progress.Manual, gates *layerGates) error {
-	ctx = i.withLayerExecutors(ctx, len(layers))
+	ctx = withLayerExecutors(ctx, len(layers))
 
 	idxs := make([]int, len(layers))
 	for n := range idxs {
@@ -418,14 +402,12 @@ const (
 // withLayerExecutors fills in the stage executors this image should use for any the caller has not
 // supplied. Never bounded at zero: a zero-concurrency go-sync executor runs inline on the caller's
 // goroutine, which would collapse the two stages back into one and lose the overlap.
-func (i *Image) withLayerExecutors(ctx context.Context, layers int) context.Context {
+func withLayerExecutors(ctx context.Context, layers int) context.Context {
 	if !async.HasContextExecutor(ctx, LayerFetchExecutor) {
-		ctx = async.SetContextExecutor(ctx, LayerFetchExecutor,
-			async.NewExecutor(layerReadWorkers(layers, i.layerReadConcurrency)))
+		ctx = async.SetContextExecutor(ctx, LayerFetchExecutor, async.NewExecutor(layerReadWorkers(layers)))
 	}
 	if !async.HasContextExecutor(ctx, LayerIndexExecutor) {
-		ctx = async.SetContextExecutor(ctx, LayerIndexExecutor,
-			async.NewExecutor(layerReadWorkers(layers, 0)))
+		ctx = async.SetContextExecutor(ctx, LayerIndexExecutor, async.NewExecutor(layerReadWorkers(layers)))
 	}
 	return ctx
 }
@@ -489,25 +471,12 @@ func seqOfChannel[T any](ch <-chan T) iter.Seq[T] {
 	}
 }
 
-// LayerReadConcurrency is the default bound on how many layers are fetched at once (and on how many
-// are indexed at once) while an image is read; WithLayerReadConcurrency overrides the fetch bound
-// per image. Zero selects the number of CPUs, at most 8.
-var LayerReadConcurrency int
-
-// RegistryLayerReadConcurrency is what the registry provider asks for: one download at a time, with
-// indexing of already-fetched layers overlapping it.
-const RegistryLayerReadConcurrency = 1
-
-func layerReadWorkers(layers int, override int) int {
-	n := override
-	if n <= 0 {
-		n = LayerReadConcurrency
-	}
-	if n <= 0 {
-		n = runtime.NumCPU()
-		if n > 8 {
-			n = 8
-		}
+// layerReadWorkers is the default bound for a layer-read stage when the caller has not installed
+// an executor of its own: the number of CPUs, capped at 8, and never more workers than layers.
+func layerReadWorkers(layers int) int {
+	n := runtime.NumCPU()
+	if n > 8 {
+		n = 8
 	}
 	if n > layers {
 		n = layers

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -409,14 +409,17 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 		}
 	}
 
-	// fetched hands layer indexes from the fetch stage to the index stage. Small and bounded on
-	// purpose: a fetch worker blocking here is backpressure, not a bug, so decompressed-but-
-	// unindexed layers cannot pile up unbounded while indexing lags behind. This cannot deadlock -
-	// index tasks never submit work back to the fetch stage or this channel, so the index side
-	// always keeps draining until it is done or ctx is cancelled, and a fetch worker that is
-	// blocked on the handoff when the caller cancels bails out via ctx rather than blocking
-	// forever on a stage that has stopped reading.
-	fetched := make(chan int, 1)
+	// fetched hands layer indexes from the fetch stage to the index stage, buffered so that a send
+	// can never block: there are at most len(layers) of them.
+	//
+	// Do not shrink this to bound the fetch-ahead. The two stages can share one bounded executor -
+	// go-sync resolves a missing named executor to ExecutorDefault, and errGroupExecutor.Go blocks
+	// once its limit is reached, and its ChildExecutor caches a single child that both stages then
+	// resolve to. A fetch worker parked on a full channel is holding a slot the index stage needs
+	// to drain it, and with a limit of one that is a deadlock, reproducible today. Bounding the
+	// fetch-ahead has to happen where no worker slot is held: in fetchIdxs, which runs on the
+	// submitting goroutine, gated on how many layers are fetched but not yet indexed.
+	fetched := make(chan int, len(layers))
 	fetchDone := make(chan error, 1)
 
 	fetchCtx := ctx

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -208,27 +208,14 @@ func (i *Image) applyOverrideMetadata() error {
 // The context bounds the read: cancelling it abandons work that has not started and stops the
 // layer pools from picking up more.
 func (i *Image) Read(ctx context.Context) error {
-	var err error
-	i.Metadata, err = readImageMetadata(i.image)
-	if err != nil {
-		return err
-	}
-
-	// override any metadata with what the user has provided manually
-	if err = i.applyOverrideMetadata(); err != nil {
-		return err
-	}
-
 	startTime := time.Now()
-	lapTime := startTime
 
-	v1Layers, err := i.image.Layers()
-	if err != nil {
+	if err := i.readMetadata(); err != nil {
 		return err
 	}
 
-	// validate all layer media types before processing
-	if err := validateLayerMediaTypes(v1Layers); err != nil {
+	layers, err := i.buildLayers()
+	if err != nil {
 		return err
 	}
 
@@ -240,37 +227,74 @@ func (i *Image) Read(ctx context.Context) error {
 	// there used to leave a consumer's bar stuck at whatever it had reached
 	defer readProg.SetCompleted()
 
+	// this rebuilds every layer, so release what a previous Read left open. Done here rather than
+	// at the top of Read so that a failure before this point leaves the existing layers usable
+	i.releasePreviousLayers()
+
 	fileCatalog := NewFileCatalog()
 
-	// this rebuilds every layer, so release what a previous Read left open. Deferred to here rather
-	// than the top of Read so that a failure before this point leaves the existing layers usable
+	lapTime := time.Now()
+	if err := i.readAndSquashLayers(ctx, layers, fileCatalog, readProg); err != nil {
+		// i.Layers is not assigned until this succeeds, so a failure releases the local slice
+		// rather than i.Layers - the caller has an error and may never reach Cleanup, and a
+		// half-built layer set must not be left visible either: accessors like SquashedTree read
+		// the last layer, which here was never squashed.
+		for _, closeErr := range closeLayers(layers) {
+			log.WithFields("error", closeErr).Trace("unable to release a layer tar after a failed read")
+		}
+		return err
+	}
+
+	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image layer read and squash")
+	lapTime = time.Now()
+
+	i.Layers = layers
+	i.FileCatalog = fileCatalog
+	i.SquashedSearchContext = i.squashedSearchContext()
+
+	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image search context")
+	log.WithFields("digest", i.Metadata.ID, "mediaType", i.Metadata.MediaType, "tags", i.Metadata.Tags, "time", time.Since(startTime)).Info("completed image read")
+
+	return nil
+}
+
+// readMetadata populates i.Metadata from the image, then lets the caller's overrides have the
+// final word on it.
+func (i *Image) readMetadata() error {
+	var err error
+	i.Metadata, err = readImageMetadata(i.image)
+	if err != nil {
+		return err
+	}
+	return i.applyOverrideMetadata()
+}
+
+// buildLayers resolves the layer set this read will work through, rejecting media types we cannot
+// process up front rather than partway through a read of an image we were never going to finish.
+func (i *Image) buildLayers() ([]*Layer, error) {
+	v1Layers, err := i.image.Layers()
+	if err != nil {
+		return nil, err
+	}
+	if err := validateLayerMediaTypes(v1Layers); err != nil {
+		return nil, err
+	}
+	return newLayers(v1Layers, i.Metadata.Config.RootFS.DiffIDs), nil
+}
+
+// releasePreviousLayers releases every layer tar a previous Read left open and forgets the layers.
+func (i *Image) releasePreviousLayers() {
 	for _, closeErr := range i.closeLayers() {
 		log.WithFields("error", closeErr).Trace("unable to release a layer tar from a previous read")
 	}
 	i.Layers = nil
+}
 
-	// the config already records every layer's diff ID, which saves each layer computing its own
-	// (for an OCI layout that means decompressing the entire layer just to hash it). When the
-	// config does not list exactly one per layer we cannot line them up, so let each layer answer.
-	diffIDs := i.Metadata.Config.RootFS.DiffIDs
-	if len(diffIDs) != len(v1Layers) {
-		diffIDs = nil
-	}
-
-	// fetch, index and squash all run concurrently from here; see readLayers for how the stages
-	// are bounded and squashLayers for why consuming in manifest order keeps it correct
-	layers := make([]*Layer, len(v1Layers))
-	for idx, v1Layer := range v1Layers {
-		var knownDiffID string
-		if diffIDs != nil {
-			knownDiffID = diffIDs[idx].String()
-		}
-		layers[idx] = newLayer(v1Layer, knownDiffID)
-	}
-
-	// squash runs alongside the read stages rather than after them. It consumes layers in
-	// manifest order, blocking on each layer's gate until that layer is indexed, so layer 0 is
-	// being squashed while layer 3 is still downloading.
+// readAndSquashLayers runs the squash alongside the read stages rather than after them: squash
+// consumes layers in manifest order, blocking on each layer's gate until that layer is indexed, so
+// layer 0 is being squashed while layer 3 is still downloading. See readLayers for how the read
+// stages are bounded and squashLayers for why consuming in manifest order keeps it correct.
+func (i *Image) readAndSquashLayers(ctx context.Context, layers []*Layer, fileCatalog *FileCatalog, readProg *progress.Manual) error {
 	gates := newLayerGates(len(layers))
 	squashDone := make(chan error, 1)
 	// capture what the goroutine logs, and send last: once Read receives from squashDone it may
@@ -290,51 +314,27 @@ func (i *Image) Read(ctx context.Context) error {
 	gates.releaseAll()
 	squashErr := <-squashDone
 
-	// i.Layers is not assigned until every one of these succeeds, so each failure releases the
-	// local slice rather than i.Layers - the caller has an error and may never reach Cleanup, and
-	// a half-built layer set must not be left visible either: accessors like SquashedTree read the
-	// last layer, which here was never squashed.
 	if readErr != nil {
-		for _, closeErr := range closeLayers(layers) {
-			log.WithFields("error", closeErr).Trace("unable to release a layer tar after a failed read")
-		}
 		return readErr
 	}
 	if err := ctx.Err(); err != nil {
 		// checked before squashErr because cancellation is the root cause a caller wants to see:
 		// the stages stop starting queued work, so neither raises a per-layer failure and the
 		// squash just finds layers that were never indexed
-		for _, closeErr := range closeLayers(layers) {
-			log.WithFields("error", closeErr).Trace("unable to release a layer tar after a cancelled read")
-		}
 		return fmt.Errorf("unable to read image: %w", err)
 	}
-	if squashErr != nil {
-		for _, closeErr := range closeLayers(layers) {
-			log.WithFields("error", closeErr).Trace("unable to release a layer tar after a failed squash")
-		}
-		return squashErr
-	}
-	i.Layers = layers
+	return squashErr
+}
 
-	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image layer read and squash")
-	lapTime = time.Now()
-
-	i.FileCatalog = fileCatalog
-	// the top layer's squash IS the image squash, and squashLayers already built a search context
-	// over that same tree and index. Rebuilding it here walked every symlink and hardlink in the
-	// whole catalog a second time, which with the squash now overlapped was the largest piece of
-	// serial work left in Read.
+// squashedSearchContext returns the search context for the image squash. The top layer's squash IS
+// the image squash, and squashLayers already built a search context over that same tree and index.
+// Rebuilding it here walked every symlink and hardlink in the whole catalog a second time, which
+// with the squash now overlapped was the largest piece of serial work left in Read.
+func (i *Image) squashedSearchContext() filetree.Searcher {
 	if len(i.Layers) > 0 {
-		i.SquashedSearchContext = i.Layers[len(i.Layers)-1].SquashedSearchContext
-	} else {
-		i.SquashedSearchContext = filetree.NewSearchContext(i.SquashedTree(), i.FileCatalog)
+		return i.Layers[len(i.Layers)-1].SquashedSearchContext
 	}
-
-	log.WithFields("digest", i.Metadata.ID, "time", time.Since(lapTime)).Trace("completed image search context")
-	log.WithFields("digest", i.Metadata.ID, "mediaType", i.Metadata.MediaType, "tags", i.Metadata.Tags, "time", time.Since(startTime)).Info("completed image read")
-
-	return nil
+	return filetree.NewSearchContext(i.SquashedTree(), i.FileCatalog)
 }
 
 // readLayers drives the two stages of a layer read: a fetch stage (download + decompress into the

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -395,19 +395,27 @@ func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *Fi
 //
 // A caller-supplied executor always wins; Read only fills in what is missing.
 const (
-	LayerFetchExecutor = "stereoscope-layer-fetch"
-	LayerIndexExecutor = "stereoscope-layer-index"
+	LayerFetchExecutor = "layer-fetch"
+	LayerIndexExecutor = "layer-index"
 )
 
 // withLayerExecutors fills in the stage executors this image should use for any the caller has not
 // supplied. Never bounded at zero: a zero-concurrency go-sync executor runs inline on the caller's
 // goroutine, which would collapse the two stages back into one and lose the overlap.
 func withLayerExecutors(ctx context.Context, layers int) context.Context {
-	if !async.HasContextExecutor(ctx, LayerFetchExecutor) {
-		ctx = async.SetContextExecutor(ctx, LayerFetchExecutor, async.NewExecutor(layerReadWorkers(layers)))
-	}
-	if !async.HasContextExecutor(ctx, LayerIndexExecutor) {
-		ctx = async.SetContextExecutor(ctx, LayerIndexExecutor, async.NewExecutor(layerReadWorkers(layers)))
+	for _, name := range []string{LayerFetchExecutor, LayerIndexExecutor} {
+		if async.HasContextExecutor(ctx, name) {
+			continue
+		}
+		// go-sync resolves a missing named executor to ExecutorDefault, so a host that installed
+		// one to express a single process-wide budget already has an answer for this stage and we
+		// should not talk over it. Only fill in when there is nothing at all, because the last
+		// fallback go-sync offers is an inline serial executor, which would collapse the two
+		// stages into one and lose the overlap.
+		if async.HasContextExecutor(ctx, async.ExecutorDefault) {
+			continue
+		}
+		ctx = async.SetContextExecutor(ctx, name, async.NewExecutor(layerReadWorkers(layers)))
 	}
 	return ctx
 }
@@ -471,8 +479,16 @@ func seqOfChannel[T any](ch <-chan T) iter.Seq[T] {
 	}
 }
 
-// layerReadWorkers is the default bound for a layer-read stage when the caller has not installed
-// an executor of its own: the number of CPUs, capped at 8, and never more workers than layers.
+// layerReadWorkers is the default bound for a layer-read stage when neither a named executor nor
+// ExecutorDefault is in the context: the number of CPUs, capped at 8, and never more workers than
+// there are layers.
+//
+// The cap is measured, not a guess. Both stages are throughput-bound rather than latency-bound -
+// decompress and write, then read back and walk - so oversubscribing past a handful of workers
+// costs more in contention than it buys in overlap. On a 40-layer image over 12 cores, where the
+// cap actually binds: 4 workers 718ms, 8 workers 679ms, 12 workers 694ms, 24 workers 715ms,
+// 48 workers 746ms. Going wider is slower, so this is not the place to scale with NumCPU alone.
+// Layer count is usually the real ceiling anyway; a 12-layer image cannot use more than 12.
 func layerReadWorkers(layers int) int {
 	n := runtime.NumCPU()
 	if n > 8 {

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -6,10 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"os"
 	"runtime"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -18,6 +18,7 @@ import (
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
 
+	async "github.com/anchore/go-sync"
 	"github.com/anchore/stereoscope/internal/bus"
 	"github.com/anchore/stereoscope/internal/log"
 	"github.com/anchore/stereoscope/pkg/event"
@@ -282,7 +283,7 @@ func (i *Image) Read(ctx context.Context) error {
 		layers[idx] = newLayer(v1Layer, knownDiffID)
 	}
 
-	if err := i.readLayers(layers, fileCatalog, readProg); err != nil {
+	if err := i.readLayers(ctx, layers, fileCatalog, readProg); err != nil {
 		// release the layers that did read. The caller has an error and may never reach Cleanup,
 		// and a half-built layer set must not be left visible either: accessors like SquashedTree
 		// read the last layer, which here was never squashed. i.Layers is not assigned until
@@ -291,9 +292,6 @@ func (i *Image) Read(ctx context.Context) error {
 			log.WithFields("error", closeErr).Trace("unable to release a layer tar after a failed read")
 		}
 		return err
-	}
-	for _, layer := range layers {
-		i.Metadata.Size += layer.Metadata.Size
 	}
 	i.Layers = layers
 
@@ -315,82 +313,100 @@ func (i *Image) Read(ctx context.Context) error {
 	return err
 }
 
-// readLayers drives the two stages of a layer read over the image's layers: a fetch pool
-// (download + decompress into the cache) sized by the provider's concurrency choice, and an index
-// pool (tar walk into the file catalog) that always runs alongside, so the previous layer is
-// indexed while the next is still being fetched. It returns the first error any layer hit.
-func (i *Image) readLayers(layers []*Layer, fileCatalog *FileCatalog, readProg *progress.Manual) error {
-	fetchWorkers := layerReadWorkers(len(layers), i.layerReadConcurrency)
-	indexWorkers := layerReadWorkers(len(layers), 0)
+// readLayers drives the two stages of a layer read: a fetch stage (download + decompress into the
+// cache) and an index stage (tar walk into the file catalog) that runs alongside it, so the
+// previous layer is indexed while the next is still being fetched.
+//
+// Each stage is bounded by its own go-sync executor pulled from the context, which is what lets a
+// caller fold stereoscope into a process-wide concurrency budget: install executors under
+// LayerFetchExecutor and LayerIndexExecutor and they win. Read installs defaults when they are
+// absent, so the two bounds stay independent - the registry provider wants one download at a time
+// and eight indexers, which a single fused bound cannot express.
+//
+// Errors from both stages are joined. Panics inside either stage are captured as errors rather
+// than taking down the process, and a cancelled context stops either stage from starting more
+// work.
+func (i *Image) readLayers(ctx context.Context, layers []*Layer, fileCatalog *FileCatalog, readProg *progress.Manual) error {
+	ctx = i.withLayerExecutors(ctx, len(layers))
 
-	var (
-		errMu    sync.Mutex
-		firstErr error
-	)
-	fail := func(stage string, idx int, err error) {
-		errMu.Lock()
-		defer errMu.Unlock()
-		if firstErr == nil {
-			firstErr = fmt.Errorf("failed to %s layer %d: %w", stage, idx, err)
-		}
-	}
-	failed := func() bool {
-		errMu.Lock()
-		defer errMu.Unlock()
-		return firstErr != nil
+	idxs := make([]int, len(layers))
+	for n := range idxs {
+		idxs[n] = n
 	}
 
-	toFetch := make(chan int)
-	toIndex := make(chan int, len(layers))
+	// fetched hands layer indexes from the fetch stage to the index stage. Buffered to the layer
+	// count so a fetch worker can never block on the handoff, which keeps the two stages free of
+	// any ordering dependency on each other.
+	fetched := make(chan int, len(layers))
+	fetchDone := make(chan error, 1)
 
-	var fetchWG sync.WaitGroup
-	for w := 0; w < fetchWorkers; w++ {
-		fetchWG.Add(1)
-		go func() {
-			defer fetchWG.Done()
-			for idx := range toFetch {
-				if failed() {
-					continue
-				}
+	fetchCtx := ctx
+	go func() {
+		err := async.Collect(&fetchCtx, LayerFetchExecutor, async.ToSeq(idxs),
+			func(idx int) (int, error) {
 				if err := layers[idx].Fetch(idx, i.contentCacheDir); err != nil {
-					fail("fetch", idx, err)
-					continue
+					return idx, fmt.Errorf("failed to fetch layer %d: %w", idx, err)
 				}
-				toIndex <- idx
+				fetched <- idx
+				return idx, nil
+			}, nil)
+		close(fetched)
+		fetchDone <- err
+	}()
+
+	indexCtx := ctx
+	indexErr := async.Collect(&indexCtx, LayerIndexExecutor, seqOfChannel(fetched),
+		func(idx int) (int, error) {
+			if err := layers[idx].Index(fileCatalog); err != nil {
+				return idx, fmt.Errorf("failed to index layer %d: %w", idx, err)
 			}
-		}()
+			readProg.Increment()
+			return idx, nil
+		},
+		// the accumulator is serialised by Collect, so this needs no lock of its own
+		func(idx int, _ int) {
+			i.Metadata.Size += layers[idx].Metadata.Size
+		})
+
+	return errors.Join(<-fetchDone, indexErr)
+}
+
+// LayerFetchExecutor and LayerIndexExecutor name the go-sync executors bounding each stage of a
+// layer read. Install one under either name to take over that stage's concurrency:
+//
+//	ctx = sync.SetContextExecutor(ctx, image.LayerFetchExecutor, sync.NewExecutor(2))
+//
+// A caller-supplied executor always wins; Read only fills in what is missing.
+const (
+	LayerFetchExecutor = "stereoscope-layer-fetch"
+	LayerIndexExecutor = "stereoscope-layer-index"
+)
+
+// withLayerExecutors fills in the stage executors this image should use for any the caller has not
+// supplied. Never bounded at zero: a zero-concurrency go-sync executor runs inline on the caller's
+// goroutine, which would collapse the two stages back into one and lose the overlap.
+func (i *Image) withLayerExecutors(ctx context.Context, layers int) context.Context {
+	if !async.HasContextExecutor(ctx, LayerFetchExecutor) {
+		ctx = async.SetContextExecutor(ctx, LayerFetchExecutor,
+			async.NewExecutor(layerReadWorkers(layers, i.layerReadConcurrency)))
 	}
-	go func() {
-		for idx := range layers {
-			toFetch <- idx
+	if !async.HasContextExecutor(ctx, LayerIndexExecutor) {
+		ctx = async.SetContextExecutor(ctx, LayerIndexExecutor,
+			async.NewExecutor(layerReadWorkers(layers, 0)))
+	}
+	return ctx
+}
+
+// seqOfChannel adapts a channel to an iter.Seq so a go-sync Collect can consume a stage's output
+// as it is produced rather than waiting for all of it.
+func seqOfChannel[T any](ch <-chan T) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for v := range ch {
+			if !yield(v) {
+				return
+			}
 		}
-		close(toFetch)
-	}()
-	go func() {
-		fetchWG.Wait()
-		close(toIndex)
-	}()
-
-	var indexWG sync.WaitGroup
-	for w := 0; w < indexWorkers; w++ {
-		indexWG.Add(1)
-		go func() {
-			defer indexWG.Done()
-			for idx := range toIndex {
-				if failed() {
-					continue
-				}
-				if err := layers[idx].Index(fileCatalog); err != nil {
-					fail("index", idx, err)
-					continue
-				}
-				readProg.Increment()
-			}
-		}()
 	}
-	indexWG.Wait()
-
-	return firstErr
 }
 
 // LayerReadConcurrency is the default bound on how many layers are fetched at once (and on how many

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"archive/tar"
+	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -186,7 +187,7 @@ func TestImage_SecondReadReleasesTheFirstReadsTars(t *testing.T) {
 	// Read() looks idempotent and is called twice in the wild: pkg/image/sif/archive_provider_test.go
 	// and test/integration/oci_registry_source_test.go both re-read an already-read image
 	firstIndex := img.Layers[0].indexedContent
-	require.NoError(t, img.Read())
+	require.NoError(t, img.Read(context.Background()))
 	require.NotSame(t, firstIndex, img.Layers[0].indexedContent, "second Read builds a fresh index")
 
 	// the second Read replaced the first one's layers, so it had to release them on the way past:
@@ -211,7 +212,7 @@ func TestImage_PartialReadReleasesEarlierLayers(t *testing.T) {
 	// layer one reads fine and opens its tar, layer two fails. Counting descriptors rather than
 	// reaching for the index, because a failed Read must not leave the half-built layer set behind
 	before := testutil.OpenDescriptorCount(t)
-	require.Error(t, img.Read(), "expected the second layer to fail the read")
+	require.Error(t, img.Read(context.Background()), "expected the second layer to fail the read")
 	require.Equal(t, before, testutil.OpenDescriptorCount(t), "a partial read leaked the first layer's tar")
 
 	// and the image must stay safe to touch: accessors read the last layer, which on a partial read

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -92,6 +92,10 @@ type Layer struct {
 	// knownDiffID is the layer's diff ID as recorded in the image config, when the image could
 	// supply it; it saves computing the diff ID from the layer contents.
 	knownDiffID string
+	// contentPath is where Fetch materialized the uncompressed layer
+	contentPath string
+	// readMonitor reports indexing progress for this layer
+	readMonitor *progress.Manual
 }
 
 // NewLayer provides a new, unread layer object.
@@ -170,8 +174,42 @@ func (l *Layer) close() error {
 }
 
 // Read parses information from the underlying layer tar into this struct. This includes layer metadata, the layer
-// file tree, and the layer squash tree.
+// file tree, and the layer squash tree. It is Fetch followed by Index.
 func (l *Layer) Read(catalog *FileCatalog, idx int, uncompressedLayersCacheDir string) error {
+	if err := l.Fetch(idx, uncompressedLayersCacheDir); err != nil {
+		return err
+	}
+	return l.Index(catalog)
+}
+
+// Fetch resolves the layer's metadata and materializes its uncompressed contents in the cache
+// directory - the network download and decompression, for a registry layer. It does no indexing, so
+// an image can keep one layer's download going while other layers are indexed (see Image.Read).
+func (l *Layer) Fetch(idx int, uncompressedLayersCacheDir string) error {
+	mediaType, err := l.layer.MediaType()
+	if err != nil {
+		return err
+	}
+	if !standardLayerMediaTypes.Has(string(mediaType)) && !singularityLayerMediaTypes.Has(string(mediaType)) {
+		return fmt.Errorf("unknown layer media type: %+v", mediaType)
+	}
+
+	l.Metadata, err = newLayerMetadata(l.layer, idx, l.knownDiffID)
+	if err != nil {
+		return err
+	}
+	l.readMonitor = trackReadProgress(l.Metadata)
+
+	log.WithFields("index", l.Metadata.Index, "digest", l.Metadata.Digest, "mediaType", l.Metadata.MediaType).Trace("fetching image layer")
+	l.contentPath, err = l.uncompressedCache(uncompressedLayersCacheDir)
+	return err
+}
+
+// Index builds the layer's file tree and catalog entries from the contents Fetch materialized.
+func (l *Layer) Index(catalog *FileCatalog) error {
+	if l.contentPath == "" {
+		return fmt.Errorf("layer %d has not been fetched", l.Metadata.Index)
+	}
 	mediaType, err := l.layer.MediaType()
 	if err != nil {
 		return err
@@ -179,13 +217,14 @@ func (l *Layer) Read(catalog *FileCatalog, idx int, uncompressedLayersCacheDir s
 	tree := filetree.New()
 	l.Tree = tree
 	l.fileCatalog = catalog
+	idx := int(l.Metadata.Index)
 
 	var readErr error
 	switch {
 	case standardLayerMediaTypes.Has(string(mediaType)):
-		readErr = l.readStandardImageLayer(idx, uncompressedLayersCacheDir, tree)
+		readErr = l.indexStandardImageLayer(tree)
 	case singularityLayerMediaTypes.Has(string(mediaType)):
-		readErr = l.readSingularityImageLayer(idx, uncompressedLayersCacheDir, tree)
+		readErr = l.indexSingularityImageLayer(tree)
 	default:
 		return fmt.Errorf("unknown layer media type: %+v", mediaType)
 	}
@@ -200,58 +239,30 @@ func (l *Layer) Read(catalog *FileCatalog, idx int, uncompressedLayersCacheDir s
 	return nil
 }
 
-func (l *Layer) readStandardImageLayer(idx int, uncompressedLayersCacheDir string, tree *filetree.FileTree) error {
+func (l *Layer) indexStandardImageLayer(tree *filetree.FileTree) error {
 	var err error
-	l.Metadata, err = newLayerMetadata(l.layer, idx, l.knownDiffID)
-	monitor := trackReadProgress(l.Metadata)
-	if err != nil {
-		return err
-	}
-
-	log.WithFields("index", l.Metadata.Index, "digest", l.Metadata.Digest, "mediaType", l.Metadata.MediaType).Trace("reading uncompressed image layer")
-
-	tarFilePath, err := l.uncompressedCache(uncompressedLayersCacheDir)
-	if err != nil {
-		return err
-	}
-
 	startTime := time.Now()
 	l.indexedContent, err = file.NewTarIndex(
-		tarFilePath,
-		layerTarIndexer(tree, l.fileCatalog, &l.Metadata.Size, l, monitor),
+		l.contentPath,
+		layerTarIndexer(tree, l.fileCatalog, &l.Metadata.Size, l, l.readMonitor),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to read layer=%q tar : %w", l.Metadata.Digest, err)
 	}
 	log.WithFields("index", l.Metadata.Index, "digest", l.Metadata.Digest, "mediaType", l.Metadata.MediaType, "time", time.Since(startTime)).Trace("completed indexing image layer")
 
-	monitor.SetCompleted()
+	l.readMonitor.SetCompleted()
 	return nil
 }
 
-func (l *Layer) readSingularityImageLayer(idx int, uncompressedLayersCacheDir string, tree *filetree.FileTree) error {
-	var err error
-	l.Metadata, err = newLayerMetadata(l.layer, idx, l.knownDiffID)
-	if err != nil {
-		return err
+func (l *Layer) indexSingularityImageLayer(tree *filetree.FileTree) error {
+	startTime := time.Now()
+	if err := file.WalkSquashFS(l.contentPath, squashfsVisitor(tree, l.fileCatalog, &l.Metadata.Size, l, l.readMonitor)); err != nil {
+		return fmt.Errorf("failed to walk layer=%q squashfs : %w", l.Metadata.Digest, err)
 	}
+	log.WithFields("index", l.Metadata.Index, "digest", l.Metadata.Digest, "mediaType", l.Metadata.MediaType, "time", time.Since(startTime)).Trace("completed indexing image layer")
 
-	log.Debugf("layer metadata: index=%+v digest=%+v mediaType=%+v",
-		l.Metadata.Index,
-		l.Metadata.Digest,
-		l.Metadata.MediaType)
-
-	monitor := trackReadProgress(l.Metadata)
-	sqfsFilePath, err := l.uncompressedCache(uncompressedLayersCacheDir)
-	if err != nil {
-		return err
-	}
-
-	if err := file.WalkSquashFS(sqfsFilePath, squashfsVisitor(tree, l.fileCatalog, &l.Metadata.Size, l, monitor)); err != nil {
-		return fmt.Errorf("failed to walk layer=%q: %w", l.Metadata.Digest, err)
-	}
-
-	monitor.SetCompleted()
+	l.readMonitor.SetCompleted()
 	return nil
 }
 

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -203,7 +203,6 @@ func (l *Layer) fetch(idx int, uncompressedLayersCacheDir string) error {
 	if err != nil {
 		return err
 	}
-	l.readMonitor = trackReadProgress(l.Metadata)
 
 	log.WithFields("index", l.Metadata.Index, "digest", l.Metadata.Digest, "mediaType", l.Metadata.MediaType).Trace("fetching image layer")
 	l.contentPath, err = l.uncompressedCache(uncompressedLayersCacheDir)
@@ -225,6 +224,12 @@ func (l *Layer) index(catalog *FileCatalog) error {
 	l.Tree = tree
 	l.fileCatalog = catalog
 	idx := int(l.Metadata.Index)
+
+	// published here rather than in fetch: the monitor counts tar entries, which is entirely
+	// index-stage work. Publishing it at fetch time also meant a layer that failed to fetch left a
+	// monitor behind that nothing would ever complete, and that the event order followed fetch
+	// completion rather than the layer order consumers expect.
+	l.readMonitor = trackReadProgress(l.Metadata)
 
 	var readErr error
 	switch {

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -174,18 +174,23 @@ func (l *Layer) close() error {
 }
 
 // Read parses information from the underlying layer tar into this struct. This includes layer metadata, the layer
-// file tree, and the layer squash tree. It is Fetch followed by Index.
+// file tree, and the layer squash tree. It is fetch followed by index.
 func (l *Layer) Read(catalog *FileCatalog, idx int, uncompressedLayersCacheDir string) error {
-	if err := l.Fetch(idx, uncompressedLayersCacheDir); err != nil {
+	if err := l.fetch(idx, uncompressedLayersCacheDir); err != nil {
 		return err
 	}
-	return l.Index(catalog)
+	return l.index(catalog)
 }
 
-// Fetch resolves the layer's metadata and materializes its uncompressed contents in the cache
+// fetch resolves the layer's metadata and materializes its uncompressed contents in the cache
 // directory - the network download and decompression, for a registry layer. It does no indexing, so
 // an image can keep one layer's download going while other layers are indexed (see Image.Read).
-func (l *Layer) Fetch(idx int, uncompressedLayersCacheDir string) error {
+//
+// Unexported deliberately: fetch must run before index, and that ordering is not something the
+// type can enforce for an outside caller. FileCatalog.Layer hands a *Layer to any consumer, so an
+// exported pair would let one of them rebuild a layer out from under every other reader of the
+// same image. Layer lifetime belongs to the Image that read it; Layer.Read is the entry point.
+func (l *Layer) fetch(idx int, uncompressedLayersCacheDir string) error {
 	mediaType, err := l.layer.MediaType()
 	if err != nil {
 		return err
@@ -205,10 +210,12 @@ func (l *Layer) Fetch(idx int, uncompressedLayersCacheDir string) error {
 	return err
 }
 
-// Index builds the layer's file tree and catalog entries from the contents Fetch materialized.
-func (l *Layer) Index(catalog *FileCatalog) error {
+// index builds the layer's file tree and catalog entries from the contents fetch materialized.
+// See fetch for why this is not exported.
+func (l *Layer) index(catalog *FileCatalog) error {
 	if l.contentPath == "" {
-		return fmt.Errorf("layer %d has not been fetched", l.Metadata.Index)
+		// no index to report: Metadata is only populated by fetch, so it is zeroed here
+		return fmt.Errorf("layer contents have not been fetched")
 	}
 	mediaType, err := l.layer.MediaType()
 	if err != nil {

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -112,6 +112,27 @@ func newLayer(layer v1.Layer, knownDiffID string) *Layer {
 	}
 }
 
+// newLayers builds the layer objects in manifest order.
+//
+// The image config already records every layer's diff ID, which saves each layer computing its own
+// (for an OCI layout that means decompressing the entire layer just to hash it). When the config
+// does not list exactly one per layer we cannot line them up, so let each layer answer for itself.
+func newLayers(v1Layers []v1.Layer, diffIDs []v1.Hash) []*Layer {
+	if len(diffIDs) != len(v1Layers) {
+		diffIDs = nil
+	}
+
+	layers := make([]*Layer, len(v1Layers))
+	for idx, v1Layer := range v1Layers {
+		var knownDiffID string
+		if diffIDs != nil {
+			knownDiffID = diffIDs[idx].String()
+		}
+		layers[idx] = newLayer(v1Layer, knownDiffID)
+	}
+	return layers
+}
+
 func (l *Layer) uncompressedCache(uncompressedLayersCacheDir string) (string, error) {
 	if uncompressedLayersCacheDir == "" {
 		return "", fmt.Errorf("no cache directory given")

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -216,14 +216,9 @@ func (l *Layer) index(catalog *FileCatalog) error {
 		// no index to report: Metadata is only populated by fetch, so it is zeroed here
 		return fmt.Errorf("layer contents have not been fetched")
 	}
-	mediaType, err := l.layer.MediaType()
-	if err != nil {
-		return err
-	}
 	tree := filetree.New()
 	l.Tree = tree
 	l.fileCatalog = catalog
-	idx := int(l.Metadata.Index)
 
 	// published here rather than in fetch: the monitor counts tar entries, which is entirely
 	// index-stage work. Publishing it at fetch time also meant a layer that failed to fetch left a
@@ -231,14 +226,15 @@ func (l *Layer) index(catalog *FileCatalog) error {
 	// completion rather than the layer order consumers expect.
 	l.readMonitor = trackReadProgress(l.Metadata)
 
+	// l.Metadata.MediaType was already validated against these same sets by fetch (and, before
+	// that, validateLayerMediaTypes for every layer up front), so there is no unknown case left
+	// to handle here.
 	var readErr error
 	switch {
-	case standardLayerMediaTypes.Has(string(mediaType)):
+	case standardLayerMediaTypes.Has(string(l.Metadata.MediaType)):
 		readErr = l.indexStandardImageLayer(tree)
-	case singularityLayerMediaTypes.Has(string(mediaType)):
+	case singularityLayerMediaTypes.Has(string(l.Metadata.MediaType)):
 		readErr = l.indexSingularityImageLayer(tree)
-	default:
-		return fmt.Errorf("unknown layer media type: %+v", mediaType)
 	}
 	if readErr != nil {
 		return readErr
@@ -246,7 +242,7 @@ func (l *Layer) index(catalog *FileCatalog) error {
 
 	startTime := time.Now()
 	l.SearchContext = filetree.NewSearchContext(l.Tree, l.fileCatalog.Index)
-	log.WithFields("index", idx, "time", time.Since(startTime)).Trace("completed layer search context")
+	log.WithFields("index", l.Metadata.Index, "time", time.Since(startTime)).Trace("completed layer search context")
 
 	return nil
 }

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -1,0 +1,109 @@
+package image
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	v1Types "github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wagoodman/go-progress"
+)
+
+func Test_layerReadWorkers(t *testing.T) {
+	cpuDefault := runtime.NumCPU()
+	if cpuDefault > 8 {
+		cpuDefault = 8
+	}
+
+	tests := []struct {
+		name     string
+		layers   int
+		override int
+		want     int
+	}{
+		{name: "override wins", layers: 10, override: 3, want: 3},
+		{name: "override capped at layer count", layers: 2, override: 8, want: 2},
+		{name: "registry-style single fetch", layers: 10, override: 1, want: 1},
+		{name: "default is CPUs capped at 8 and the layer count", layers: 1000, override: 0, want: cpuDefault},
+		{name: "default capped by layer count", layers: 1, override: 0, want: 1},
+		{name: "never below one worker", layers: 0, override: 3, want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, layerReadWorkers(tt.layers, tt.override))
+		})
+	}
+}
+
+func TestWithLayerReadConcurrency(t *testing.T) {
+	i := &Image{}
+	require.NoError(t, WithLayerReadConcurrency(2)(i))
+	assert.Equal(t, 2, i.layerReadConcurrency)
+}
+
+// randomLayers builds n small, well-formed docker layers.
+func randomLayers(t *testing.T, n int) []*Layer {
+	t.Helper()
+	layers := make([]*Layer, n)
+	for idx := range layers {
+		v1Layer, err := random.Layer(64, v1Types.DockerLayer)
+		require.NoError(t, err)
+		layers[idx] = NewLayer(v1Layer)
+	}
+	return layers
+}
+
+func TestImage_readLayers_concurrentReadKeepsManifestOrder(t *testing.T) {
+	const layerCount = 6
+	layers := randomLayers(t, layerCount)
+
+	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 3}
+	require.NoError(t, i.readLayers(layers, NewFileCatalog(), &progress.Manual{}))
+
+	// completion order is up to the pools; the layer set must still be manifest-ordered and
+	// fully indexed before readLayers returns (the squash that follows depends on both)
+	for idx, layer := range layers {
+		assert.Equalf(t, uint(idx), layer.Metadata.Index, "layer %d out of order", idx)
+		assert.NotNilf(t, layer.Tree, "layer %d was not indexed", idx)
+		assert.NotEmptyf(t, layer.Metadata.Digest, "layer %d has no metadata", idx)
+	}
+}
+
+func TestImage_readLayers_sequentialMatchesConcurrent(t *testing.T) {
+	// a registry-style single-fetch run must produce the same layer set shape as a parallel one
+	for _, concurrency := range []int{1, 4} {
+		layers := randomLayers(t, 4)
+		i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: concurrency}
+		require.NoError(t, i.readLayers(layers, NewFileCatalog(), &progress.Manual{}))
+		for idx, layer := range layers {
+			require.Equal(t, uint(idx), layer.Metadata.Index)
+			require.NotNil(t, layer.Tree)
+		}
+	}
+}
+
+func TestImage_readLayers_failedLayerFailsTheReadWithoutHanging(t *testing.T) {
+	layers := randomLayers(t, 3)
+	// the middle layer fails up front (unknown media type): the read must report that layer and
+	// return - with workers still draining - rather than deadlock or panic
+	layers[1] = NewLayer(fakeLayer("garbage/media-type", nil))
+
+	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 2}
+	err := i.readLayers(layers, NewFileCatalog(), &progress.Manual{})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "layer 1"), "error should name the failed layer: %v", err)
+}
+
+func TestImage_readLayers_firstErrorWinsUnderManyFailures(t *testing.T) {
+	layers := randomLayers(t, 5)
+	for idx := range layers {
+		layers[idx] = NewLayer(fakeLayer("garbage/media-type", nil))
+	}
+	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 4}
+	err := i.readLayers(layers, NewFileCatalog(), &progress.Manual{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch layer")
+}

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	async "github.com/anchore/go-sync"
 	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -466,5 +467,35 @@ func TestImage_Read_panicInAStageBecomesAnError(t *testing.T) {
 		// a panic skips the stage's gates.done, so this also pins that Read's releaseAll
 		// safety net opens the gate the squash is waiting on
 		t.Fatal("Read hung after a panic: the squash gate was never released")
+	}
+}
+
+func TestImage_Read_squashedSearchContextMatchesAFreshlyBuiltOne(t *testing.T) {
+	// Read hands back the top layer's squashed search context rather than rebuilding one over the
+	// same tree and index. That is only safe if the two are interchangeable, so pin it: symlinks
+	// are what NewSearchContext actually indexes, so the fixture carries some.
+	var layers []v1.Layer
+	for idx := 0; idx < 4; idx++ {
+		layers = append(layers, layerFromTarEntries(t,
+			tarEntry{path: fmt.Sprintf("f%d.txt", idx), typeFlag: tar.TypeReg, contents: "x"},
+			tarEntry{path: fmt.Sprintf("s%d", idx), typeFlag: tar.TypeSymlink, linkPath: fmt.Sprintf("f%d.txt", idx)},
+			tarEntry{path: "shared.txt", typeFlag: tar.TypeReg, contents: fmt.Sprintf("v%d", idx)},
+		))
+	}
+	img := readImageFromLayers(t, layers...)
+
+	reused := img.SquashedSearchContext
+	fresh := filetree.NewSearchContext(img.SquashedTree(), img.FileCatalog)
+
+	for _, glob := range []string{"**/*.txt", "**/s*", "**"} {
+		fromReused, err := reused.SearchByGlob(glob)
+		require.NoErrorf(t, err, "glob %q", glob)
+		fromFresh, err := fresh.SearchByGlob(glob)
+		require.NoErrorf(t, err, "glob %q", glob)
+
+		require.Lenf(t, fromReused, len(fromFresh), "glob %q returned a different count", glob)
+		for i := range fromReused {
+			assert.Equalf(t, fromFresh[i].RequestPath, fromReused[i].RequestPath, "glob %q result %d", glob, i)
+		}
 	}
 }

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -1,8 +1,13 @@
 package image
 
 import (
+	"context"
+	async "github.com/anchore/go-sync"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"io"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/v1/random"
@@ -61,7 +66,7 @@ func TestImage_readLayers_concurrentReadKeepsManifestOrder(t *testing.T) {
 	layers := randomLayers(t, layerCount)
 
 	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 3}
-	require.NoError(t, i.readLayers(layers, NewFileCatalog(), &progress.Manual{}))
+	require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}))
 
 	// completion order is up to the pools; the layer set must still be manifest-ordered and
 	// fully indexed before readLayers returns (the squash that follows depends on both)
@@ -77,7 +82,7 @@ func TestImage_readLayers_sequentialMatchesConcurrent(t *testing.T) {
 	for _, concurrency := range []int{1, 4} {
 		layers := randomLayers(t, 4)
 		i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: concurrency}
-		require.NoError(t, i.readLayers(layers, NewFileCatalog(), &progress.Manual{}))
+		require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}))
 		for idx, layer := range layers {
 			require.Equal(t, uint(idx), layer.Metadata.Index)
 			require.NotNil(t, layer.Tree)
@@ -92,7 +97,7 @@ func TestImage_readLayers_failedLayerFailsTheReadWithoutHanging(t *testing.T) {
 	layers[1] = NewLayer(fakeLayer("garbage/media-type", nil))
 
 	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 2}
-	err := i.readLayers(layers, NewFileCatalog(), &progress.Manual{})
+	err := i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{})
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "layer 1"), "error should name the failed layer: %v", err)
 }
@@ -103,7 +108,112 @@ func TestImage_readLayers_firstErrorWinsUnderManyFailures(t *testing.T) {
 		layers[idx] = NewLayer(fakeLayer("garbage/media-type", nil))
 	}
 	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 4}
-	err := i.readLayers(layers, NewFileCatalog(), &progress.Manual{})
+	err := i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to fetch layer")
+}
+
+// countingLayer records the high-water mark of concurrent Uncompressed calls, which is what a
+// fetch bound is supposed to cap.
+type countingLayer struct {
+	v1.Layer
+	inFlight *atomic.Int64
+	maxSeen  *atomic.Int64
+}
+
+func (c *countingLayer) Uncompressed() (io.ReadCloser, error) {
+	n := c.inFlight.Add(1)
+	for {
+		m := c.maxSeen.Load()
+		if n <= m || c.maxSeen.CompareAndSwap(m, n) {
+			break
+		}
+	}
+	rc, err := c.Layer.Uncompressed()
+	if err != nil {
+		c.inFlight.Add(-1)
+		return nil, err
+	}
+	return &decrementOnClose{ReadCloser: rc, n: c.inFlight}, nil
+}
+
+type decrementOnClose struct {
+	io.ReadCloser
+	n *atomic.Int64
+}
+
+func (d *decrementOnClose) Close() error {
+	d.n.Add(-1)
+	return d.ReadCloser.Close()
+}
+
+func countingLayers(t *testing.T, n int, inFlight, maxSeen *atomic.Int64) []*Layer {
+	t.Helper()
+	layers := make([]*Layer, n)
+	for idx := range layers {
+		v1Layer, err := random.Layer(4096, v1Types.DockerLayer)
+		require.NoError(t, err)
+		layers[idx] = NewLayer(&countingLayer{Layer: v1Layer, inFlight: inFlight, maxSeen: maxSeen})
+	}
+	return layers
+}
+
+func TestImage_readLayers_callerSuppliedExecutorBoundsTheFetchStage(t *testing.T) {
+	// the default for 8 layers on any CI box is >1, so a max of 1 can only come from the
+	// executor the caller installed
+	var inFlight, maxSeen atomic.Int64
+	layers := countingLayers(t, 8, &inFlight, &maxSeen)
+
+	ctx := async.SetContextExecutor(context.Background(), LayerFetchExecutor, async.NewExecutor(1))
+	i := &Image{contentCacheDir: t.TempDir()}
+	require.NoError(t, i.readLayers(ctx, layers, NewFileCatalog(), &progress.Manual{}))
+
+	assert.Equal(t, int64(1), maxSeen.Load(), "caller's fetch executor was not honoured")
+	for idx, layer := range layers {
+		assert.NotNilf(t, layer.Tree, "layer %d was not indexed", idx)
+	}
+}
+
+func TestImage_readLayers_perImageDefaultAppliesWhenCallerSuppliesNothing(t *testing.T) {
+	var inFlight, maxSeen atomic.Int64
+	layers := countingLayers(t, 8, &inFlight, &maxSeen)
+
+	// WithLayerReadConcurrency is the fallback the registry provider relies on
+	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 1}
+	require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}))
+
+	assert.Equal(t, int64(1), maxSeen.Load(), "per-image fetch bound was not applied")
+}
+
+func TestImage_readLayers_stageBoundsAreIndependent(t *testing.T) {
+	// the point of two executors rather than one: pinning fetch must not serialise indexing,
+	// which is the registry configuration and what a fused work unit cannot express
+	const layerCount = 6
+	i := &Image{layerReadConcurrency: 1}
+
+	assert.Equal(t, 1, layerReadWorkers(layerCount, i.layerReadConcurrency), "fetch bound follows the per-image option")
+	assert.Greater(t, layerReadWorkers(layerCount, 0), 1, "index bound stays at the default")
+
+	// and both executors are installed, so neither stage silently falls back to inline execution
+	ctx := i.withLayerExecutors(context.Background(), layerCount)
+	assert.True(t, async.HasContextExecutor(ctx, LayerFetchExecutor))
+	assert.True(t, async.HasContextExecutor(ctx, LayerIndexExecutor))
+}
+
+func TestImage_readLayers_cancelledContextStopsTheRead(t *testing.T) {
+	layers := randomLayers(t, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	i := &Image{contentCacheDir: t.TempDir()}
+	err := i.readLayers(ctx, layers, NewFileCatalog(), &progress.Manual{})
+	require.NoError(t, err, "a cancelled read reports no per-layer failure")
+
+	indexed := 0
+	for _, layer := range layers {
+		if layer.Tree != nil {
+			indexed++
+		}
+	}
+	assert.Lessf(t, indexed, len(layers), "cancellation should have stopped some work, indexed %d/%d", indexed, len(layers))
 }

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -356,8 +356,8 @@ func TestImage_squashLayers_reportsAnUnindexedLayer(t *testing.T) {
 
 	i := &Image{contentCacheDir: t.TempDir()}
 	// layer 0 needs a tree for the idx==0 branch to work at all
-	require.NoError(t, layers[0].Fetch(0, i.contentCacheDir))
-	require.NoError(t, layers[0].Index(NewFileCatalog()))
+	require.NoError(t, layers[0].fetch(0, i.contentCacheDir))
+	require.NoError(t, layers[0].index(NewFileCatalog()))
 
 	err := i.squashLayers(layers, gates, &progress.Manual{})
 	require.Error(t, err)

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -112,14 +113,36 @@ func TestImage_readLayers_failedLayerFailsTheReadWithoutHanging(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "layer 1"), "error should name the failed layer: %v", err)
 }
 
+// barrierLayer's MediaType call blocks until every simultaneously-bad layer sharing its barrier
+// has also reached this point, then releases them all together. readLayers now cancels its
+// peers' still-queued work on the first recorded failure, so a synthetic failure that's fast
+// enough to win the race could otherwise stop a peer's fetch from ever being attempted - and an
+// error nobody ever discovered can hardly be reported.
+type barrierLayer struct {
+	v1.Layer
+	barrier *sync.WaitGroup
+}
+
+func (b barrierLayer) MediaType() (v1Types.MediaType, error) {
+	b.barrier.Done()
+	b.barrier.Wait()
+	return b.Layer.MediaType()
+}
+
+func badLayersWithBarrier(layers []*Layer, bad ...int) {
+	var barrier sync.WaitGroup
+	barrier.Add(len(bad))
+	for _, idx := range bad {
+		layers[idx] = NewLayer(barrierLayer{Layer: fakeLayer("garbage/media-type", nil), barrier: &barrier})
+	}
+}
+
 func TestImage_readLayers_reportsFailuresLowestLayerFirst(t *testing.T) {
 	// several layers can fail, and go-sync joins in completion order, so without ordering the
 	// reported error names a different layer from one run to the next - enough to flake a
 	// downstream test over a corrupt-image fixture
 	layers := randomLayers(t, 6)
-	for _, bad := range []int{4, 1, 3} {
-		layers[bad] = NewLayer(fakeLayer("garbage/media-type", nil))
-	}
+	badLayersWithBarrier(layers, 4, 1, 3)
 
 	i := &Image{contentCacheDir: t.TempDir()}
 	err := i.readLayers(layerConcurrency(4, 4), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
@@ -140,9 +163,7 @@ func TestImage_readLayers_errorOrderIsStableAcrossRuns(t *testing.T) {
 	var first string
 	for run := 0; run < 25; run++ {
 		layers := randomLayers(t, 6)
-		for _, bad := range []int{5, 2, 4} {
-			layers[bad] = NewLayer(fakeLayer("garbage/media-type", nil))
-		}
+		badLayersWithBarrier(layers, 5, 2, 4)
 		i := &Image{contentCacheDir: t.TempDir()}
 		err := i.readLayers(layerConcurrency(4, 4), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
 		require.Error(t, err)
@@ -318,6 +339,20 @@ func TestImage_readLayers_cancelledContextStopsTheRead(t *testing.T) {
 	assert.Lessf(t, indexed, len(layers), "cancellation should have stopped some work, indexed %d/%d", indexed, len(layers))
 }
 
+func TestImage_readLayers_internalAbortReportsTheLayerErrorNotCancellation(t *testing.T) {
+	// layer 2 fails, which cancels readLayers' internal context so its peers stop starting more
+	// work. That internal cancellation is our own bookkeeping, not the caller's, and must not
+	// leak out as context.Canceled.
+	layers := randomLayers(t, 6)
+	layers[2] = NewLayer(fakeLayer("garbage/media-type", nil))
+
+	i := &Image{contentCacheDir: t.TempDir()}
+	err := i.readLayers(layerConcurrency(4, 4), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch layer 2")
+	assert.NotErrorIs(t, err, context.Canceled, "an internal abort must not surface as cancellation")
+}
+
 // failingFetchLayer has a valid media type, so Image.Read's up-front validation passes and the
 // failure lands in the fetch stage where the pipeline has to cope with it.
 type failingFetchLayer struct {
@@ -422,6 +457,59 @@ func TestImage_Read_cancelledContextDoesNotHangTheSquash(t *testing.T) {
 		assert.ErrorIs(t, readErr, context.Canceled)
 	case <-time.After(30 * time.Second):
 		t.Fatal("Read hung on a cancelled context: gates were never released")
+	}
+}
+
+// blockingLayer's Uncompressed call reports itself started and then waits to be released, so a
+// test can cancel the read while this layer's fetch worker is provably still in flight rather
+// than racing to catch it with a sleep.
+type blockingLayer struct {
+	v1.Layer
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (b blockingLayer) Uncompressed() (io.ReadCloser, error) {
+	close(b.started)
+	<-b.release
+	return b.Layer.Uncompressed()
+}
+
+func TestImage_Read_midFlightCancellationIsReportedAsCancellation(t *testing.T) {
+	// this is also the regression case for the fetch/index handoff: cancelling while a fetch
+	// worker is genuinely mid-flight is what could race the handoff channel's close against a
+	// worker still trying to hand a layer off to indexing
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	var layers []v1.Layer
+	for idx := 0; idx < 6; idx++ {
+		l := layerFromTarEntries(t, tarEntry{path: fmt.Sprintf("f%d.txt", idx), typeFlag: tar.TypeReg, contents: "ok"})
+		if idx == 3 {
+			l = blockingLayer{Layer: l, started: started, release: release}
+		}
+		layers = append(layers, l)
+	}
+	v1Img, err := mutate.AppendLayers(empty.Image, layers...)
+	require.NoError(t, err)
+
+	img := New(v1Img, file.NewTempDirGenerator("cancel-midflight-test"), t.TempDir())
+	t.Cleanup(func() { _ = img.Cleanup() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- img.Read(ctx) }()
+
+	<-started
+	cancel()
+	close(release) // let the blocked worker proceed now that it is already cancelled
+
+	select {
+	case readErr := <-done:
+		require.Error(t, readErr)
+		assert.ErrorIs(t, readErr, context.Canceled, "a mid-flight caller cancellation must be reported as cancellation")
+	case <-time.After(30 * time.Second):
+		t.Fatal("Read hung after a mid-flight cancellation")
 	}
 }
 

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"io"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -88,16 +89,97 @@ func TestImage_readLayers_concurrentReadKeepsManifestOrder(t *testing.T) {
 	}
 }
 
-func TestImage_readLayers_sequentialMatchesConcurrent(t *testing.T) {
-	// a registry-style single-fetch run must produce the same layer set shape as a parallel one
-	for _, concurrency := range []int{1, 4} {
-		layers := randomLayers(t, 4)
-		i := &Image{contentCacheDir: t.TempDir()}
-		require.NoError(t, i.readLayers(layerConcurrency(concurrency, concurrency), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
-		for idx, layer := range layers {
-			require.Equal(t, uint(idx), layer.Metadata.Index)
-			require.NotNil(t, layer.Tree)
+// fileTuple is the part of a file's identity that must survive indexing unchanged, regardless of
+// how many workers raced to produce it.
+type fileTuple struct {
+	RealPath        string
+	Type            file.Type
+	Size            int64
+	LinkDestination string
+}
+
+// fileTuples walks every file in tree (including dirs and links, not just regulars) and resolves
+// each against catalog, so the comparison covers exactly what the tree/catalog pair actually
+// recorded rather than just path names.
+func fileTuples(t *testing.T, tree filetree.Reader, catalog FileCatalogReader) []fileTuple {
+	t.Helper()
+	var tuples []fileTuple
+	for _, ref := range tree.AllFiles(file.AllTypes()...) {
+		entry, err := catalog.Get(ref)
+		require.NoErrorf(t, err, "no catalog entry for %s", ref.RealPath)
+		tuples = append(tuples, fileTuple{
+			RealPath:        string(entry.RealPath),
+			Type:            entry.Type,
+			Size:            entry.Size(),
+			LinkDestination: entry.LinkDestination,
+		})
+	}
+	sort.Slice(tuples, func(i, j int) bool { return tuples[i].RealPath < tuples[j].RealPath })
+	return tuples
+}
+
+func TestImage_Read_concurrentMatchesSequential(t *testing.T) {
+	// output parity between the serial and concurrent read paths is the core correctness claim of
+	// the fetch/index pipeline. Build one layer set, read it twice - once with both stages bounded
+	// to 1, once bounded well above the layer count - and require the two images to be identical,
+	// not just individually well-formed.
+	const layerCount = 6
+	reg, lnk, sym := byte(tar.TypeReg), byte(tar.TypeLink), byte(tar.TypeSymlink)
+
+	var v1Layers []v1.Layer
+	for idx := 0; idx < layerCount; idx++ {
+		entries := []tarEntry{
+			{path: fmt.Sprintf("only-in-%d.txt", idx), typeFlag: reg, contents: fmt.Sprintf("unique-%d", idx)},
+			// every layer overwrites this, so squash order matters
+			{path: "shared.txt", typeFlag: reg, contents: fmt.Sprintf("v%d", idx)},
+			{path: fmt.Sprintf("link-to-%d", idx), typeFlag: sym, linkPath: fmt.Sprintf("only-in-%d.txt", idx)},
 		}
+		if idx == 0 {
+			// a same-layer hardlink pair: the data-carrying name must precede the hardlink header
+			entries = append(entries,
+				tarEntry{path: "hard-target.txt", typeFlag: reg, contents: "hardlink-payload"},
+				tarEntry{path: "hard-link.txt", typeFlag: lnk, linkPath: "hard-target.txt"},
+			)
+		}
+		v1Layers = append(v1Layers, layerFromTarEntries(t, entries...))
+	}
+
+	read := func(ctx context.Context) *Image {
+		t.Helper()
+		v1Img, err := mutate.AppendLayers(empty.Image, v1Layers...)
+		require.NoError(t, err)
+		img := New(v1Img, file.NewTempDirGenerator("concurrency-parity-test"), t.TempDir())
+		t.Cleanup(func() { require.NoError(t, img.Cleanup()) })
+		require.NoError(t, img.Read(ctx))
+		return img
+	}
+
+	serial := read(layerConcurrency(1, 1))
+	concurrent := read(layerConcurrency(4, 4))
+
+	require.Equal(t, serial.Metadata.Size, concurrent.Metadata.Size, "image size")
+	require.Len(t, concurrent.Layers, len(serial.Layers))
+
+	for idx := range serial.Layers {
+		s, c := serial.Layers[idx], concurrent.Layers[idx]
+		require.Equalf(t, s.Metadata.Index, c.Metadata.Index, "layer %d index", idx)
+		require.Equalf(t, s.Metadata.Digest, c.Metadata.Digest, "layer %d digest", idx)
+		require.Equalf(t, s.Metadata.Size, c.Metadata.Size, "layer %d size", idx)
+
+		require.Equalf(t, fileTuples(t, s.Tree, serial.FileCatalog), fileTuples(t, c.Tree, concurrent.FileCatalog),
+			"layer %d tree", idx)
+		require.Equalf(t, fileTuples(t, s.SquashedTree, serial.FileCatalog), fileTuples(t, c.SquashedTree, concurrent.FileCatalog),
+			"layer %d squashed tree", idx)
+	}
+
+	// and both must resolve the overwritten path to the top layer's value
+	for name, img := range map[string]*Image{"serial": serial, "concurrent": concurrent} {
+		rc, err := img.OpenPathFromSquash("/shared.txt")
+		require.NoErrorf(t, err, "%s image", name)
+		contents, err := io.ReadAll(rc)
+		require.NoErrorf(t, err, "%s image", name)
+		require.NoErrorf(t, rc.Close(), "%s image", name)
+		require.Equalf(t, fmt.Sprintf("v%d", layerCount-1), string(contents), "%s image resolved the wrong layer", name)
 	}
 }
 

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -1,14 +1,20 @@
 package image
 
 import (
+	"archive/tar"
 	"context"
+	"fmt"
 	async "github.com/anchore/go-sync"
+	"github.com/anchore/stereoscope/pkg/file"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"io"
 	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	v1Types "github.com/google/go-containerregistry/pkg/v1/types"
@@ -66,7 +72,7 @@ func TestImage_readLayers_concurrentReadKeepsManifestOrder(t *testing.T) {
 	layers := randomLayers(t, layerCount)
 
 	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 3}
-	require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}))
+	require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
 
 	// completion order is up to the pools; the layer set must still be manifest-ordered and
 	// fully indexed before readLayers returns (the squash that follows depends on both)
@@ -82,7 +88,7 @@ func TestImage_readLayers_sequentialMatchesConcurrent(t *testing.T) {
 	for _, concurrency := range []int{1, 4} {
 		layers := randomLayers(t, 4)
 		i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: concurrency}
-		require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}))
+		require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
 		for idx, layer := range layers {
 			require.Equal(t, uint(idx), layer.Metadata.Index)
 			require.NotNil(t, layer.Tree)
@@ -97,7 +103,7 @@ func TestImage_readLayers_failedLayerFailsTheReadWithoutHanging(t *testing.T) {
 	layers[1] = NewLayer(fakeLayer("garbage/media-type", nil))
 
 	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 2}
-	err := i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{})
+	err := i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "layer 1"), "error should name the failed layer: %v", err)
 }
@@ -108,7 +114,7 @@ func TestImage_readLayers_firstErrorWinsUnderManyFailures(t *testing.T) {
 		layers[idx] = NewLayer(fakeLayer("garbage/media-type", nil))
 	}
 	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 4}
-	err := i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{})
+	err := i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to fetch layer")
 }
@@ -166,7 +172,7 @@ func TestImage_readLayers_callerSuppliedExecutorBoundsTheFetchStage(t *testing.T
 
 	ctx := async.SetContextExecutor(context.Background(), LayerFetchExecutor, async.NewExecutor(1))
 	i := &Image{contentCacheDir: t.TempDir()}
-	require.NoError(t, i.readLayers(ctx, layers, NewFileCatalog(), &progress.Manual{}))
+	require.NoError(t, i.readLayers(ctx, layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
 
 	assert.Equal(t, int64(1), maxSeen.Load(), "caller's fetch executor was not honoured")
 	for idx, layer := range layers {
@@ -180,7 +186,7 @@ func TestImage_readLayers_perImageDefaultAppliesWhenCallerSuppliesNothing(t *tes
 
 	// WithLayerReadConcurrency is the fallback the registry provider relies on
 	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 1}
-	require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}))
+	require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
 
 	assert.Equal(t, int64(1), maxSeen.Load(), "per-image fetch bound was not applied")
 }
@@ -206,7 +212,7 @@ func TestImage_readLayers_cancelledContextStopsTheRead(t *testing.T) {
 	cancel()
 
 	i := &Image{contentCacheDir: t.TempDir()}
-	err := i.readLayers(ctx, layers, NewFileCatalog(), &progress.Manual{})
+	err := i.readLayers(ctx, layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
 	require.NoError(t, err, "a cancelled read reports no per-layer failure")
 
 	indexed := 0
@@ -216,4 +222,145 @@ func TestImage_readLayers_cancelledContextStopsTheRead(t *testing.T) {
 		}
 	}
 	assert.Lessf(t, indexed, len(layers), "cancellation should have stopped some work, indexed %d/%d", indexed, len(layers))
+}
+
+// failingFetchLayer has a valid media type, so Image.Read's up-front validation passes and the
+// failure lands in the fetch stage where the pipeline has to cope with it.
+type failingFetchLayer struct {
+	v1.Layer
+}
+
+func (failingFetchLayer) MediaType() (v1Types.MediaType, error) { return v1Types.DockerLayer, nil }
+func (failingFetchLayer) Uncompressed() (io.ReadCloser, error) {
+	return nil, fmt.Errorf("simulated fetch failure")
+}
+
+func TestImage_Read_squashOverlapMatchesOrderedSquash(t *testing.T) {
+	// every layer overwrites shared.txt, so a squash that ran out of order would resolve it wrong
+	var layers []v1.Layer
+	for idx := 0; idx < 6; idx++ {
+		layers = append(layers, layerFromTarEntries(t,
+			tarEntry{path: fmt.Sprintf("only-in-%d.txt", idx), typeFlag: tar.TypeReg, contents: fmt.Sprintf("c%d", idx)},
+			tarEntry{path: "shared.txt", typeFlag: tar.TypeReg, contents: fmt.Sprintf("v%d", idx)},
+		))
+	}
+	img := readImageFromLayers(t, layers...)
+
+	require.Len(t, img.Layers, 6)
+	for idx, layer := range img.Layers {
+		assert.Equalf(t, uint(idx), layer.Metadata.Index, "layer %d out of order", idx)
+		assert.NotNilf(t, layer.SquashedTree, "layer %d was never squashed", idx)
+		assert.NotNilf(t, layer.SquashedSearchContext, "layer %d has no squashed search context", idx)
+	}
+
+	// the squash must still be bottom-up: the top layer's value wins
+	rc, err := img.OpenPathFromSquash("/shared.txt")
+	require.NoError(t, err)
+	defer rc.Close()
+	contents, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "v5", string(contents), "squash did not resolve to the top layer")
+
+	// and each layer's own squash sees only layers at or below it
+	for idx, layer := range img.Layers {
+		_, ref, err := layer.SquashedTree.File(file.Path(fmt.Sprintf("/only-in-%d.txt", idx)))
+		require.NoErrorf(t, err, "layer %d squash", idx)
+		assert.Truef(t, ref.HasReference(), "layer %d squash is missing its own file", idx)
+
+		if idx+1 < len(img.Layers) {
+			_, above, err := layer.SquashedTree.File(file.Path(fmt.Sprintf("/only-in-%d.txt", idx+1)))
+			require.NoErrorf(t, err, "layer %d squash", idx)
+			assert.Falsef(t, above.HasReference(), "layer %d squash leaked a file from the layer above", idx)
+		}
+	}
+}
+
+func TestImage_Read_fetchFailureDoesNotHangTheSquash(t *testing.T) {
+	good := func(idx int) v1.Layer {
+		return layerFromTarEntries(t, tarEntry{
+			path: fmt.Sprintf("f%d.txt", idx), typeFlag: tar.TypeReg, contents: "ok",
+		})
+	}
+	// the middle layer fails to fetch, so its gate must open as not-ok and squash must stop
+	// rather than block forever or squash a layer with no tree
+	v1Img, err := mutate.AppendLayers(empty.Image, good(0), failingFetchLayer{Layer: good(1)}, good(2))
+	require.NoError(t, err)
+
+	img := New(v1Img, file.NewTempDirGenerator("gate-test"), t.TempDir())
+	t.Cleanup(func() { _ = img.Cleanup() })
+
+	done := make(chan error, 1)
+	go func() { done <- img.Read(context.Background()) }()
+
+	select {
+	case readErr := <-done:
+		require.Error(t, readErr)
+		assert.Contains(t, readErr.Error(), "layer 1")
+	case <-time.After(30 * time.Second):
+		t.Fatal("Read hung: a failed layer left the squash waiting on its gate")
+	}
+}
+
+func TestImage_Read_cancelledContextDoesNotHangTheSquash(t *testing.T) {
+	var layers []v1.Layer
+	for idx := 0; idx < 8; idx++ {
+		layers = append(layers, layerFromTarEntries(t, tarEntry{
+			path: fmt.Sprintf("f%d.txt", idx), typeFlag: tar.TypeReg, contents: "ok",
+		}))
+	}
+	v1Img, err := mutate.AppendLayers(empty.Image, layers...)
+	require.NoError(t, err)
+
+	img := New(v1Img, file.NewTempDirGenerator("cancel-test"), t.TempDir())
+	t.Cleanup(func() { _ = img.Cleanup() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- img.Read(ctx) }()
+
+	select {
+	case readErr := <-done:
+		// a cancelled read must report the cancellation rather than hand back a half-built
+		// image, and must not panic building a search context over an unsquashed layer
+		require.Error(t, readErr)
+		assert.ErrorIs(t, readErr, context.Canceled)
+	case <-time.After(30 * time.Second):
+		t.Fatal("Read hung on a cancelled context: gates were never released")
+	}
+}
+
+func TestLayerGates_releaseAllIsIdempotentAndUnblocksWaiters(t *testing.T) {
+	g := newLayerGates(3)
+	g.done(0, true)
+	g.done(0, false) // second call must not flip the answer or double-Done
+
+	g.releaseAll()
+	g.releaseAll()
+
+	assert.True(t, g.wait(0), "an indexed layer should stay ok")
+	assert.False(t, g.wait(1), "an unreached layer should report not-ok")
+	assert.False(t, g.wait(2))
+}
+
+func TestImage_squashLayers_reportsAnUnindexedLayer(t *testing.T) {
+	// squash must not trust the read stages to have raised something. If it returned nil here,
+	// Read would carry on and build the image search context over a layer with no tree, which
+	// panics. This is the deterministic backstop for that.
+	layers := randomLayers(t, 3)
+	gates := newLayerGates(len(layers))
+	gates.done(0, true)
+	gates.done(1, false) // indexed nothing
+	gates.done(2, true)
+
+	i := &Image{contentCacheDir: t.TempDir()}
+	// layer 0 needs a tree for the idx==0 branch to work at all
+	require.NoError(t, layers[0].Fetch(0, i.contentCacheDir))
+	require.NoError(t, layers[0].Index(NewFileCatalog()))
+
+	err := i.squashLayers(layers, gates, &progress.Manual{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "layer 1")
+	assert.Contains(t, err.Error(), "not indexed")
 }

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -30,29 +30,32 @@ func Test_layerReadWorkers(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		layers   int
-		override int
-		want     int
+		name   string
+		layers int
+		want   int
 	}{
-		{name: "override wins", layers: 10, override: 3, want: 3},
-		{name: "override capped at layer count", layers: 2, override: 8, want: 2},
-		{name: "registry-style single fetch", layers: 10, override: 1, want: 1},
-		{name: "default is CPUs capped at 8 and the layer count", layers: 1000, override: 0, want: cpuDefault},
-		{name: "default capped by layer count", layers: 1, override: 0, want: 1},
-		{name: "never below one worker", layers: 0, override: 3, want: 1},
+		{name: "CPUs capped at 8", layers: 1000, want: cpuDefault},
+		{name: "capped by layer count", layers: 1, want: 1},
+		{name: "never below one worker", layers: 0, want: 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, layerReadWorkers(tt.layers, tt.override))
+			assert.Equal(t, tt.want, layerReadWorkers(tt.layers))
 		})
 	}
 }
 
-func TestWithLayerReadConcurrency(t *testing.T) {
-	i := &Image{}
-	require.NoError(t, WithLayerReadConcurrency(2)(i))
-	assert.Equal(t, 2, i.layerReadConcurrency)
+// layerConcurrency installs stage executors the way a caller would. A bound of 0 leaves that
+// stage out, so Read fills in the default.
+func layerConcurrency(fetch, index int) context.Context {
+	ctx := context.Background()
+	if fetch > 0 {
+		ctx = async.SetContextExecutor(ctx, LayerFetchExecutor, async.NewExecutor(fetch))
+	}
+	if index > 0 {
+		ctx = async.SetContextExecutor(ctx, LayerIndexExecutor, async.NewExecutor(index))
+	}
+	return ctx
 }
 
 // randomLayers builds n small, well-formed docker layers.
@@ -71,8 +74,8 @@ func TestImage_readLayers_concurrentReadKeepsManifestOrder(t *testing.T) {
 	const layerCount = 6
 	layers := randomLayers(t, layerCount)
 
-	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 3}
-	require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
+	i := &Image{contentCacheDir: t.TempDir()}
+	require.NoError(t, i.readLayers(layerConcurrency(3, 3), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
 
 	// completion order is up to the pools; the layer set must still be manifest-ordered and
 	// fully indexed before readLayers returns (the squash that follows depends on both)
@@ -87,8 +90,8 @@ func TestImage_readLayers_sequentialMatchesConcurrent(t *testing.T) {
 	// a registry-style single-fetch run must produce the same layer set shape as a parallel one
 	for _, concurrency := range []int{1, 4} {
 		layers := randomLayers(t, 4)
-		i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: concurrency}
-		require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
+		i := &Image{contentCacheDir: t.TempDir()}
+		require.NoError(t, i.readLayers(layerConcurrency(concurrency, concurrency), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
 		for idx, layer := range layers {
 			require.Equal(t, uint(idx), layer.Metadata.Index)
 			require.NotNil(t, layer.Tree)
@@ -102,8 +105,8 @@ func TestImage_readLayers_failedLayerFailsTheReadWithoutHanging(t *testing.T) {
 	// return - with workers still draining - rather than deadlock or panic
 	layers[1] = NewLayer(fakeLayer("garbage/media-type", nil))
 
-	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 2}
-	err := i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
+	i := &Image{contentCacheDir: t.TempDir()}
+	err := i.readLayers(layerConcurrency(2, 2), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "layer 1"), "error should name the failed layer: %v", err)
 }
@@ -113,8 +116,8 @@ func TestImage_readLayers_firstErrorWinsUnderManyFailures(t *testing.T) {
 	for idx := range layers {
 		layers[idx] = NewLayer(fakeLayer("garbage/media-type", nil))
 	}
-	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 4}
-	err := i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
+	i := &Image{contentCacheDir: t.TempDir()}
+	err := i.readLayers(layerConcurrency(4, 4), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to fetch layer")
 }
@@ -180,30 +183,44 @@ func TestImage_readLayers_callerSuppliedExecutorBoundsTheFetchStage(t *testing.T
 	}
 }
 
-func TestImage_readLayers_perImageDefaultAppliesWhenCallerSuppliesNothing(t *testing.T) {
+func TestImage_readLayers_defaultAppliesWhenCallerSuppliesNothing(t *testing.T) {
 	var inFlight, maxSeen atomic.Int64
 	layers := countingLayers(t, 8, &inFlight, &maxSeen)
 
-	// WithLayerReadConcurrency is the fallback the registry provider relies on
-	i := &Image{contentCacheDir: t.TempDir(), layerReadConcurrency: 1}
+	// no executors installed at all: both stages must still get a working bound rather than
+	// falling back to go-sync's inline serial executor, which would collapse the two stages
+	i := &Image{contentCacheDir: t.TempDir()}
 	require.NoError(t, i.readLayers(context.Background(), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
 
-	assert.Equal(t, int64(1), maxSeen.Load(), "per-image fetch bound was not applied")
+	assert.LessOrEqual(t, maxSeen.Load(), int64(layerReadWorkers(len(layers))), "default fetch bound was exceeded")
+	for idx, layer := range layers {
+		assert.NotNilf(t, layer.Tree, "layer %d was not indexed", idx)
+	}
 }
 
 func TestImage_readLayers_stageBoundsAreIndependent(t *testing.T) {
-	// the point of two executors rather than one: pinning fetch must not serialise indexing,
-	// which is the registry configuration and what a fused work unit cannot express
-	const layerCount = 6
-	i := &Image{layerReadConcurrency: 1}
+	// the point of two executors rather than one over a fused per-layer unit: pinning fetch must
+	// not serialise indexing. This is the registry configuration, and a single bound cannot
+	// express it.
+	const layerCount = 8
+	var inFlight, maxSeen atomic.Int64
+	layers := countingLayers(t, layerCount, &inFlight, &maxSeen)
 
-	assert.Equal(t, 1, layerReadWorkers(layerCount, i.layerReadConcurrency), "fetch bound follows the per-image option")
-	assert.Greater(t, layerReadWorkers(layerCount, 0), 1, "index bound stays at the default")
+	// only a fetch executor, so Read must fill in the index default rather than reusing this one
+	ctx := layerConcurrency(1, 0)
+	i := &Image{contentCacheDir: t.TempDir()}
+	require.NoError(t, i.readLayers(ctx, layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
 
-	// and both executors are installed, so neither stage silently falls back to inline execution
-	ctx := i.withLayerExecutors(context.Background(), layerCount)
-	assert.True(t, async.HasContextExecutor(ctx, LayerFetchExecutor))
-	assert.True(t, async.HasContextExecutor(ctx, LayerIndexExecutor))
+	assert.Equal(t, int64(1), maxSeen.Load(), "the caller's fetch bound was not honoured")
+	for idx, layer := range layers {
+		assert.NotNilf(t, layer.Tree, "layer %d was not indexed", idx)
+	}
+
+	// and the default filled in for the stage the caller left out
+	filled := withLayerExecutors(layerConcurrency(1, 0), layerCount)
+	assert.True(t, async.HasContextExecutor(filled, LayerFetchExecutor))
+	assert.True(t, async.HasContextExecutor(filled, LayerIndexExecutor))
+	assert.Greater(t, layerReadWorkers(layerCount), 1, "the index default should not be serial")
 }
 
 func TestImage_readLayers_cancelledContextStopsTheRead(t *testing.T) {

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -198,6 +198,51 @@ func TestImage_readLayers_defaultAppliesWhenCallerSuppliesNothing(t *testing.T) 
 	}
 }
 
+func TestWithLayerExecutors_defaultsFillInOnlyWhenNothingIsInstalled(t *testing.T) {
+	const layerCount = 6
+
+	t.Run("nothing installed", func(t *testing.T) {
+		// both stages need a bound, because go-sync's last fallback is an inline serial executor
+		// and that would collapse the pipeline into one stage
+		ctx := withLayerExecutors(context.Background(), layerCount)
+		assert.True(t, async.HasContextExecutor(ctx, LayerFetchExecutor))
+		assert.True(t, async.HasContextExecutor(ctx, LayerIndexExecutor))
+	})
+
+	t.Run("ExecutorDefault installed", func(t *testing.T) {
+		// a host that installed a single process-wide budget already answered for both stages;
+		// go-sync resolves the missing names to it, so we must not talk over it
+		base := async.SetContextExecutor(context.Background(), async.ExecutorDefault, async.NewExecutor(3))
+		ctx := withLayerExecutors(base, layerCount)
+		assert.False(t, async.HasContextExecutor(ctx, LayerFetchExecutor), "overrode the host's default")
+		assert.False(t, async.HasContextExecutor(ctx, LayerIndexExecutor), "overrode the host's default")
+	})
+
+	t.Run("one stage named, plus ExecutorDefault", func(t *testing.T) {
+		// the registry provider's shape: it pins fetch and leaves indexing to whatever the host set
+		base := async.SetContextExecutor(context.Background(), async.ExecutorDefault, async.NewExecutor(3))
+		base = async.SetContextExecutor(base, LayerFetchExecutor, async.NewExecutor(1))
+		ctx := withLayerExecutors(base, layerCount)
+		assert.True(t, async.HasContextExecutor(ctx, LayerFetchExecutor), "the pinned stage must survive")
+		assert.False(t, async.HasContextExecutor(ctx, LayerIndexExecutor), "the other stage falls back to the host's default")
+	})
+}
+
+func TestImage_readLayers_honoursExecutorDefault(t *testing.T) {
+	// end to end: a host budget of one must actually bound fetching, not just be recorded
+	var inFlight, maxSeen atomic.Int64
+	layers := countingLayers(t, 8, &inFlight, &maxSeen)
+
+	ctx := async.SetContextExecutor(context.Background(), async.ExecutorDefault, async.NewExecutor(1))
+	i := &Image{contentCacheDir: t.TempDir()}
+	require.NoError(t, i.readLayers(ctx, layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers))))
+
+	assert.Equal(t, int64(1), maxSeen.Load(), "the host's ExecutorDefault did not bound the fetch stage")
+	for idx, layer := range layers {
+		assert.NotNilf(t, layer.Tree, "layer %d was not indexed", idx)
+	}
+}
+
 func TestImage_readLayers_stageBoundsAreIndependent(t *testing.T) {
 	// the point of two executors rather than one over a fused per-layer unit: pinning fetch must
 	// not serialise indexing. This is the registry configuration, and a single bound cannot

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -4,12 +4,6 @@ import (
 	"archive/tar"
 	"context"
 	"fmt"
-	async "github.com/anchore/go-sync"
-	"github.com/anchore/stereoscope/pkg/file"
-	"github.com/anchore/stereoscope/pkg/filetree"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/empty"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"io"
 	"runtime"
 	"sort"
@@ -19,11 +13,18 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	v1Types "github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wagoodman/go-progress"
+
+	async "github.com/anchore/go-sync"
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree"
 )
 
 func Test_layerReadWorkers(t *testing.T) {

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -112,15 +112,46 @@ func TestImage_readLayers_failedLayerFailsTheReadWithoutHanging(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "layer 1"), "error should name the failed layer: %v", err)
 }
 
-func TestImage_readLayers_firstErrorWinsUnderManyFailures(t *testing.T) {
-	layers := randomLayers(t, 5)
-	for idx := range layers {
-		layers[idx] = NewLayer(fakeLayer("garbage/media-type", nil))
+func TestImage_readLayers_reportsFailuresLowestLayerFirst(t *testing.T) {
+	// several layers can fail, and go-sync joins in completion order, so without ordering the
+	// reported error names a different layer from one run to the next - enough to flake a
+	// downstream test over a corrupt-image fixture
+	layers := randomLayers(t, 6)
+	for _, bad := range []int{4, 1, 3} {
+		layers[bad] = NewLayer(fakeLayer("garbage/media-type", nil))
 	}
+
 	i := &Image{contentCacheDir: t.TempDir()}
 	err := i.readLayers(layerConcurrency(4, 4), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to fetch layer")
+
+	msg := err.Error()
+	assert.Contains(t, msg, "failed to fetch layer 1")
+	// every failure is reported, and layer 1 before layer 3 before layer 4
+	one, three, four := strings.Index(msg, "layer 1"), strings.Index(msg, "layer 3"), strings.Index(msg, "layer 4")
+	require.NotEqual(t, -1, three)
+	require.NotEqual(t, -1, four)
+	assert.Less(t, one, three, "layer 1 should be reported before layer 3")
+	assert.Less(t, three, four, "layer 3 should be reported before layer 4")
+}
+
+func TestImage_readLayers_errorOrderIsStableAcrossRuns(t *testing.T) {
+	// the ordering above must not just happen to hold on one scheduling
+	var first string
+	for run := 0; run < 25; run++ {
+		layers := randomLayers(t, 6)
+		for _, bad := range []int{5, 2, 4} {
+			layers[bad] = NewLayer(fakeLayer("garbage/media-type", nil))
+		}
+		i := &Image{contentCacheDir: t.TempDir()}
+		err := i.readLayers(layerConcurrency(4, 4), layers, NewFileCatalog(), &progress.Manual{}, newLayerGates(len(layers)))
+		require.Error(t, err)
+		if run == 0 {
+			first = err.Error()
+			continue
+		}
+		require.Equal(t, first, err.Error(), "error text changed between runs")
+	}
 }
 
 // countingLayer records the high-water mark of concurrent Uncompressed calls, which is what a

--- a/pkg/image/layer_read_pipeline_test.go
+++ b/pkg/image/layer_read_pipeline_test.go
@@ -364,3 +364,45 @@ func TestImage_squashLayers_reportsAnUnindexedLayer(t *testing.T) {
 	assert.Contains(t, err.Error(), "layer 1")
 	assert.Contains(t, err.Error(), "not indexed")
 }
+
+// panickingLayer panics where a stage will run it, with a media type that passes Read's
+// up-front validation so the panic actually reaches the pool.
+type panickingLayer struct {
+	v1.Layer
+}
+
+func (panickingLayer) MediaType() (v1Types.MediaType, error) { return v1Types.DockerLayer, nil }
+func (panickingLayer) Uncompressed() (io.ReadCloser, error) {
+	panic("boom from a fetch worker")
+}
+
+func TestImage_Read_panicInAStageBecomesAnError(t *testing.T) {
+	// stereoscope reads untrusted images inside long-running services, so a panic in a worker
+	// must not take the process down. Before the stages were driven by go-sync the panic
+	// happened on a goroutine the caller could not recover from at all.
+	//
+	// What this pins is containment: no crash, no hang, and the panic reaches the caller as an
+	// error. It is deliberately not a regression test for go-sync losing the error it recovered
+	// (fixed in v0.1.2) - two layers do not reliably open that window, and go-sync covers it
+	// directly in Test_CollectHandlesPanicsConcurrently.
+	good := layerFromTarEntries(t, tarEntry{path: "a.txt", typeFlag: tar.TypeReg, contents: "ok"})
+	bad := layerFromTarEntries(t, tarEntry{path: "b.txt", typeFlag: tar.TypeReg, contents: "different digest"})
+	v1Img, err := mutate.AppendLayers(empty.Image, good, panickingLayer{Layer: bad})
+	require.NoError(t, err)
+
+	img := New(v1Img, file.NewTempDirGenerator("panic-test"), t.TempDir())
+	t.Cleanup(func() { _ = img.Cleanup() })
+
+	done := make(chan error, 1)
+	go func() { done <- img.Read(context.Background()) }()
+
+	select {
+	case readErr := <-done:
+		require.Error(t, readErr, "a panicking layer must surface as an error, not a crash")
+		assert.Contains(t, readErr.Error(), "boom from a fetch worker")
+	case <-time.After(30 * time.Second):
+		// a panic skips the stage's gates.done, so this also pins that Read's releaseAll
+		// safety net opens the gate the squash is waiting on
+		t.Fatal("Read hung after a panic: the squash gate was never released")
+	}
+}

--- a/pkg/image/oci/directory_provider.go
+++ b/pkg/image/oci/directory_provider.go
@@ -42,7 +42,7 @@ func (p *directoryImageProvider) Name() string {
 }
 
 // Provide an image object that represents the OCI image as a directory.
-func (p *directoryImageProvider) Provide(_ context.Context) (*image.Image, error) {
+func (p *directoryImageProvider) Provide(ctx context.Context) (*image.Image, error) {
 	if _, err := layout.FromPath(p.path); err != nil {
 		return nil, fmt.Errorf("unable to read image from OCI directory path %q: %w", p.path, err)
 	}
@@ -108,7 +108,7 @@ func (p *directoryImageProvider) Provide(_ context.Context) (*image.Image, error
 	}
 
 	out := image.New(selectedImage, p.tmpDirGen, contentTempDir, metadata...)
-	err = out.Read()
+	err = out.Read(ctx)
 	if err != nil {
 		cleanErr := out.Cleanup()
 		return nil, errors.Join(err, cleanErr)

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -162,6 +162,9 @@ func (p *registryImageProvider) Provide(ctx context.Context) (*image.Image, erro
 		)
 	}
 
+	// registry layers arrive over the network: download them one at a time (a second stream only
+	// splits the link) while already-fetched layers are indexed in parallel
+	metadata = append([]image.AdditionalMetadata{image.WithLayerReadConcurrency(image.RegistryLayerReadConcurrency)}, metadata...)
 	out := image.New(img, p.tmpDirGen, imageTempDir, metadata...)
 	err = out.Read()
 	if err != nil {

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -166,7 +166,7 @@ func (p *registryImageProvider) Provide(ctx context.Context) (*image.Image, erro
 	// splits the link) while already-fetched layers are indexed in parallel
 	metadata = append([]image.AdditionalMetadata{image.WithLayerReadConcurrency(image.RegistryLayerReadConcurrency)}, metadata...)
 	out := image.New(img, p.tmpDirGen, imageTempDir, metadata...)
-	err = out.Read()
+	err = out.Read(ctx)
 	if err != nil {
 		cleanErr := out.Cleanup()
 		return nil, errors.Join(err, cleanErr)

--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	containerregistryV1Types "github.com/google/go-containerregistry/pkg/v1/types"
 
+	async "github.com/anchore/go-sync"
 	"github.com/anchore/stereoscope/internal/log"
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
@@ -162,9 +163,14 @@ func (p *registryImageProvider) Provide(ctx context.Context) (*image.Image, erro
 		)
 	}
 
-	// registry layers arrive over the network: download them one at a time (a second stream only
-	// splits the link) while already-fetched layers are indexed in parallel
-	metadata = append([]image.AdditionalMetadata{image.WithLayerReadConcurrency(image.RegistryLayerReadConcurrency)}, metadata...)
+	// registry layers arrive over the network: download them one at a time, since a second stream
+	// only splits a link a single stream already saturates, while already-fetched layers are
+	// indexed in parallel at the default bound. A caller that installed its own fetch executor
+	// knows better than we do, so leave theirs alone.
+	if !async.HasContextExecutor(ctx, image.LayerFetchExecutor) {
+		ctx = async.SetContextExecutor(ctx, image.LayerFetchExecutor, async.NewExecutor(1))
+	}
+
 	out := image.New(img, p.tmpDirGen, imageTempDir, metadata...)
 	err = out.Read(ctx)
 	if err != nil {

--- a/pkg/image/sif/archive_provider.go
+++ b/pkg/image/sif/archive_provider.go
@@ -32,7 +32,7 @@ func (p *singularityImageProvider) Name() string {
 }
 
 // Provide returns an Image that represents a Singularity Image Format (SIF) image.
-func (p *singularityImageProvider) Provide(_ context.Context) (*image.Image, error) {
+func (p *singularityImageProvider) Provide(ctx context.Context) (*image.Image, error) {
 	// We need to map the SIF to a GGCR v1.Image. Start with an implementation of the GGCR
 	// partial.UncompressedImageCore interface.
 	si, err := newSIFImage(p.path)
@@ -59,7 +59,7 @@ func (p *singularityImageProvider) Provide(_ context.Context) (*image.Image, err
 	}
 
 	out := image.New(ui, p.tmpDirGen, contentCacheDir, metadata...)
-	err = out.Read()
+	err = out.Read(ctx)
 	if err != nil {
 		cleanErr := out.Cleanup()
 		return nil, errors.Join(err, cleanErr)

--- a/pkg/image/sif/archive_provider_test.go
+++ b/pkg/image/sif/archive_provider_test.go
@@ -44,7 +44,7 @@ func TestSingularityImageProvider_Provide(t *testing.T) {
 			}
 
 			if err == nil {
-				if err := i.Read(); err != nil {
+				if err := i.Read(context.Background()); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/pkg/image/synthetic_image_test.go
+++ b/pkg/image/synthetic_image_test.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"archive/tar"
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -87,7 +88,7 @@ func tryReadImageFromLayers(t *testing.T, layers ...v1.Layer) (*Image, error) {
 		require.NoError(t, img.Cleanup())
 	})
 
-	return img, img.Read()
+	return img, img.Read(context.Background())
 }
 
 // readImageFromLayersWithConfig is readImageFromLayers with the image config rewritten before the
@@ -102,7 +103,7 @@ func readImageFromLayersWithConfig(t *testing.T, override func(*v1.ConfigFile), 
 	t.Cleanup(func() {
 		require.NoError(t, img.Cleanup())
 	})
-	require.NoError(t, img.Read())
+	require.NoError(t, img.Read(context.Background()))
 
 	return img
 }

--- a/test/integration/oci_registry_source_test.go
+++ b/test/integration/oci_registry_source_test.go
@@ -38,7 +38,7 @@ func TestOciRegistrySourceMetadata(t *testing.T) {
 		require.NoError(t, img.Cleanup())
 	})
 
-	require.NoError(t, img.Read())
+	require.NoError(t, img.Read(context.Background()))
 
 	assert.Len(t, img.Metadata.RepoDigests, 1)
 	assert.Equal(t, "index.docker.io/"+ref, img.Metadata.RepoDigests[0])


### PR DESCRIPTION
## Issue

`Image.Read` handled layers strictly one at a time: download a layer, decompress it, walk its tar, then start the next. Downloading is network work, decompressing/indexing is CPU work, and running them back to back keeps exactly one resource busy at any moment — total read time is the **sum** of network and CPU time when it could approach the **max** of the two.

## Fix

- `Layer.Read` = `Layer.Fetch` (download + decompress into the layer cache) followed by `Layer.Index` (tar walk, file-tree build); `Image.Read` drives the two stages as a pipeline with separate worker pools.
- `WithLayerReadConcurrency(n)` bounds concurrent fetches per image; indexing always overlaps fetching.
- **Source-aware concurrency, set from measurement:** the registry provider fetches **one layer at a time** — against nvcr.io on a 10.5 GiB image, one stream ran ~62 MB/s while four in parallel managed ~27 MB/s aggregate (pull 3m20s → 6m18s) and even two streams were ~20% slower, because a single stream already saturated the link. Local sources (daemon tarballs, OCI layouts) are disk-bound and decompress several layers at once (default NumCPU, capped at 8; `LayerReadConcurrency` overrides).
- Cache-path population is serialized per digest, so two layers sharing a digest (empty layers do) cannot race under concurrent fetch.

## Measured

Imported into anchorectl, back to back with the same anchorectl commit on current stereoscope main, medians of 3:

| Scenario (anchorectl import, median of 3 warmed runs) | stereoscope main — wall / CPU / peak RSS | this PR — wall / CPU / peak RSS |
|---|---|---|
| enterprise:dev from the docker daemon (1.28 GB, 40k files) | 15.83 s / 22.33 s / 948 MB | 16.02 s / 22.48 s / 918 MB (+1% wall) |
| nginx from a registry (loopback) | 1.55 s / 4.73 s / 246 MB | 1.45 s / 4.69 s / 245 MB (-6% wall) |
| enterprise:dev from a registry (loopback) | 9.41 s / 24.00 s / 973 MB | 9.31 s / 23.94 s / 922 MB (-1% wall) |
| OCI layout on disk (centralized analyze path) | 14.15 s / 29.12 s / 966 MB | 13.50 s / 29.60 s / 960 MB (-5% wall) |

The daemon scenario is dominated by a single-stream `docker save`, so wall stays roughly flat there; loopback-registry wall is unchanged by design (fetch stays at 1) with indexing overlap giving the small wins shown. The gains grow with layer count and slower disks; the registry single-fetch rationale carries its own measurements (see commit message).

Output parity: package sets, files, digests, search results and relationship counts are identical to the baseline. The only diffs observed are pre-existing run-to-run nondeterminism, reproduced with *unpatched* stereoscope main under the same anchorectl commit: syft v1.51.0 can credit a duplicated python package (`packaging@26.3` vs the copy vendored inside setuptools) as the `dependency-of` parent either way, which then shifts document digests in the bundle manifest.

## Ordering guarantee

Layers may fetch and index in any order, but nothing downstream can observe that: results land in `layers[idx]` by manifest position, `readLayers` returns only after **every** layer is indexed, and only then does `Image.Read` run the existing bottom-up squash — so squashed trees are still built lowest layer first, over a fully indexed, correctly ordered layer list.
