### PR TITLE
fix: make layer-cache writes atomic and serialized per path

### DIFF
--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -118,6 +119,11 @@ func (l *Layer) uncompressedCache(uncompressedLayersCacheDir string) (string, er
 	// layer's unpacked content.
 	path := path.Join(uncompressedLayersCacheDir, fmt.Sprintf("%d-%s", l.Metadata.Index, l.Metadata.Digest))
 
+	// two layers of one image may share a digest (empty layers do); only one populates the cache
+	// path, anyone else waits and then finds it complete
+	unlock := lockCachePath(path)
+	defer unlock()
+
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		return path, nil
 	}
@@ -131,14 +137,24 @@ func (l *Layer) uncompressedCache(uncompressedLayersCacheDir string) (string, er
 	}
 	defer rawReader.Close()
 
-	fh, err := os.Create(path)
+	// write to a temporary name and rename into place, so a reader never sees a partial layer
+	fh, err := os.CreateTemp(uncompressedLayersCacheDir, l.Metadata.Digest+".*.partial")
 	if err != nil {
 		return "", fmt.Errorf("unable to create layer cache dir=%q : %w", path, err)
 	}
-	defer fh.Close()
-
+	tmpPath := fh.Name()
 	if _, err := io.Copy(fh, rawReader); err != nil {
+		_ = fh.Close()
+		_ = os.Remove(tmpPath)
 		return "", fmt.Errorf("unable to populate layer cache dir=%q : %w", path, err)
+	}
+	if err := fh.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("unable to finish layer cache dir=%q : %w", path, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("unable to place layer cache dir=%q : %w", path, err)
 	}
 	log.WithFields("index", l.Metadata.Index, "path", path, "time", time.Since(startTime)).Trace("completed uncompressed layer cache")
 
@@ -155,6 +171,21 @@ func (l *Layer) close() error {
 		return nil
 	}
 	return l.indexedContent.Close()
+}
+
+// cachePathLocks serializes population of one cache path across layers read concurrently. The
+// locks are in-process mutexes on purpose: they die with the process, so a crash can never leave a
+// stale lock a later run would have to reason about (the liveness problem on-disk lock files have).
+// Cross-process safety comes from the write protocol instead - a writer only ever exposes a
+// complete layer via rename, and a crash leaves at most an orphaned *.partial temp file that no
+// reader ever looks at.
+var cachePathLocks sync.Map
+
+func lockCachePath(path string) (unlock func()) {
+	mu, _ := cachePathLocks.LoadOrStore(path, &sync.Mutex{})
+	m := mu.(*sync.Mutex)
+	m.Lock()
+	return m.Unlock
 }
 
 // Read parses information from the underlying layer tar into this struct. This includes layer metadata, the layer

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"sync"
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -119,11 +118,6 @@ func (l *Layer) uncompressedCache(uncompressedLayersCacheDir string) (string, er
 	// layer's unpacked content.
 	path := path.Join(uncompressedLayersCacheDir, fmt.Sprintf("%d-%s", l.Metadata.Index, l.Metadata.Digest))
 
-	// two layers of one image may share a digest (empty layers do); only one populates the cache
-	// path, anyone else waits and then finds it complete
-	unlock := lockCachePath(path)
-	defer unlock()
-
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		return path, nil
 	}
@@ -137,24 +131,26 @@ func (l *Layer) uncompressedCache(uncompressedLayersCacheDir string) (string, er
 	}
 	defer rawReader.Close()
 
-	// write to a temporary name and rename into place, so a reader never sees a partial layer
-	fh, err := os.CreateTemp(uncompressedLayersCacheDir, l.Metadata.Digest+".*.partial")
+	// write to a unique temp name and rename into place, so this path only ever holds a complete
+	// layer: a write that dies partway leaves nothing for a later os.Stat to trust
+	fh, err := os.CreateTemp(uncompressedLayersCacheDir, "partial-")
 	if err != nil {
-		return "", fmt.Errorf("unable to create layer cache dir=%q : %w", path, err)
+		return "", fmt.Errorf("unable to create layer cache path=%q : %w", path, err)
 	}
 	tmpPath := fh.Name()
+	defer func() {
+		fh.Close()         // no-op once already closed
+		os.Remove(tmpPath) // no-op once renamed away
+	}()
+
 	if _, err := io.Copy(fh, rawReader); err != nil {
-		_ = fh.Close()
-		_ = os.Remove(tmpPath)
-		return "", fmt.Errorf("unable to populate layer cache dir=%q : %w", path, err)
+		return "", fmt.Errorf("unable to populate layer cache path=%q : %w", path, err)
 	}
 	if err := fh.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return "", fmt.Errorf("unable to finish layer cache dir=%q : %w", path, err)
+		return "", fmt.Errorf("unable to finish layer cache path=%q : %w", path, err)
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
-		return "", fmt.Errorf("unable to place layer cache dir=%q : %w", path, err)
+		return "", fmt.Errorf("unable to place layer cache path=%q : %w", path, err)
 	}
 	log.WithFields("index", l.Metadata.Index, "path", path, "time", time.Since(startTime)).Trace("completed uncompressed layer cache")
 
@@ -171,21 +167,6 @@ func (l *Layer) close() error {
 		return nil
 	}
 	return l.indexedContent.Close()
-}
-
-// cachePathLocks serializes population of one cache path across layers read concurrently. The
-// locks are in-process mutexes on purpose: they die with the process, so a crash can never leave a
-// stale lock a later run would have to reason about (the liveness problem on-disk lock files have).
-// Cross-process safety comes from the write protocol instead - a writer only ever exposes a
-// complete layer via rename, and a crash leaves at most an orphaned *.partial temp file that no
-// reader ever looks at.
-var cachePathLocks sync.Map
-
-func lockCachePath(path string) (unlock func()) {
-	mu, _ := cachePathLocks.LoadOrStore(path, &sync.Mutex{})
-	m := mu.(*sync.Mutex)
-	m.Lock()
-	return m.Unlock
 }
 
 // Read parses information from the underlying layer tar into this struct. This includes layer metadata, the layer

--- a/pkg/image/layer_cache_test.go
+++ b/pkg/image/layer_cache_test.go
@@ -1,0 +1,53 @@
+package image
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// the per-path lock hands the path to one writer at a time; others wait rather than interleave
+func Test_lockCachePath_serializesWriters(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "sha256-x")
+	var active, maxActive int
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			unlock := lockCachePath(target)
+			defer unlock()
+			mu.Lock()
+			active++
+			if active > maxActive {
+				maxActive = active
+			}
+			mu.Unlock()
+			// simulate the stat-then-write critical section
+			if _, err := os.Stat(target); os.IsNotExist(err) {
+				require.NoError(t, os.WriteFile(target, []byte("layer-bytes"), 0o600))
+			}
+			mu.Lock()
+			active--
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, 1, maxActive, "writers must not overlap on one cache path")
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "layer-bytes", string(got))
+	// no .partial temp files may remain
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasSuffix(e.Name(), ".partial"), e.Name())
+	}
+}

--- a/pkg/image/layer_cache_test.go
+++ b/pkg/image/layer_cache_test.go
@@ -4,10 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"testing/iotest"
 
@@ -15,112 +12,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// the per-path lock hands the path to one writer at a time; others wait rather than interleave
-func Test_lockCachePath_serializesWriters(t *testing.T) {
-	dir := t.TempDir()
-	target := filepath.Join(dir, "sha256-x")
-	var active, maxActive int
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-	for i := 0; i < 16; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			unlock := lockCachePath(target)
-			defer unlock()
-			mu.Lock()
-			active++
-			if active > maxActive {
-				maxActive = active
-			}
-			mu.Unlock()
-			// simulate the stat-then-write critical section
-			if _, err := os.Stat(target); os.IsNotExist(err) {
-				require.NoError(t, os.WriteFile(target, []byte("layer-bytes"), 0o600))
-			}
-			mu.Lock()
-			active--
-			mu.Unlock()
-		}()
-	}
-	wg.Wait()
-	assert.Equal(t, 1, maxActive, "writers must not overlap on one cache path")
-	got, err := os.ReadFile(target)
-	require.NoError(t, err)
-	assert.Equal(t, "layer-bytes", string(got))
-	// no .partial temp files may remain
-	entries, err := os.ReadDir(dir)
-	require.NoError(t, err)
-	for _, e := range entries {
-		assert.False(t, strings.HasSuffix(e.Name(), ".partial"), e.Name())
-	}
-}
-
-// countingContentLayer serves fixed content and counts how many times it is asked for it.
-type countingContentLayer struct {
-	mockLayer
-	opens   *int32
-	content string
-}
-
-func (c countingContentLayer) Uncompressed() (io.ReadCloser, error) {
-	atomic.AddInt32(c.opens, 1)
-	return io.NopCloser(strings.NewReader(c.content)), nil
-}
-
 // truncatedContentLayer fails partway through being read, the shape of a dropped connection.
 type truncatedContentLayer struct{ mockLayer }
 
 func (truncatedContentLayer) Uncompressed() (io.ReadCloser, error) {
-	return io.NopCloser(io.MultiReader(strings.NewReader("partial-bytes"), iotest.ErrReader(errors.New("connection dropped")))), nil
+	return io.NopCloser(io.MultiReader(
+		strings.NewReader("partial-bytes"),
+		iotest.ErrReader(errors.New("connection dropped")),
+	)), nil
 }
 
-func Test_uncompressedCache_concurrentSameDigestPopulatesOnce(t *testing.T) {
-	dir := t.TempDir()
-	var opens int32
-
-	// several layers of one image can share a digest; every reader must see a complete layer and
-	// the content must only be materialized once
-	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			l := &Layer{layer: countingContentLayer{opens: &opens, content: "layer-bytes"}}
-			l.Metadata.Digest = "sha256:shared"
-			path, err := l.uncompressedCache(dir)
-			if assert.NoError(t, err) {
-				got, err := os.ReadFile(path)
-				if assert.NoError(t, err) {
-					assert.Equal(t, "layer-bytes", string(got))
-				}
-			}
-		}()
-	}
-	wg.Wait()
-
-	assert.Equal(t, int32(1), opens, "the layer content must be fetched exactly once")
-	assertNoPartialFiles(t, dir)
-}
-
-func Test_uncompressedCache_existingCompleteFileIsReused(t *testing.T) {
-	dir := t.TempDir()
-	// the cache path is keyed on index and digest, not digest alone
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "0-sha256:cached"), []byte("already-here"), 0o600))
-
-	var opens int32
-	l := &Layer{layer: countingContentLayer{opens: &opens, content: "should-not-be-read"}}
-	l.Metadata.Digest = "sha256:cached"
-
-	path, err := l.uncompressedCache(dir)
-	require.NoError(t, err)
-	got, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Equal(t, "already-here", string(got))
-	assert.Zero(t, opens, "a complete cached layer must not be re-fetched")
-}
-
-func Test_uncompressedCache_failedReadLeavesNothingBehind(t *testing.T) {
+// a write that dies partway must leave nothing behind: no partial at the final path for a later
+// os.Stat to trust, and no orphaned temp file.
+func Test_uncompressedCache_failedWriteLeavesNothingBehind(t *testing.T) {
 	dir := t.TempDir()
 	l := &Layer{layer: truncatedContentLayer{}}
 	l.Metadata.Digest = "sha256:doomed"
@@ -128,17 +32,7 @@ func Test_uncompressedCache_failedReadLeavesNothingBehind(t *testing.T) {
 	_, err := l.uncompressedCache(dir)
 	require.Error(t, err)
 
-	// neither a partial at the final path (a later hit would trust it) nor an orphaned temp file
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 	assert.Empty(t, entries, "a failed write must leave the cache directory untouched")
-}
-
-func assertNoPartialFiles(t *testing.T, dir string) {
-	t.Helper()
-	entries, err := os.ReadDir(dir)
-	require.NoError(t, err)
-	for _, e := range entries {
-		assert.False(t, strings.HasSuffix(e.Name(), ".partial"), "leftover temp file: %s", e.Name())
-	}
 }

--- a/pkg/image/layer_cache_test.go
+++ b/pkg/image/layer_cache_test.go
@@ -1,11 +1,15 @@
 package image
 
 import (
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/iotest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,5 +53,92 @@ func Test_lockCachePath_serializesWriters(t *testing.T) {
 	require.NoError(t, err)
 	for _, e := range entries {
 		assert.False(t, strings.HasSuffix(e.Name(), ".partial"), e.Name())
+	}
+}
+
+// countingContentLayer serves fixed content and counts how many times it is asked for it.
+type countingContentLayer struct {
+	mockLayer
+	opens   *int32
+	content string
+}
+
+func (c countingContentLayer) Uncompressed() (io.ReadCloser, error) {
+	atomic.AddInt32(c.opens, 1)
+	return io.NopCloser(strings.NewReader(c.content)), nil
+}
+
+// truncatedContentLayer fails partway through being read, the shape of a dropped connection.
+type truncatedContentLayer struct{ mockLayer }
+
+func (truncatedContentLayer) Uncompressed() (io.ReadCloser, error) {
+	return io.NopCloser(io.MultiReader(strings.NewReader("partial-bytes"), iotest.ErrReader(errors.New("connection dropped")))), nil
+}
+
+func Test_uncompressedCache_concurrentSameDigestPopulatesOnce(t *testing.T) {
+	dir := t.TempDir()
+	var opens int32
+
+	// several layers of one image can share a digest; every reader must see a complete layer and
+	// the content must only be materialized once
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			l := &Layer{layer: countingContentLayer{opens: &opens, content: "layer-bytes"}}
+			l.Metadata.Digest = "sha256:shared"
+			path, err := l.uncompressedCache(dir)
+			if assert.NoError(t, err) {
+				got, err := os.ReadFile(path)
+				if assert.NoError(t, err) {
+					assert.Equal(t, "layer-bytes", string(got))
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), opens, "the layer content must be fetched exactly once")
+	assertNoPartialFiles(t, dir)
+}
+
+func Test_uncompressedCache_existingCompleteFileIsReused(t *testing.T) {
+	dir := t.TempDir()
+	// the cache path is keyed on index and digest, not digest alone
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "0-sha256:cached"), []byte("already-here"), 0o600))
+
+	var opens int32
+	l := &Layer{layer: countingContentLayer{opens: &opens, content: "should-not-be-read"}}
+	l.Metadata.Digest = "sha256:cached"
+
+	path, err := l.uncompressedCache(dir)
+	require.NoError(t, err)
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "already-here", string(got))
+	assert.Zero(t, opens, "a complete cached layer must not be re-fetched")
+}
+
+func Test_uncompressedCache_failedReadLeavesNothingBehind(t *testing.T) {
+	dir := t.TempDir()
+	l := &Layer{layer: truncatedContentLayer{}}
+	l.Metadata.Digest = "sha256:doomed"
+
+	_, err := l.uncompressedCache(dir)
+	require.Error(t, err)
+
+	// neither a partial at the final path (a later hit would trust it) nor an orphaned temp file
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "a failed write must leave the cache directory untouched")
+}
+
+func assertNoPartialFiles(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasSuffix(e.Name(), ".partial"), "leftover temp file: %s", e.Name())
 	}
 }


### PR DESCRIPTION
## Issue

The uncompressed-layer cache wrote each decompressed layer directly to its final digest-keyed path (`os.Create` + `io.Copy`). Two writers of the same digest can interleave, and any reader arriving mid-write sees a truncated layer — silent corruption rather than an error. Two layers of one image *can* share a digest (empty layers do), and any future concurrency around layer reads or a longer-lived cache directory makes this a real race.

## Fix

- Write to `os.CreateTemp` in the cache directory and `os.Rename` into place — atomic on POSIX filesystems, so a cache path either does not exist or holds a complete layer, never a partial one.
- A per-path mutex serializes writers of one digest; the loser of the race finds the winner's completed file on the `os.Stat` check and reuses it instead of rewriting.
- Failures remove the temp file, so nothing half-written is left behind under any name.

**Why in-process mutexes and not lock files:** an on-disk lock has a liveness problem — if the process holding it dies, the next process cannot tell whether the holder is alive. The per-path locks here are plain `sync.Mutex`es that die with the process, so a stale lock cannot exist; cross-process safety comes from the write protocol instead (a writer only exposes a complete layer via rename, and a crash leaves at most an orphaned `*.partial` that no reader looks at).

Unit test covers concurrent writers of one path: no overlap, correct content, no `.partial` files left.

## Measured

Imported into anchorectl and compared back to back with the same anchorectl commit on current stereoscope main (expected to be performance-neutral; the point is correctness), medians of 3:

| Scenario (anchorectl import, median of 3 warmed runs) | stereoscope main — wall / CPU / peak RSS | this PR — wall / CPU / peak RSS |
|---|---|---|
| enterprise:dev from the docker daemon (1.28 GB, 40k files) | 15.83 s / 22.33 s / 948 MB | 15.81 s / 22.12 s / 970 MB (-0% wall) |
| nginx from a registry (loopback) | 1.55 s / 4.73 s / 246 MB | 1.54 s / 4.70 s / 246 MB (-1% wall) |
| enterprise:dev from a registry (loopback) | 9.41 s / 24.00 s / 973 MB | 9.37 s / 23.90 s / 929 MB (-0% wall) |
| OCI layout on disk (centralized analyze path) | 14.15 s / 29.12 s / 966 MB | 14.51 s / 30.15 s / 939 MB (+3% wall) |

Performance-neutral within run-to-run noise, as expected — this PR is a correctness fix; the numbers are here to show it costs nothing.

Output parity: package sets, files, digests, search results and relationship counts are identical to the baseline. The only diffs observed are pre-existing run-to-run nondeterminism, reproduced with *unpatched* stereoscope main under the same anchorectl commit: syft v1.51.0 can credit a duplicated python package (`packaging@26.3` vs the copy vendored inside setuptools) as the `dependency-of` parent either way, which then shifts document digests in the bundle manifest.
