### PR TITLE
perf: raise registry transport MaxIdleConnsPerHost to 50

### DIFF
--- a/pkg/image/oci/registry_provider.go
+++ b/pkg/image/oci/registry_provider.go
@@ -230,25 +230,40 @@ func prepareRemoteOptions(ctx context.Context, ref name.Reference, registryOptio
 		log.Warn("unable to configure TLS transport: %w", err)
 	}
 
-	// Use our custom transport that captures effective URLs after redirects
-	transport := getTransportWithEffectiveURL(tlsConfig, effectiveTransport)
+	// Use our custom transport that captures effective URLs after redirects. A caller-supplied
+	// transport is used verbatim as its base (bring your own proxy/TLS/pool settings); otherwise
+	// the default transport is built from the TLS options.
+	transport := getTransportWithEffectiveURL(tlsConfig, effectiveTransport, registryOptions.Transport)
 	options = append(options, remote.WithTransport(transport))
 
 	return options
 }
 
+// registryMaxIdleConnsPerHost mirrors go-containerregistry's own default transport ("we usually are
+// dealing with 2 hosts at most, split MaxIdleConns between them"). http.DefaultTransport allows 2,
+// which makes bursts of manifest and blob requests against one registry host re-do the TCP + TLS
+// handshake for every request beyond the two kept-alive connections.
+const registryMaxIdleConnsPerHost = 50
+
 func getTransport(tlsConfig *tls.Config) *http.Transport {
 	// use the default transport to inherit existing default options (including proxy options)
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = tlsConfig
+	if transport.MaxIdleConnsPerHost < registryMaxIdleConnsPerHost {
+		transport.MaxIdleConnsPerHost = registryMaxIdleConnsPerHost
+	}
 	return transport
 }
 
-func getTransportWithEffectiveURL(tlsConfig *tls.Config, effectiveTransport *effectiveURLTransport) http.RoundTripper {
-	// create base transport with TLS config
-	baseTransport := getTransport(tlsConfig)
+func getTransportWithEffectiveURL(tlsConfig *tls.Config, effectiveTransport *effectiveURLTransport, custom http.RoundTripper) http.RoundTripper {
+	// the caller's transport, when given, is the base as-is; otherwise build the default with the
+	// TLS config applied
+	base := custom
+	if base == nil {
+		base = getTransport(tlsConfig)
+	}
 
 	// wrap it with our effective URL capturing transport
-	effectiveTransport.base = baseTransport
+	effectiveTransport.base = base
 	return effectiveTransport
 }

--- a/pkg/image/oci/registry_provider_test.go
+++ b/pkg/image/oci/registry_provider_test.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -447,4 +448,32 @@ func Test_getTransportWithEffectiveURL_customTransportUsedVerbatim(t *testing.T)
 	base, ok := et2.base.(*http.Transport)
 	require.True(t, ok)
 	assert.Equal(t, registryMaxIdleConnsPerHost, base.MaxIdleConnsPerHost)
+}
+
+func Test_getTransport_appliesTLSConfigAndPool(t *testing.T) {
+	tlsCfg := &tls.Config{InsecureSkipVerify: true}
+	transport := getTransport(tlsCfg)
+
+	// the default transport gets the TLS options and the registry-sized idle pool, and keeps the
+	// environment proxy behavior it inherits from http.DefaultTransport
+	assert.Same(t, tlsCfg, transport.TLSClientConfig)
+	assert.Equal(t, registryMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+	assert.NotNil(t, transport.Proxy)
+}
+
+func Test_getTransportWithEffectiveURL_customTransportOwnership(t *testing.T) {
+	// a caller-supplied transport is the caller's to configure: neither the TLS options nor the
+	// idle-pool bump may be applied to it
+	callersTLS := &tls.Config{ServerName: "callers-choice"}
+	custom := &http.Transport{MaxIdleConnsPerHost: 1, TLSClientConfig: callersTLS}
+
+	et := newEffectiveURLTransport(nil)
+	got := getTransportWithEffectiveURL(&tls.Config{ServerName: "ignored"}, et, custom)
+
+	require.Same(t, et, got)
+	base, ok := et.base.(*http.Transport)
+	require.True(t, ok)
+	require.Same(t, custom, base)
+	assert.Equal(t, 1, base.MaxIdleConnsPerHost, "the pool bump must not touch a caller-supplied transport")
+	assert.Same(t, callersTLS, base.TLSClientConfig, "the TLS options must not touch a caller-supplied transport")
 }

--- a/pkg/image/oci/registry_provider_test.go
+++ b/pkg/image/oci/registry_provider_test.go
@@ -287,8 +287,11 @@ func Test_getTransport_haxProxyCfg(t *testing.T) {
 	assert.NotNil(t, transport.Proxy)
 	assert.NotNil(t, transport.DialContext)
 
+	// idle connections per host are raised so concurrent layer fetches are not throttled to two
+	assert.Equal(t, registryMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+
 	if d := cmp.Diff(defTransport, transport,
-		cmpopts.IgnoreFields(http.Transport{}, "TLSClientConfig", "Proxy", "DialContext", "TLSNextProto"),
+		cmpopts.IgnoreFields(http.Transport{}, "TLSClientConfig", "Proxy", "DialContext", "TLSNextProto", "MaxIdleConnsPerHost"),
 		cmpopts.IgnoreUnexported(http.Transport{})); d != "" {
 		t.Errorf("unexpected proxy config (-want +got):\n%s", d)
 	}
@@ -425,4 +428,23 @@ type mockRoundTripper struct {
 
 func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return m.resp, m.err
+}
+
+type staticRoundTripper struct{}
+
+func (staticRoundTripper) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }
+
+func Test_getTransportWithEffectiveURL_customTransportUsedVerbatim(t *testing.T) {
+	custom := staticRoundTripper{}
+	et := newEffectiveURLTransport(nil)
+	got := getTransportWithEffectiveURL(nil, et, custom)
+	require.Same(t, et, got)
+	assert.Equal(t, custom, et.base, "a caller-supplied transport must be the base, untouched")
+
+	// and without one, the default transport (with the raised idle pool) is built
+	et2 := newEffectiveURLTransport(nil)
+	_ = getTransportWithEffectiveURL(nil, et2, nil)
+	base, ok := et2.base.(*http.Transport)
+	require.True(t, ok)
+	assert.Equal(t, registryMaxIdleConnsPerHost, base.MaxIdleConnsPerHost)
 }

--- a/pkg/image/registry_options.go
+++ b/pkg/image/registry_options.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -24,6 +25,11 @@ type RegistryOptions struct {
 	Credentials           []RegistryCredentials
 	Keychain              authn.Keychain
 	CAFileOrDir           string
+	// Transport, when set, is used verbatim as the HTTP transport for registry requests: the
+	// caller owns its proxy, TLS, and connection-pool configuration, and the TLS-related options
+	// above are not applied to it. When nil, a clone of http.DefaultTransport is used with the TLS
+	// options applied and the idle connection pool sized for registry traffic.
+	Transport http.RoundTripper
 }
 
 type credentialSelection struct {


### PR DESCRIPTION
## Issue

The registry transport clones `http.DefaultTransport`, which keeps only **2** idle connections per host. A registry pull is exactly the traffic shape that punishes this — bursts of manifest, config and blob requests against one host — so every request beyond the two kept-alive connections pays a fresh TCP + TLS handshake. Against remote registries each handshake costs a round trip plus the TLS exchange; on small images the handshakes are a visible fraction of the whole pull.

## Fix

Set `MaxIdleConnsPerHost = 50` on the cloned transport (mirroring go-containerregistry's own default transport, which raises the same limit for the same reason). The transport is still derived from `http.DefaultTransport`, so `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` and environment TLS behavior keep working; the existing proxy test now also asserts the pool size.

**Bring your own transport:** `RegistryOptions.Transport` now accepts a caller-supplied `http.RoundTripper` that is used verbatim as the base transport — proxy, TLS and connection-pool settings stay entirely under the caller's control, and the raised default applies only when no transport is given. Covered by a test asserting the custom transport is used untouched.

## Measured

Imported into anchorectl, back to back with the same anchorectl commit on current stereoscope main, medians of 3:

| Scenario (anchorectl import, median of 3 warmed runs) | stereoscope main — wall / CPU / peak RSS | this PR — wall / CPU / peak RSS |
|---|---|---|
| enterprise:dev from the docker daemon (1.28 GB, 40k files) | 15.83 s / 22.33 s / 948 MB | 15.62 s / 22.03 s / 922 MB (-1% wall) |
| nginx from a registry (loopback) | 1.55 s / 4.73 s / 246 MB | 1.56 s / 4.66 s / 251 MB (+1% wall) |
| enterprise:dev from a registry (loopback) | 9.41 s / 24.00 s / 973 MB | 10.24 s / 25.94 s / 932 MB (+9% wall) |
| OCI layout on disk (centralized analyze path) | 14.15 s / 29.12 s / 966 MB | 14.68 s / 31.15 s / 974 MB (+4% wall) |

Against a loopback registry the handshakes this removes are nearly free, so the local numbers are flat within noise — the benefit is per-request TCP+TLS round trips against remote registries. An interleaved A/B re-check of the loopback registry scenario showed +0.3% wall (noise).

Output parity: package sets, files, digests, search results and relationship counts are identical to the baseline. The only diffs observed are pre-existing run-to-run nondeterminism, reproduced with *unpatched* stereoscope main under the same anchorectl commit: syft v1.51.0 can credit a duplicated python package (`packaging@26.3` vs the copy vendored inside setuptools) as the `dependency-of` parent either way, which then shifts document digests in the bundle manifest.
